### PR TITLE
fix: make private Windows package input robust

### DIFF
--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -188,7 +188,24 @@ $env:AUTO_TEST_PERSIST_API_KEY = "0"
 
 内部私有包正常使用时无需输入 API Key。只有调试公开源码包或主动轮换凭据时，安装器才会使用隐藏输入；不要把 Key 写进命令行。
 
-私有发行管理员在受控服务器上构建零输入包时，通过标准输入或私有进程环境把专用 Key 交给 `scripts/build-private-windows-package.sh`。脚本只允许从干净、已提交的工作树构建，输出位于被 Git 忽略的 `artifacts/private-release/`，且不会打印 Key。
+私有发行管理员在受控服务器上构建零输入包时，可以直接运行快速脚本：
+
+```bash
+AUTO_TEST_CODEX_BASE_URL="https://model-api.example/v1" \
+AUTO_TEST_CODEX_MODEL="your-model-id" \
+bash scripts/build-private-windows-package-quick.sh
+```
+
+脚本会隐藏读取 API Key，完成后输出 ZIP 的绝对路径和 SHA-256。也可以使用底层脚本进行自动化构建：
+
+```bash
+printf '%s\n' "$MODEL_API_KEY" | \
+  AUTO_TEST_CODEX_BASE_URL="https://model-api.example/v1" \
+  AUTO_TEST_CODEX_MODEL="your-model-id" \
+  bash scripts/build-private-windows-package.sh
+```
+
+两种脚本都只允许从干净、已提交的工作树构建，输出位于被 Git 忽略的 `artifacts/private-release/`。包名形如 `Auto-Test-Windows-private-<commit>.zip`；把它复制到 Windows 后解压，双击 `Auto-Test.cmd` 即可。包内含可提取的模型 API Key，禁止提交 Git、上传 GitHub、网盘或公开制品库。
 
 ## 注意事项
 

--- a/scripts/build-private-windows-package-quick.sh
+++ b/scripts/build-private-windows-package-quick.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repository_root"
+
+base_url="${AUTO_TEST_CODEX_BASE_URL:-}"
+model_id="${AUTO_TEST_CODEX_MODEL:-}"
+if [[ -z "$base_url" ]]; then
+  read -r -p "Model API Base URL: " base_url
+fi
+if [[ -z "$model_id" ]]; then
+  read -r -p "Model ID: " model_id
+fi
+if [[ -z "$base_url" || -z "$model_id" ]]; then
+  echo "Base URL 和模型 ID 都不能为空。" >&2
+  exit 1
+fi
+
+printf 'API Key（输入不回显）: ' >&2
+IFS= read -r -s model_api_key || :
+printf '\n' >&2
+if [[ -z "$model_api_key" ]]; then
+  echo "API Key 不能为空。" >&2
+  exit 1
+fi
+
+trap 'unset model_api_key base_url model_id' EXIT
+printf '%s\n' "$model_api_key" | \
+  AUTO_TEST_CODEX_BASE_URL="$base_url" \
+  AUTO_TEST_CODEX_MODEL="$model_id" \
+  bash "$repository_root/scripts/build-private-windows-package.sh"

--- a/scripts/build-private-windows-package.sh
+++ b/scripts/build-private-windows-package.sh
@@ -10,7 +10,10 @@ model_api_key="${AUTO_TEST_MODEL_API_KEY:-}"
 model_base_url="${AUTO_TEST_CODEX_BASE_URL:-}"
 model_id="${AUTO_TEST_CODEX_MODEL:-}"
 if [[ -z "$model_api_key" && ! -t 0 ]]; then
-  IFS= read -r model_api_key
+  # A pipe may end without a newline (for example printf '%s' "$key").
+  # Bash read stores the value but returns 1 at EOF; do not let set -e
+  # terminate before the explicit empty-key validation below.
+  IFS= read -r model_api_key || :
 fi
 if [[ -z "$model_api_key" ]]; then
   echo "缺少模型 API Key；请通过标准输入或私有构建进程环境提供。" >&2

--- a/tests/windows-launcher.test.ts
+++ b/tests/windows-launcher.test.ts
@@ -7,6 +7,7 @@ describe('Windows portable launcher', () => {
     const script = await readFile(resolve(import.meta.dirname, '../scripts/launch-windows.ps1'), 'utf8')
     const browserCheck = await readFile(resolve(import.meta.dirname, '../scripts/check-playwright-browser.cjs'), 'utf8')
     const privatePackageBuilder = await readFile(resolve(import.meta.dirname, '../scripts/build-private-windows-package.sh'), 'utf8')
+    const quickPackageBuilder = await readFile(resolve(import.meta.dirname, '../scripts/build-private-windows-package-quick.sh'), 'utf8')
 
     expect(script).toContain("node_modules\\npm\\bin\\npm-cli.js")
     expect(script).toContain("node_modules\\@playwright\\test\\cli.js")
@@ -31,5 +32,8 @@ describe('Windows portable launcher', () => {
     expect(privatePackageBuilder).toContain('AUTO_TEST_CODEX_BASE_URL')
     expect(privatePackageBuilder).toContain('AUTO_TEST_CODEX_MODEL')
     expect(privatePackageBuilder).toContain('Auto-Test.private-provider.json')
+    expect(privatePackageBuilder).toContain('read -r model_api_key || :')
+    expect(quickPackageBuilder).toContain('read -r -s model_api_key || :')
+    expect(quickPackageBuilder).toContain('build-private-windows-package.sh')
   })
 })


### PR DESCRIPTION
Fix silent exit when a piped API key has no trailing newline under set -e. Add a hidden-input quick builder and document package output, verification, and handling instructions. Local npm run check passes.