### PR TITLE
feat(agent): validate composite field representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Windows 测试工程师可以直接双击 `Auto-Test.cmd`：启动器会自动�
 
 默认主链路已经切换为 Codex-native 测试代理：输入测试用例 Excel 和已注册环境后，一个持久 Codex 线程通过 Playwright MCP 持续完成用例理解、页面探索、证据驱动计划修订、真实执行、业务断言、恢复和结构化交付。它不会先把新场景压缩成固定 Execution Plan；既有 IR/Runtime 只作为显式 `--legacy-runtime` 兼容路径和未来稳定回归加速器。
 
-当前实现已经完成 Excel Intake、环境选择与认证刷新、隔离 Codex Home、Playwright MCP、Auto-Test Control MCP、动态计划、证据索引、Mutation Ledger、结构化结果、同 thread 中断恢复和 Windows 启动器接入。真实 Windows 充电闭环已经仅使用 Excel、三个目标 URL 和一次环境注册完成自主执行，并在主机离线与模型限流后从原 run 恢复到 `passed`；任意新业务场景仍应先执行一条安全 canary，不能把单个复杂场景通过等同于所有网站天然兼容。
+当前实现已经完成 Excel Intake、环境选择与认证刷新、隔离 Codex Home、Playwright MCP、Auto-Test Control MCP、动态计划、证据索引、Mutation Ledger、复合字段输入 Gate、结构化结果、同 thread 中断恢复和 Windows 启动器接入。复合字段 Gate 将一个逻辑测试值与页面上的选择器、输入框、显示前缀等组件分离，并在提交前阻断未知或重复表示；未经通过 Gate 的格式错误不能被报告为产品缺陷。真实 Windows 充电闭环已经仅使用 Excel、三个目标 URL 和一次环境注册完成自主执行，并在主机离线与模型限流后从原 run 恢复到 `passed`；任意新业务场景仍应先执行一条安全 canary，不能把单个复杂场景通过等同于所有网站天然兼容。
 
 ## 当前文档
 

--- a/docs/autonomous-workflow.md
+++ b/docs/autonomous-workflow.md
@@ -69,6 +69,8 @@ When exactly one profile covers all supplied URL origins, the autonomous command
 
 Live page evidence redacts every value supplied through `AUTO_TEST_SECRET_*`, including profile-only secrets and members of JSON list bindings, even when the current Draft does not reference that secret.
 
+Composite values are governed by a generic field-representation contract. When one logical value is split across selectors, one or more editable inputs, display components, or derived controls, the agent must record the observed decomposition and a post-fill representation with `field_composition_check` before submitting. In the current execution-first mode, `test_value_get` exposes only the requested Excel/Profile run value to the test agent, allowing it to derive component values without receiving provider keys, cookies, browser storage, or host credentials. The gate requires one authoritative logical source, privately reconstructs it from components marked as segments, ignores context-only controls, strips raw derived values from persisted gate and event records, and rejects unknown semantics, missing observations, or duplicated/omitted segments. A validation response may be classified as `product_failed` only when the referenced field gate passed; malformed or unverified representations terminate as `blocked` with `failureSource: agent_execution`. `--opaque-test-data` retains the stricter alias-only mode for environments that require it.
+
 See `templates/environment-profiles.example.json` for the registry shape.
 
 ## Current Boundary

--- a/docs/windows-acceptance-runbook.md
+++ b/docs/windows-acceptance-runbook.md
@@ -97,11 +97,13 @@ Get-Content "$Run\.agent-private\environment-requirements.json" -Raw | ConvertFr
 $Result = Get-Content "$Run\codex-agent.result.json" -Raw | ConvertFrom-Json
 $Plan = Get-Content "$Run\agent-workspace\execution-plan.json" -Raw | ConvertFrom-Json
 $Ledger = Get-Content "$Run\.agent-private\mutation-ledger.json" -Raw | ConvertFrom-Json
+$FieldGates = Get-Content "$Run\.agent-private\field-compositions.json" -Raw | ConvertFrom-Json
 
 $Result.outcome
 $Result.cases | Format-Table caseId, outcome
 $Plan.steps | Where-Object status -ne "passed" | Format-Table id, status
 $Ledger | Where-Object status -eq "pending" | Format-Table id, caseId, status
+$FieldGates | Where-Object status -eq "blocked" | Format-Table id, caseId, fieldId, status
 ```
 
 只有同时满足以下条件，才算该 run 通过：
@@ -110,6 +112,7 @@ $Ledger | Where-Object status -eq "pending" | Format-Table id, caseId, status
 - 每个测试用例均为 `passed`，且有对应业务证据；
 - 动态计划没有 `pending`、`in_progress`、`failed` 或 `blocked` 步骤；
 - Mutation Ledger 没有 `pending` 条目；
+- 任何已提交的复合字段都有对应的 `passed` Gate；验证类 `product_failed` 必须引用已通过的 `fieldGateIds`；
 - 测试材料要求的最终业务状态已验证，例如零活动订单、测试数据已删除、设备或连接器已恢复。
 
 一次页面点击成功、浏览器没有报错或部分步骤执行完成，都不能替代这些终态条件。

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -98,7 +98,9 @@ $env:AUTO_TEST_PLAYWRIGHT_DOWNLOAD_HOST = "https://your-mirror.example/playwrigh
 
 默认执行主体是一个持久 Codex 测试线程。它通过 Playwright MCP 查看真实页面、持续更新动态计划、执行操作、验证业务结果并完成恢复；测试工程师不需要编辑 Execution Plan。旧 Planner/Refiner/Runtime 只在命令行显式加入 `--legacy-runtime` 时使用。
 
-每次运行目录中的 `codex-agent.events.jsonl` 保存脱敏后的线程和工具事件，`codex-agent.result.json` 保存最终结果，`agent-workspace/evidence/` 保存页面证据。模型额度、MCP、浏览器或网络不可用时会返回 `blocked` 并写明原因，不会把基础设施错误误报为测试通过。
+一个逻辑测试值如果在页面上被拆成选择器、输入框、显示前缀或其他组件，代理必须在提交前通过通用的复合字段输入 Gate。当前默认使用 execution-first：模型可以按需读取本次 Excel/Profile 中的测试值，自主派生各页面组件所需的值；它仍无法通过该接口读取模型 API Key、Cookie、浏览器存储或宿主机凭据。Gate 会根据组件的 `segment/context/none` 关系私下重建原始逻辑值，并从持久化记录中删除派生明文；重复、遗漏、未知表示或缺少填充后证据会直接阻断提交。只有 Gate 已通过、应用仍拒绝正确表示时，结果才能记为产品缺陷；代理填错必须记为 `blocked/agent_execution`。需要恢复严格别名模式时，在命令行加入 `--opaque-test-data`。
+
+每次运行目录中的 `codex-agent.events.jsonl` 保存脱敏后的线程和工具事件，`codex-agent.result.json` 保存最终结果，`agent-workspace/evidence/` 保存页面证据，`.agent-private/field-compositions.json` 保存复合字段 Gate。模型额度、MCP、浏览器或网络不可用时会返回 `blocked` 并写明原因，不会把基础设施错误误报为测试通过。
 
 如果测试材料或页面证据提出了环境 Profile 未注册的新网站 origin，代理不会直接访问或猜测替代路由，而会在 `.agent-private/environment-requirements.json` 和 `codex-agent.result.json` 中记录待补充 origin。完成环境注册后，使用原 Excel、原 Profile 和原输出目录执行 `--resume`；这不会重做已经确认的业务写入。
 
@@ -127,6 +129,8 @@ $env:AUTO_TEST_PLAYWRIGHT_DOWNLOAD_HOST = "https://your-mirror.example/playwrigh
 ```
 
 `--headed` 会显示认证刷新和 Codex 测试代理的浏览器操作；`--headless` 适合无人值守执行。浏览器在运行结束后会正常关闭，页面证据和结构化结果仍保存在本次结果目录中。
+
+默认 direct 测试数据模式只扩大模型对本次运行测试值的可见性，不放开 origin allowlist、Mutation Ledger、身份匹配、清理和最终结果门禁。
 
 如果电脑睡眠、网络、模型连接、浏览器或 MCP 导致运行中断，恢复网络后复用原命令、原 Excel、原环境和原结果目录，并增加 `--resume`：
 

--- a/src/agent/control-server.ts
+++ b/src/agent/control-server.ts
@@ -8,7 +8,10 @@ import { writePrivateJson } from './state.js'
 import { readEnvironmentRequirements, requestEnvironmentAccess } from './environment-requirements.js'
 import type { CodexTestControlConfig } from './control-types.js'
 import { resolveEvidenceArtifact } from './evidence-artifact.js'
-import type { CodexTestCaseDecision, CodexTestMutationLedgerEntry, CodexTestRisk } from './types.js'
+import { validateFieldCompositionGate } from './field-composition.js'
+import { decisionFieldContractProblem } from './decision-contract.js'
+import { getRunScopedTestValue, parseAgentSecretValues } from './test-data-access.js'
+import type { CodexTestCaseDecision, CodexTestFailureKind, CodexTestFailureSource, CodexTestFieldCompositionGate, CodexTestMutationLedgerEntry, CodexTestRisk } from './types.js'
 
 interface AgentPlan {
   summary: string
@@ -48,6 +51,11 @@ function text(value: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] }
 }
 
+async function readSecretValues(path?: string): Promise<Record<string, string>> {
+  if (!path) return {}
+  return parseAgentSecretValues(await readFile(path, 'utf8'))
+}
+
 async function main(): Promise<void> {
   process.umask(0o077)
   const configPath = process.argv[2]
@@ -55,11 +63,14 @@ async function main(): Promise<void> {
   const config = JSON.parse(await readFile(configPath, 'utf8')) as CodexTestControlConfig
   const environmentRequirementsPath = config.environmentRequirementsPath
     ?? resolve(config.evidenceDirectory, '..', '..', '.agent-private', 'environment-requirements.json')
+  const fieldCompositionPath = config.fieldCompositionPath
+    ?? resolve(config.evidenceDirectory, '..', '..', '.agent-private', 'field-compositions.json')
   const caseIds = new Set(config.caseIds)
   const server = new McpServer({ name: 'auto-test-control', version: '0.1.0' }, {
     instructions: [
       'Use test_plan_update before browser execution and whenever live evidence changes the plan.',
       'Use evidence_record for every business assertion and important failure observation.',
+      'For every logical value split across multiple visible controls, call field_composition_check after filling and before any submit or side effect.',
       'After the final assertion for each case, use case_result_record exactly once to persist passed, product_failed, or blocked with a concise summary.',
       'Before any browser action that can create, update, start, stop, settle, delete, pay, or otherwise mutate business state, call mutation_begin with the owning caseId.',
       'Resolve each mutation only after verified compensation or when the expected business change is explicitly accepted by the test case.',
@@ -77,7 +88,19 @@ async function main(): Promise<void> {
     targetUrls: config.targetUrls,
     allowedOrigins: allowedOrigins(config),
     caseIds: config.caseIds,
+    testDataAccess: config.testDataAccess ?? 'opaque',
   }))
+
+  server.registerTool('test_value_get', {
+    title: 'Get a run-scoped test value',
+    description: 'Return one Excel/Profile test value by alias when direct test-data access is enabled. Provider keys, cookies, browser storage, and host credentials are never available through this tool.',
+    inputSchema: { alias: z.string().min(1) },
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, async ({ alias }) => {
+    const values = await readSecretValues(config.secretValuesPath)
+    const value = getRunScopedTestValue(config.testDataAccess ?? 'opaque', values, alias)
+    return text({ alias, value })
+  })
 
   server.registerTool('environment_requirements', {
     title: 'List environment access requirements',
@@ -149,6 +172,53 @@ async function main(): Promise<void> {
     return text(note)
   })
 
+  server.registerTool('field_composition_check', {
+    title: 'Validate a composite field representation',
+    description: 'Record and validate how one logical value is represented across multiple visible controls. Full run values are referenced by alias; transient derived component values are privately checked and removed from the persisted gate record.',
+    inputSchema: {
+      caseId: z.string().min(1),
+      fieldId: z.string().min(1),
+      logicalValueRef: z.string().min(1),
+      purpose: z.string().min(1),
+      components: z.array(z.object({
+        id: z.string().min(1),
+        role: z.enum(['selector', 'input', 'display', 'hidden']),
+        label: z.string().min(1),
+        source: z.enum(['static', 'secret', 'derived', 'unknown']),
+        observedValue: z.string().optional(),
+        representation: z.enum(['full', 'component', 'suffix', 'none', 'unknown']),
+        contribution: z.enum(['segment', 'context', 'none']),
+      })).min(2),
+      rendered: z.array(z.object({
+        componentId: z.string().min(1),
+        valueKind: z.enum(['static', 'secret', 'derived', 'empty']),
+        valueLength: z.number().int().nonnegative().optional(),
+        literalValue: z.string().optional(),
+        secretAlias: z.string().min(1).optional(),
+      })).min(2),
+      evidence: z.array(z.string().min(1)).min(1),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  }, async (input) => {
+    if (!caseIds.has(input.caseId)) throw new Error(`Unknown caseId: ${input.caseId}`)
+    const gate = validateFieldCompositionGate({
+      ...input,
+      secretValues: await readSecretValues(config.secretValuesPath),
+    })
+    const gates = await readJson<CodexTestFieldCompositionGate[]>(fieldCompositionPath, [])
+    const existing = gates.findIndex((item) => item.id === gate.id)
+    if (existing >= 0) gates[existing] = gate
+    else gates.push(gate)
+    await writePrivateJson(fieldCompositionPath, gates)
+    return text(gate)
+  })
+
+  server.registerTool('field_composition_list', {
+    title: 'List composite field gates',
+    description: 'Return recorded composite-field representation checks for this run.',
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  }, async () => text(await readJson<CodexTestFieldCompositionGate[]>(fieldCompositionPath, [])))
+
   server.registerTool('case_result_record', {
     title: 'Record final case result',
     description: 'Persist the final evidence-based outcome for one immutable test case. Update the same case if later evidence changes the conclusion.',
@@ -158,9 +228,12 @@ async function main(): Promise<void> {
       summary: z.string().min(1),
       blockers: z.array(z.string().min(1)).default([]),
       productDefects: z.array(z.string().min(1)).default([]),
+      failureSource: z.enum(['product', 'agent_execution', 'environment', 'input']).optional(),
+      failureKind: z.enum(['assertion', 'validation', 'authentication', 'environment', 'data', 'execution']).optional(),
+      fieldGateIds: z.array(z.string().min(1)).default([]),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-  }, async ({ caseId, outcome, summary, blockers, productDefects }) => {
+  }, async ({ caseId, outcome, summary, blockers, productDefects, failureSource, failureKind, fieldGateIds }) => {
     if (!caseIds.has(caseId)) throw new Error(`Unknown caseId: ${caseId}`)
     if (outcome === 'passed' && (blockers.length > 0 || productDefects.length > 0)) {
       throw new Error('Passed case results cannot include blockers or product defects')
@@ -174,8 +247,13 @@ async function main(): Promise<void> {
       summary,
       blockers: [...new Set(blockers)],
       productDefects: [...new Set(productDefects)],
+      ...(failureSource ? { failureSource: failureSource as CodexTestFailureSource } : {}),
+      ...(failureKind ? { failureKind: failureKind as CodexTestFailureKind } : {}),
+      ...(fieldGateIds.length > 0 ? { fieldGateIds: [...new Set(fieldGateIds)] } : {}),
       recordedAt: new Date().toISOString(),
     }
+    const contractProblem = decisionFieldContractProblem(decision, await readJson<CodexTestFieldCompositionGate[]>(fieldCompositionPath, []))
+    if (contractProblem) throw new Error(`Case result violates the field representation contract: ${contractProblem}`)
     const existing = decisions.findIndex((item) => item.caseId === caseId)
     if (existing >= 0) decisions[existing] = decision
     else decisions.push(decision)

--- a/src/agent/control-types.ts
+++ b/src/agent/control-types.ts
@@ -15,4 +15,7 @@ export interface CodexTestControlConfig {
   caseResultsPath: string
   mutationLedgerPath: string
   environmentRequirementsPath?: string
+  fieldCompositionPath?: string
+  secretValuesPath?: string
+  testDataAccess?: 'direct' | 'opaque'
 }

--- a/src/agent/decision-contract.ts
+++ b/src/agent/decision-contract.ts
@@ -1,0 +1,24 @@
+import type { CodexTestCaseDecision, CodexTestFieldCompositionGate } from './types.js'
+
+export function decisionFieldContractProblem(
+  decision: CodexTestCaseDecision,
+  fieldGates: CodexTestFieldCompositionGate[],
+): string | undefined {
+  if (decision.outcome === 'passed') {
+    if (decision.failureSource || decision.failureKind) return 'passed decision contains a failure classification'
+    const ids = decision.fieldGateIds ?? []
+    const gates = ids.map((id) => fieldGates.find((gate) => gate.id === id))
+    if (gates.some((gate) => !gate || gate.caseId !== decision.caseId || gate.status !== 'passed')) return 'passed decision references an invalid or blocked composite-field gate'
+    return undefined
+  }
+  if (!decision.failureSource || !decision.failureKind) return 'failure decision has no failure source and kind classification'
+  if (decision.outcome === 'product_failed' && decision.failureSource !== 'product') return 'product failure is not classified as product-sourced'
+  if (decision.outcome === 'blocked' && decision.failureSource === 'product') return 'blocked decision is incorrectly classified as product-sourced'
+  if (decision.failureKind !== 'validation') return undefined
+  const ids = decision.fieldGateIds ?? []
+  const gates = ids.map((id) => fieldGates.find((gate) => gate.id === id))
+  if (ids.length === 0 || gates.some((gate) => !gate || gate.caseId !== decision.caseId)) return 'validation decision lacks matching composite-field gates'
+  if (decision.failureSource === 'product' && gates.some((gate) => gate?.status !== 'passed')) return 'product validation failure lacks a passed composite-field gate'
+  if (decision.failureSource === 'agent_execution' && gates.every((gate) => gate?.status !== 'blocked')) return 'agent validation failure lacks a blocked composite-field gate'
+  return undefined
+}

--- a/src/agent/field-composition.ts
+++ b/src/agent/field-composition.ts
@@ -1,0 +1,81 @@
+import type { CodexTestFieldCompositionGate, CodexTestFieldComponent, CodexTestFieldRenderedComponent } from './types.js'
+
+export function validateFieldCompositionGate(input: {
+  caseId: string
+  fieldId: string
+  logicalValueRef: string
+  purpose: string
+  components: CodexTestFieldComponent[]
+  rendered: CodexTestFieldRenderedComponent[]
+  evidence: string[]
+  secretValues?: Record<string, string>
+}): CodexTestFieldCompositionGate {
+  const components = input.components
+  const sanitizedComponents = components.map((component) => component.source === 'static'
+    ? component
+    : { ...component, observedValue: undefined })
+  const sanitizedRendered = input.rendered.map((component) => component.valueKind === 'static'
+    ? component
+    : { ...component, literalValue: undefined })
+  const renderedIds = new Set(input.rendered.map((component) => component.componentId))
+  const hasSecretAlias = (alias: string) => Object.prototype.hasOwnProperty.call(input.secretValues ?? {}, alias)
+  const reasons: string[] = []
+  if (components.length < 2) reasons.push('composite field must describe at least two visible components')
+  if (new Set(components.map((component) => component.id)).size !== components.length) reasons.push('composite field component IDs must be unique')
+  if (renderedIds.size !== input.rendered.length) reasons.push('rendered composite field component IDs must be unique')
+  if (!components.some((component) => component.role === 'input')) reasons.push('composite field must contain an editable input component')
+  if (input.evidence.length === 0) reasons.push('composite field requires page evidence')
+  for (const component of components) {
+    if (!component.id.trim() || !component.label.trim()) reasons.push('composite field components require stable IDs and labels')
+    if (component.source === 'static' && !component.observedValue?.trim()) reasons.push(`static component ${component.id} must record its observed value`)
+    if (component.source !== 'static' && component.observedValue !== undefined) reasons.push(`secret or derived component ${component.id} must not record a raw observed value`)
+    if (component.representation === 'unknown') reasons.push(`component ${component.id} has an unknown representation`)
+  }
+  for (const rendered of input.rendered) {
+    const definition = components.find((component) => component.id === rendered.componentId)
+    if (!definition) reasons.push(`rendered value references unknown component ${rendered.componentId}`)
+    if (rendered.valueKind === 'secret' && rendered.literalValue !== undefined) reasons.push(`secret component ${rendered.componentId} must not expose a raw value`)
+    if (['secret', 'derived'].includes(rendered.valueKind) && !rendered.secretAlias) reasons.push(`secret-derived component ${rendered.componentId} must identify its source alias`)
+    if (rendered.valueKind === 'derived' && rendered.literalValue === undefined) reasons.push(`derived component ${rendered.componentId} must provide the rendered component value for private validation`)
+    if (definition?.source === 'static' && rendered.valueKind !== 'static') reasons.push(`static component ${rendered.componentId} must remain static after filling`)
+    if (definition?.source === 'static' && rendered.literalValue?.trim() !== definition.observedValue?.trim()) reasons.push(`static component ${rendered.componentId} changed after filling`)
+    if (definition?.source !== 'static' && rendered.valueKind === 'static') reasons.push(`non-static component ${rendered.componentId} was incorrectly reported as static`)
+    if (rendered.secretAlias && !hasSecretAlias(rendered.secretAlias)) reasons.push(`secret alias ${rendered.secretAlias} is unavailable to the field gate`)
+    const renderedValue = rendered.valueKind === 'secret'
+      ? (rendered.secretAlias ? input.secretValues?.[rendered.secretAlias] : undefined)
+      : rendered.literalValue
+    if (rendered.valueLength !== undefined && renderedValue !== undefined && rendered.valueLength !== renderedValue.length) {
+      reasons.push(`component ${rendered.componentId} length does not match its rendered value`)
+    }
+  }
+  for (const component of components) if (!renderedIds.has(component.id)) reasons.push(`component ${component.id} has no post-fill rendered observation`)
+  const sourceAliases = [...new Set(input.rendered.flatMap((component) => component.secretAlias ? [component.secretAlias] : []))]
+  if (sourceAliases.length !== 1) reasons.push('composite field must reference exactly one logical source alias')
+  const sourceAlias = sourceAliases[0]
+  const sourceValue = sourceAlias && hasSecretAlias(sourceAlias) ? input.secretValues?.[sourceAlias] : undefined
+  if (sourceValue !== undefined) {
+    const renderedById = new Map(input.rendered.map((component) => [component.componentId, component]))
+    const reconstructed = components.filter((component) => component.contribution === 'segment').map((component) => {
+      const rendered = renderedById.get(component.id)
+      if (!rendered) return ''
+      if (rendered.valueKind === 'secret') return rendered.secretAlias ? input.secretValues?.[rendered.secretAlias] ?? '' : ''
+      return rendered.literalValue ?? ''
+    }).join('')
+    if (reconstructed.normalize('NFKC') !== sourceValue.normalize('NFKC')) {
+      reasons.push('rendered segment components do not reconstruct the logical source value exactly')
+    }
+  }
+  return {
+    id: `${input.caseId}:${input.fieldId}`,
+    caseId: input.caseId,
+    fieldId: input.fieldId,
+    logicalValueRef: input.logicalValueRef,
+    purpose: input.purpose,
+    components: sanitizedComponents,
+    rendered: sanitizedRendered,
+    evidence: [...new Set(input.evidence)],
+    status: reasons.length === 0 ? 'passed' : 'blocked',
+    reasons: [...new Set(reasons)],
+    checkedAt: new Date().toISOString(),
+  }
+}

--- a/src/agent/progress.ts
+++ b/src/agent/progress.ts
@@ -47,8 +47,11 @@ const browserToolLabels: Record<string, string> = {
 
 const controlToolLabels: Record<string, string> = {
   test_contract: '读取不可变测试契约',
+  test_value_get: '读取本次运行测试数据',
   test_plan_update: '更新动态 Execution Plan',
   evidence_record: '记录测试证据',
+  field_composition_check: '校验复合字段输入表示',
+  field_composition_list: '核对复合字段输入门禁',
   case_result_record: '记录测试用例终态',
   mutation_begin: '登记业务写入到 Mutation Ledger',
   mutation_resolve: '核销业务写入和清理结果',

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -7,14 +7,16 @@ export function codexTestAgentPrompt(options: {
   secretAliases: AgentSecretAlias[]
   allowedOrigins?: string[]
   maxIterations?: number
+  testDataAccess?: 'direct' | 'opaque'
 }): string {
   const registeredOrigins = [...new Set(options.allowedOrigins ?? options.manifest.targetUrls.map((url) => new URL(url).origin))]
   const secretGuide = options.secretAliases.length === 0
     ? 'No secret aliases are available.'
     : options.secretAliases.map((item) => (
         `- ${item.purpose}: use ${item.aliases.map((alias) => JSON.stringify(alias)).join(', ')} as the browser input value. ` +
-        'The Playwright server replaces the alias inside the browser; never try to discover or print the underlying value. ' +
-        'When the page decomposes one logical value into multiple controls, keep the secret unchanged and do not duplicate a prefix already represented by another control.'
+        (options.testDataAccess === 'direct'
+          ? 'Call auto-test-control.test_value_get for the exact run-scoped value when page evidence requires inspection or transformation. You may derive a transient component value, but do not request provider keys, cookies, or host credentials.'
+          : 'The Playwright server replaces the alias inside the browser; never try to discover or print the underlying value.')
       )).join('\n')
   const canary = options.maxIterations === undefined
     ? 'Execute the full data set described by the test material.'
@@ -37,9 +39,9 @@ Mandatory operating protocol:
 10. Use only the Playwright and Auto-Test Control MCP tools. Do not use shell, web search, external apps, plugins, or source-code edits.
 11. Browser navigation is restricted to the registered origin allowlist below. Before using a URL discovered in a screenshot, link, redirect, or page, call request_environment_access. If it returns blocked, do not navigate or retry that origin; record the requirement and block only the affected case or dependent phases.
 12. Treat ERR_BLOCKED_BY_CLIENT on an unregistered origin as an environment-policy block, not a product failure. Do not guess an equivalent route on a registered origin.
-13. For any form with a composite value, first inspect the visible control decomposition and request evidence. Keep secret material immutable; derive only the transient representation required by the visible controls. If the application returns a format/validation error, capture evidence and make at most one evidence-driven correction before recording product_failed. Never retry a side effect blindly.
+13. For any logical value split across multiple visible controls, inspect a fresh accessibility snapshot, derive the component values from the run-scoped test value, fill them, then call auto-test-control.field_composition_check before any submit or side effect. Mark each component as a logical segment, context, or non-contributing control. The gate privately reconstructs the logical value from the rendered segments and strips raw values from its persisted record. If the gate is blocked, do not submit. Make at most one evidence-driven correction, take fresh evidence, and check again. If it remains blocked, record blocked with failureSource agent_execution, failureKind validation, and the blocked field gate ID. Never retry a side effect blindly.
 14. Before finalizing, call mutation_list and make the final browser assertions needed to prove a safe final state.
-15. After the final assertion for each case, call case_result_record exactly once with passed, product_failed, or blocked. A passed record cannot include blockers or product defects. A product_failed record must name the verified mismatch. A blocked record must name the missing data, permission, authentication, recovery authority, or ambiguity.
+15. After the final assertion for each case, call case_result_record exactly once with passed, product_failed, or blocked. Include passed fieldGateIds for composite fields submitted successfully. Every non-passed result must include failureSource and failureKind. A product_failed validation result is permitted only after a passed field_composition_check and must reference its fieldGateIds. A malformed or unverified representation is blocked/agent_execution, never a product defect. A passed record cannot include blockers or product defects.
 16. After every case result is recorded and recovery is complete, reply with a short plain-text execution summary. Do not emit JSON in this turn.
 
 ${canary}
@@ -70,6 +72,7 @@ Mandatory recovery protocol:
 4. Recreate browser tabs and authentication as needed from the registered environment, then continue from the earliest unfinished plan step. Refresh the dynamic plan when interruption evidence changes its status.
 5. Preserve immutable expected results and all prior evidence. Add new recovery evidence instead of weakening or deleting earlier findings.
 6. Resolve every pending Mutation Ledger entry only after verified compensation or an explicitly expected safe accepted state.
-7. Complete all remaining case_result_record entries and final safety assertions. Finish with a short plain-text summary; do not emit JSON.
+7. Call field_composition_list before finalizing any validation-related failure. A product validation failure requires a passed gate; a blocked gate must be classified as blocked/agent_execution rather than product_failed.
+8. Complete all remaining case_result_record entries and final safety assertions. Finish with a short plain-text summary; do not emit JSON.
 `
 }

--- a/src/agent/redact.ts
+++ b/src/agent/redact.ts
@@ -8,3 +8,19 @@ export function redactAgentValue(value: string, secrets: string[]): string {
   for (const secret of secrets) output = output.replaceAll(secret, '<redacted-secret>')
   return output
 }
+
+export function transientAgentEventValues(event: unknown): string[] {
+  const candidate = event as {
+    type?: unknown
+    item?: { type?: unknown; tool?: unknown; arguments?: unknown }
+  }
+  if (candidate.type !== 'item.started' && candidate.type !== 'item.updated' && candidate.type !== 'item.completed') return []
+  if (candidate.item?.type !== 'mcp_tool_call' || candidate.item.tool !== 'field_composition_check') return []
+  const input = candidate.item.arguments as { rendered?: unknown } | undefined
+  if (!Array.isArray(input?.rendered)) return []
+  return [...new Set(input.rendered.flatMap((component) => {
+    if (!component || typeof component !== 'object') return []
+    const value = (component as { literalValue?: unknown }).literalValue
+    return typeof value === 'string' && value.length > 0 ? [value] : []
+  }))].sort((left, right) => right.length - left.length)
+}

--- a/src/agent/result.ts
+++ b/src/agent/result.ts
@@ -20,6 +20,9 @@ export const codexTestResultSchema = {
           title: { type: 'string' },
           outcome: { type: 'string', enum: ['passed', 'product_failed', 'blocked'] },
           summary: { type: 'string' },
+          failureSource: { type: 'string', enum: ['product', 'agent_execution', 'environment', 'input'] },
+          failureKind: { type: 'string', enum: ['assertion', 'validation', 'authentication', 'environment', 'data', 'execution'] },
+          fieldGateIds: { type: 'array', items: { type: 'string' } },
           evidence: {
             type: 'array',
             items: {
@@ -128,6 +131,8 @@ export function enforceMutationLedger(
       ...item,
       outcome: 'blocked',
       summary: `${item.summary} Unrecovered business mutations remain for this case.`,
+      failureSource: 'agent_execution',
+      failureKind: 'execution',
       evidence: [
         ...item.evidence,
         ...pending.filter((entry) => entry.caseId === item.caseId).map((entry) => ({

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -7,12 +7,13 @@ import { fileURLToPath } from 'node:url'
 import type { EnvironmentProfile } from '../workflow/environment-profile.js'
 import type { WorkflowIntakeManifest } from '../workflow/types.js'
 import { blockedNavigationOriginsFromEvents, reconcileEnvironmentRequirements, requestEnvironmentAccess } from './environment-requirements.js'
+import { decisionFieldContractProblem } from './decision-contract.js'
 import { codexTestAgentPrompt, codexTestAgentResumePrompt } from './prompt.js'
 import { CodexTestProgressReporter, type CodexTestAgentProgressSink } from './progress.js'
-import { redactAgentValue, secretValues } from './redact.js'
+import { redactAgentValue, secretValues, transientAgentEventValues } from './redact.js'
 import { enforceMutationLedger } from './result.js'
 import { initialCodexTestState, updateCodexTestState, writePrivateJson } from './state.js'
-import type { CodexTestAgentResult, CodexTestAgentState, CodexTestCaseDecision, CodexTestEnvironmentRequirement, CodexTestMutationLedgerEntry } from './types.js'
+import type { CodexTestAgentResult, CodexTestAgentState, CodexTestCaseDecision, CodexTestEnvironmentRequirement, CodexTestFieldCompositionGate, CodexTestMutationLedgerEntry } from './types.js'
 import { prepareCodexAgentWorkspace } from './workspace.js'
 
 export interface CodexTestAgentOptions {
@@ -32,6 +33,7 @@ export interface CodexTestAgentOptions {
   resume?: boolean
   onProgress?: CodexTestAgentProgressSink
   progressHeartbeatMs?: number
+  testDataAccess?: 'direct' | 'opaque'
 }
 
 export interface CodexTestAgentRun {
@@ -223,7 +225,7 @@ function startSdkThread(options: {
 }
 
 async function appendEvent(path: string, event: ThreadEvent, secrets: string[]): Promise<void> {
-  const serialized = redactAgentValue(JSON.stringify(event), secrets)
+  const serialized = redactAgentValue(JSON.stringify(event), [...secrets, ...transientAgentEventValues(event)])
   await writeFile(path, `${serialized}\n`, { encoding: 'utf8', flag: 'a', mode: 0o600 })
   if (process.platform !== 'win32') await chmod(path, 0o600)
 }
@@ -255,6 +257,7 @@ function decisionProblems(
   manifest: WorkflowIntakeManifest,
   evidence: AgentEvidenceNote[],
   ledger: CodexTestMutationLedgerEntry[],
+  fieldGates: CodexTestFieldCompositionGate[],
   plan?: AgentPlan,
 ): string[] {
   const requiredCases = new Set(manifest.phases.map((phase) => phase.id))
@@ -281,6 +284,8 @@ function decisionProblems(
     }
     if (decision.outcome === 'blocked' && decision.blockers.length === 0) problems.push(`blocked case decision ${decision.caseId} has no blocker`)
     if (decision.outcome === 'product_failed' && decision.productDefects.length === 0) problems.push(`product-failed case decision ${decision.caseId} has no product defect`)
+    const fieldProblem = decisionFieldContractProblem(decision, fieldGates)
+    if (fieldProblem) problems.push(`case ${decision.caseId} ${fieldProblem}`)
   }
   if (ledger.some((entry) => entry.status === 'pending')) problems.push('Mutation Ledger contains pending entries')
   return problems
@@ -299,6 +304,7 @@ function resultFromDecisions(options: {
   evidence: AgentEvidenceNote[]
   ledger: CodexTestMutationLedgerEntry[]
   environmentRequirements: CodexTestEnvironmentRequirement[]
+  fieldGates: CodexTestFieldCompositionGate[]
   problems: string[]
 }): CodexTestAgentResult {
   const pendingEnvironmentRequirements = options.environmentRequirements.filter((item) => item.status === 'pending')
@@ -312,11 +318,20 @@ function resultFromDecisions(options: {
     : 'The execution agent did not record a final case decision.'
   const cases = options.manifest.phases.map((phase) => {
     const decision = decisionByCase.get(phase.id)
+    const fieldProblem = decision ? decisionFieldContractProblem(decision, options.fieldGates) : undefined
+    const failureSource = fieldProblem ? 'agent_execution' as const : decision?.failureSource
+    const failureKind = fieldProblem
+      ? (decision?.failureKind === 'validation' ? 'validation' as const : 'execution' as const)
+      : decision?.failureKind
+    const outcome = fieldProblem ? 'blocked' as const : decision?.outcome ?? 'blocked' as const
     return {
       caseId: phase.id,
       title: phase.title,
-      outcome: decision?.outcome ?? 'blocked' as const,
-      summary: decision?.summary ?? missingMessage,
+      outcome,
+      summary: fieldProblem ? `${decision?.summary ?? missingMessage} Composite-field contract: ${fieldProblem}.` : decision?.summary ?? missingMessage,
+      ...(outcome !== 'passed' ? { failureSource: failureSource ?? 'agent_execution' as const } : {}),
+      ...(outcome !== 'passed' ? { failureKind: failureKind ?? 'execution' as const } : {}),
+      ...(decision?.fieldGateIds?.length ? { fieldGateIds: decision.fieldGateIds } : {}),
       evidence: (evidenceByCase.get(phase.id) ?? []).map((note) => ({
         kind: note.kind,
         description: note.description,
@@ -328,7 +343,9 @@ function resultFromDecisions(options: {
     ...options.decisions.flatMap((item) => item.blockers),
     ...effectiveProblems,
   ])]
-  const productDefects = [...new Set(options.decisions.flatMap((item) => item.productDefects))]
+  const productDefects = [...new Set(options.decisions.flatMap((item) => (
+    decisionFieldContractProblem(item, options.fieldGates) ? [] : item.productDefects
+  )))]
   const decisionOutcome = outcomeFor(options.decisions)
   const outcome = effectiveProblems.length > 0 ? 'blocked' : decisionOutcome
   const result: CodexTestAgentResult = {
@@ -384,6 +401,8 @@ function blockedResult(
       title: phase.title,
       outcome: 'blocked',
       summary: message,
+      failureSource: 'environment',
+      failureKind: 'environment',
       evidence: [{ kind: 'observation', description: 'Execution dependency failure recorded in codex-agent.events.jsonl.' }],
     })),
     mutations: [],
@@ -503,6 +522,7 @@ export async function runCodexTestAgent(
       ...(options.slowMo !== undefined ? { slowMo: options.slowMo } : {}),
       sourceCodexHome: options.codexHome ?? process.env.CODEX_HOME ?? process.env.AUTO_TEST_CODEX_HOME ?? resolve(process.env.HOME ?? '.', '.codex'),
       environment: process.env,
+      testDataAccess: options.testDataAccess ?? 'direct',
       ...(options.resume ? { resume: true } : {}),
     })
     mutationLedgerPath = workspace.mutationLedgerPath
@@ -543,6 +563,7 @@ export async function runCodexTestAgent(
             environmentContext: options.environmentContext,
             secretAliases: workspace.secretAliases,
             allowedOrigins: options.profile.origins,
+            testDataAccess: options.testDataAccess ?? 'direct',
             ...(options.maxIterations !== undefined ? { maxIterations: options.maxIterations } : {}),
           }) },
           ...options.imagePaths.map((path) => ({ type: 'local_image' as const, path })),
@@ -554,12 +575,13 @@ export async function runCodexTestAgent(
     progress.report('stage', '浏览器执行阶段结束，正在核对 Execution Plan、证据和 Mutation Ledger')
     let ledger = await readMutationLedger(workspace.mutationLedgerPath)
     let environmentRequirements = await readJsonOr<CodexTestEnvironmentRequirement[]>(workspace.environmentRequirementsPath, [])
+    let fieldGates = await readJsonOr<CodexTestFieldCompositionGate[]>(workspace.fieldCompositionPath, [])
     let evidence = await readJsonOr<AgentEvidenceNote[]>(workspace.evidenceIndexPath, [])
     let plan = await readJsonOr<AgentPlan | undefined>(workspace.planPath, undefined)
     let decisions = await readJsonOr<CodexTestCaseDecision[]>(workspace.caseResultsPath, [])
     const maxFinalizationTurns = options.maxFinalizationTurns ?? 2
     for (let turn = 0; turn < maxFinalizationTurns; turn++) {
-      const problems = decisionProblems(decisions, options.manifest, evidence, ledger, plan)
+      const problems = decisionProblems(decisions, options.manifest, evidence, ledger, fieldGates, plan)
       if (problems.length === 0) break
       progress.report('stage', `交付核对发现 ${problems.length} 项不完整，正在进行第 ${turn + 1}/${maxFinalizationTurns} 轮补齐`)
       await runTurn(thread, [{
@@ -573,16 +595,18 @@ export async function runCodexTestAgent(
       )
       ledger = await readMutationLedger(workspace.mutationLedgerPath)
       environmentRequirements = await readJsonOr<CodexTestEnvironmentRequirement[]>(workspace.environmentRequirementsPath, [])
+      fieldGates = await readJsonOr<CodexTestFieldCompositionGate[]>(workspace.fieldCompositionPath, [])
       evidence = await readJsonOr<AgentEvidenceNote[]>(workspace.evidenceIndexPath, [])
       plan = await readJsonOr<AgentPlan | undefined>(workspace.planPath, undefined)
       decisions = await readJsonOr<CodexTestCaseDecision[]>(workspace.caseResultsPath, [])
     }
     ledger = await readMutationLedger(workspace.mutationLedgerPath)
     environmentRequirements = await readJsonOr<CodexTestEnvironmentRequirement[]>(workspace.environmentRequirementsPath, [])
+    fieldGates = await readJsonOr<CodexTestFieldCompositionGate[]>(workspace.fieldCompositionPath, [])
     evidence = await readJsonOr<AgentEvidenceNote[]>(workspace.evidenceIndexPath, [])
     plan = await readJsonOr<AgentPlan | undefined>(workspace.planPath, undefined)
     decisions = await readJsonOr<CodexTestCaseDecision[]>(workspace.caseResultsPath, [])
-    const finalProblems = decisionProblems(decisions, options.manifest, evidence, ledger, plan)
+    const finalProblems = decisionProblems(decisions, options.manifest, evidence, ledger, fieldGates, plan)
     const result = resultFromDecisions({
       manifest: options.manifest,
       state,
@@ -590,6 +614,7 @@ export async function runCodexTestAgent(
       evidence,
       ledger,
       environmentRequirements,
+      fieldGates,
       problems: finalProblems,
     })
     await writePrivateJson(resultPath, result)

--- a/src/agent/test-data-access.ts
+++ b/src/agent/test-data-access.ts
@@ -1,0 +1,24 @@
+export function parseAgentSecretValues(content: string): Record<string, string> {
+  const values: Record<string, string> = {}
+  for (const line of content.split(/\r?\n/)) {
+    if (!line) continue
+    const separator = line.indexOf('=')
+    if (separator < 1) throw new Error('Secret alias file contains an invalid line')
+    const alias = line.slice(0, separator)
+    const value = JSON.parse(line.slice(separator + 1)) as unknown
+    if (typeof value !== 'string') throw new Error(`Secret alias ${alias} is not a string`)
+    values[alias] = value
+  }
+  return values
+}
+
+export function getRunScopedTestValue(
+  access: 'direct' | 'opaque',
+  values: Record<string, string>,
+  alias: string,
+): string {
+  if (access !== 'direct') throw new Error('Direct test-data access is disabled for this run')
+  const value = values[alias]
+  if (value === undefined) throw new Error(`Unknown run-scoped test value alias: ${alias}`)
+  return value
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,5 +1,7 @@
 export type CodexTestOutcome = 'passed' | 'product_failed' | 'blocked'
 export type CodexTestRisk = 'read' | 'write' | 'destructive'
+export type CodexTestFailureSource = 'product' | 'agent_execution' | 'environment' | 'input'
+export type CodexTestFailureKind = 'assertion' | 'validation' | 'authentication' | 'environment' | 'data' | 'execution'
 
 export interface CodexTestEvidence {
   kind: 'snapshot' | 'screenshot' | 'console' | 'network' | 'observation' | 'mutation'
@@ -12,7 +14,47 @@ export interface CodexTestCaseResult {
   title: string
   outcome: CodexTestOutcome
   summary: string
+  failureSource?: CodexTestFailureSource
+  failureKind?: CodexTestFailureKind
+  fieldGateIds?: string[]
   evidence: CodexTestEvidence[]
+}
+
+export type CodexTestFieldComponentRole = 'selector' | 'input' | 'display' | 'hidden'
+export type CodexTestFieldComponentSource = 'static' | 'secret' | 'derived' | 'unknown'
+export type CodexTestFieldRepresentation = 'full' | 'component' | 'suffix' | 'none' | 'unknown'
+export type CodexTestFieldContribution = 'segment' | 'context' | 'none'
+
+export interface CodexTestFieldComponent {
+  id: string
+  role: CodexTestFieldComponentRole
+  label: string
+  source: CodexTestFieldComponentSource
+  observedValue?: string | undefined
+  representation: CodexTestFieldRepresentation
+  contribution: CodexTestFieldContribution
+}
+
+export interface CodexTestFieldRenderedComponent {
+  componentId: string
+  valueKind: 'static' | 'secret' | 'derived' | 'empty'
+  valueLength?: number | undefined
+  literalValue?: string | undefined
+  secretAlias?: string | undefined
+}
+
+export interface CodexTestFieldCompositionGate {
+  id: string
+  caseId: string
+  fieldId: string
+  logicalValueRef: string
+  purpose: string
+  components: CodexTestFieldComponent[]
+  rendered: CodexTestFieldRenderedComponent[]
+  evidence: string[]
+  status: 'passed' | 'blocked'
+  reasons: string[]
+  checkedAt: string
 }
 
 export interface CodexTestMutationResult {
@@ -79,5 +121,8 @@ export interface CodexTestCaseDecision {
   summary: string
   blockers: string[]
   productDefects: string[]
+  failureSource?: CodexTestFailureSource
+  failureKind?: CodexTestFailureKind
+  fieldGateIds?: string[]
   recordedAt: string
 }

--- a/src/agent/workspace.ts
+++ b/src/agent/workspace.ts
@@ -33,6 +33,7 @@ export interface CodexAgentWorkspace {
   controlConfigPath: string
   mutationLedgerPath: string
   environmentRequirementsPath: string
+  fieldCompositionPath: string
   evidenceIndexPath: string
   caseResultsPath: string
   planPath: string
@@ -169,6 +170,7 @@ export async function prepareCodexAgentWorkspace(options: {
   sourceCodexHome: string
   environment?: NodeJS.ProcessEnv
   resume?: boolean
+  testDataAccess?: 'direct' | 'opaque'
 }): Promise<CodexAgentWorkspace> {
   const outputDirectory = resolve(options.outputDirectory)
   const workspaceDirectory = resolve(outputDirectory, 'agent-workspace')
@@ -181,6 +183,7 @@ export async function prepareCodexAgentWorkspace(options: {
   const controlConfigPath = resolve(privateDirectory, 'control-config.json')
   const mutationLedgerPath = resolve(privateDirectory, 'mutation-ledger.json')
   const environmentRequirementsPath = resolve(privateDirectory, 'environment-requirements.json')
+  const fieldCompositionPath = resolve(privateDirectory, 'field-compositions.json')
   const evidenceIndexPath = resolve(workspaceDirectory, 'evidence-index.json')
   const caseResultsPath = resolve(workspaceDirectory, 'case-results.json')
   const planPath = resolve(workspaceDirectory, 'execution-plan.json')
@@ -294,14 +297,17 @@ export async function prepareCodexAgentWorkspace(options: {
   })
 
   const requirementsMissing = await access(environmentRequirementsPath).then(() => false, () => true)
+  const fieldCompositionMissing = await access(fieldCompositionPath).then(() => false, () => true)
   if (!options.resume) {
     await writePrivateJson(mutationLedgerPath, [])
     await writePrivateJson(environmentRequirementsPath, [])
+    await writePrivateJson(fieldCompositionPath, [])
     await writePrivateJson(evidenceIndexPath, [])
     await writePrivateJson(caseResultsPath, [])
   } else if (requirementsMissing) {
     await writePrivateJson(environmentRequirementsPath, [])
   }
+  if (options.resume && fieldCompositionMissing) await writePrivateJson(fieldCompositionPath, [])
   const controlConfig: CodexTestControlConfig = {
     version: '1.0',
     workflowId: options.manifest.workflowId,
@@ -317,6 +323,9 @@ export async function prepareCodexAgentWorkspace(options: {
     caseResultsPath,
     mutationLedgerPath,
     environmentRequirementsPath,
+    fieldCompositionPath,
+    secretValuesPath: playwrightSecretsPath,
+    testDataAccess: options.testDataAccess ?? 'direct',
   }
   await writePrivateJson(controlConfigPath, controlConfig)
 
@@ -333,6 +342,7 @@ export async function prepareCodexAgentWorkspace(options: {
     controlConfigPath,
     mutationLedgerPath,
     environmentRequirementsPath,
+    fieldCompositionPath,
     evidenceIndexPath,
     caseResultsPath,
     planPath,

--- a/src/cli/agent-test.ts
+++ b/src/cli/agent-test.ts
@@ -37,6 +37,7 @@ export interface AgentTestCliOptions {
   codexExecutable?: string
   codexHome?: string
   resume?: boolean
+  testDataAccess: 'direct' | 'opaque'
 }
 
 interface AgentEnvironmentSelection {
@@ -44,6 +45,7 @@ interface AgentEnvironmentSelection {
   origins: string[]
   policy: EnvironmentProfile['policy']
   authenticatedOrigins: string[]
+  testDataAccess?: 'direct' | 'opaque'
 }
 
 function timestamp(): string {
@@ -86,6 +88,7 @@ function help(): string {
     '  --max-finalization-turns N  结果契约修复轮数，默认 2',
     '  --codex-bin <path>          显式 Codex 可执行文件；通常无需设置',
     '  --codex-home <path>         源 Codex 配置目录；运行仍使用隔离副本',
+    '  --opaque-test-data          不向模型直接提供本次 Excel/Profile 测试值；默认 direct',
     '  --resume                    恢复同一输出目录中的中断 run、Codex thread 与 Mutation Ledger',
   ].join('\n')
 }
@@ -146,6 +149,7 @@ export function parseAgentTestArgs(args: string[]): AgentTestCliOptions {
     ...(valueAfter(args, '--model') ? { model: valueAfter(args, '--model')! } : {}),
     headed: args.includes('--headed'),
     resume: args.includes('--resume'),
+    testDataAccess: args.includes('--opaque-test-data') ? 'opaque' : 'direct',
     ...(slowMo !== undefined ? { slowMo } : {}),
     ...(maxIterations !== undefined ? { maxIterations } : {}),
     ...(maxFinalizationTurns !== undefined ? { maxFinalizationTurns } : {}),
@@ -208,11 +212,12 @@ function isAppendOnlyOrigins(previous: string[], current: string[]): boolean {
 }
 
 function isAppendOnlyEnvironmentSelection(
-  previous: { profileId: string; origins: string[]; policy: EnvironmentProfile['policy']; authenticatedOrigins: string[] },
-  current: { profileId: string; origins: string[]; policy: EnvironmentProfile['policy']; authenticatedOrigins: string[] },
+  previous: AgentEnvironmentSelection,
+  current: AgentEnvironmentSelection,
 ): boolean {
   return previous.profileId === current.profileId &&
     JSON.stringify(previous.policy) === JSON.stringify(current.policy) &&
+    (previous.testDataAccess === undefined || previous.testDataAccess === current.testDataAccess) &&
     isAppendOnlyOrigins(previous.origins, current.origins) &&
     isAppendOnlyOrigins(previous.authenticatedOrigins, current.authenticatedOrigins)
 }
@@ -377,6 +382,7 @@ export async function runAgentTestCli(options: AgentTestCliOptions): Promise<num
       origins: profile.origins,
       policy: profile.policy,
       authenticatedOrigins: profile.auth.map((adapter) => adapter.origin),
+      testDataAccess: options.testDataAccess,
     }
     if (options.resume) {
       if (!priorSelection || !isAppendOnlyEnvironmentSelection(priorSelection, environmentSelection)) {
@@ -405,6 +411,7 @@ export async function runAgentTestCli(options: AgentTestCliOptions): Promise<num
     ...(options.codexHome ? { codexHome: options.codexHome } : {}),
     ...(options.maxFinalizationTurns !== undefined ? { maxFinalizationTurns: options.maxFinalizationTurns } : {}),
     ...(options.resume ? { resume: true } : {}),
+    testDataAccess: options.testDataAccess,
     onProgress: (progress) => printProgress(progress.message),
   })
   console.log(`测试状态：${run.state.status}`)

--- a/src/cli/easy.ts
+++ b/src/cli/easy.ts
@@ -33,6 +33,7 @@ interface EasyRunOptions {
   slowMo?: number
   legacyRuntime?: boolean
   resume?: boolean
+  testDataAccess?: 'direct' | 'opaque'
 }
 
 const rl = createInterface({ input, output })
@@ -284,6 +285,7 @@ export async function runEasyWorkflow(options: EasyRunOptions): Promise<number> 
       ...(options.maxIterations !== undefined ? { maxIterations: options.maxIterations } : {}),
       ...(process.env.AUTO_TEST_CODEX_HOME ? { codexHome: process.env.AUTO_TEST_CODEX_HOME } : {}),
       ...(options.resume ? { resume: true } : {}),
+      testDataAccess: options.testDataAccess ?? 'direct',
     })
     statePath = resolve(outputDirectory, 'codex-agent.state.json')
   }
@@ -483,6 +485,7 @@ async function main(): Promise<void> {
       ...(slowMo !== undefined ? { slowMo } : {}),
       legacyRuntime: args.includes('--legacy-runtime'),
       resume: args.includes('--resume'),
+      testDataAccess: args.includes('--opaque-test-data') ? 'opaque' : 'direct',
     })
     process.exitCode = code
     return
@@ -495,7 +498,7 @@ async function main(): Promise<void> {
   }
   if (command === '--help' || command === 'help') {
     console.log('用法：npm run easy（交互菜单）')
-    console.log('      npm run easy -- run --file cases.xlsx [--url https://example.test/] [--headed|--headless] [--slow-mo 150]')
+    console.log('      npm run easy -- run --file cases.xlsx [--url https://example.test/] [--headed|--headless] [--slow-mo 150] [--opaque-test-data]')
     console.log('      中断恢复：在原命令后加入 --resume，并复用原 --output-dir')
     console.log('      默认运行 Codex-native 测试代理；仅兼容旧链路时使用 --legacy-runtime')
     console.log('      npm run easy -- register --profile test --url https://example.test/')

--- a/tests/agent-redact.test.ts
+++ b/tests/agent-redact.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { transientAgentEventValues } from '../src/agent/redact.js'
+
+describe('agent event redaction', () => {
+  it('extracts transient composite-field values without treating unrelated tool arguments as secrets', () => {
+    expect(transientAgentEventValues({
+      type: 'item.completed',
+      item: {
+        type: 'mcp_tool_call',
+        tool: 'field_composition_check',
+        arguments: {
+          rendered: [
+            { componentId: 'selector', valueKind: 'derived', literalValue: 'segment-a' },
+            { componentId: 'input', valueKind: 'derived', literalValue: 'segment-b' },
+          ],
+        },
+      },
+    })).toEqual(['segment-a', 'segment-b'])
+
+    expect(transientAgentEventValues({
+      type: 'item.completed',
+      item: { type: 'mcp_tool_call', tool: 'browser_fill_form', arguments: { value: 'visible-to-existing-redaction' } },
+    })).toEqual([])
+  })
+})

--- a/tests/agent-test-cli.test.ts
+++ b/tests/agent-test-cli.test.ts
@@ -9,6 +9,7 @@ describe('Codex agent CLI', () => {
     expect(options.headed).toBe(true)
     expect(options.maxIterations).toBe(2)
     expect(options.slowMo).toBe(50)
+    expect(options.testDataAccess).toBe('direct')
     expect(options.outputDirectory).toMatch(/artifacts[\\/]runs[\\/].*cases-/)
   })
 
@@ -22,6 +23,10 @@ describe('Codex agent CLI', () => {
 
     expect(options.resume).toBe(true)
     expect(options.outputDirectory).toMatch(/artifacts[\\/]recovery$/)
+  })
+
+  it('supports an explicit opaque test-data mode', () => {
+    expect(parseAgentTestArgs(['--file', 'cases.xlsx', '--opaque-test-data']).testDataAccess).toBe('opaque')
   })
 
   it('fails closed when environment and workbook secrets disagree', () => {

--- a/tests/codex-agent-prompt.test.ts
+++ b/tests/codex-agent-prompt.test.ts
@@ -22,13 +22,20 @@ describe('Codex test agent prompt safety rules', () => {
     const prompt = codexTestAgentPrompt({
       manifest: manifest(),
       environmentContext: '',
-      secretAliases: [{ secretRef: 'workflow.value', purpose: 'sensitive value', aliases: ['AUTO_TEST_VALUE_001'] }],
+      secretAliases: [{
+        secretRef: 'workflow.value', purpose: 'sensitive value', aliases: ['AUTO_TEST_VALUE_001'],
+      }],
+      testDataAccess: 'direct',
     })
 
     expect(prompt).toContain('request_environment_access')
     expect(prompt).toContain('Registered target origins (strict browser allowlist)')
-    expect(prompt).toContain('do not duplicate a prefix')
+    expect(prompt).toContain('field_composition_check')
+    expect(prompt).toContain('failureSource agent_execution')
+    expect(prompt).toContain('malformed or unverified representation')
+    expect(prompt).toContain('test_value_get')
     expect(prompt).toContain('at most one evidence-driven correction')
     expect(prompt).not.toContain('659')
+    expect(prompt).not.toContain('+65')
   })
 })

--- a/tests/codex-agent-result.test.ts
+++ b/tests/codex-agent-result.test.ts
@@ -50,6 +50,24 @@ describe('Codex test result contract', () => {
     expect(enforced.blockers.join(' ')).toContain('archive-row')
     expect(enforced.mutations[0]?.status).toBe('pending')
     expect(enforced.cases[0]?.outcome).toBe('blocked')
+    expect(enforced.cases[0]).toMatchObject({ failureSource: 'agent_execution', failureKind: 'execution' })
     expect(enforced.cases[0]?.evidence.some((item) => item.kind === 'mutation')).toBe(true)
+  })
+
+  it('validates optional failure classification and field gate references', () => {
+    const classified = result()
+    classified.outcome = 'blocked'
+    classified.cases[0] = {
+      ...classified.cases[0]!,
+      outcome: 'blocked',
+      failureSource: 'agent_execution',
+      failureKind: 'validation',
+      fieldGateIds: ['filter-catalog:query'],
+    }
+    classified.blockers = ['The field representation gate blocked submission.']
+
+    expect(parseCodexTestResult(JSON.stringify(classified)).cases[0]).toMatchObject({
+      failureSource: 'agent_execution', failureKind: 'validation', fieldGateIds: ['filter-catalog:query'],
+    })
   })
 })

--- a/tests/codex-agent-runner.test.ts
+++ b/tests/codex-agent-runner.test.ts
@@ -219,6 +219,8 @@ describe('Codex test agent runner', () => {
     })
 
     expect(run.result?.outcome).toBe('passed')
+    expect(run.result?.cases[0]?.failureSource).toBeUndefined()
+    expect(run.result?.cases[0]?.failureKind).toBeUndefined()
     expect(executionRunStreamed).toHaveBeenCalledTimes(2)
     expect(JSON.stringify(executionInputs[0])).toContain('Do not produce the structured final result')
     expect(JSON.stringify(executionInputs[1])).toContain('missing final case decision')
@@ -250,6 +252,7 @@ describe('Codex test agent runner', () => {
 
     expect(run.state).toMatchObject({ status: 'completed', stage: 'completed', outcome: 'blocked', threadId: 'thread-fixture' })
     expect(run.result?.blockers).toContain('429 usage limit reached')
+    expect(run.result?.cases[0]).toMatchObject({ failureSource: 'environment', failureKind: 'environment' })
     expect(run.result?.cases[0]?.evidence).not.toHaveLength(0)
   })
 
@@ -385,6 +388,56 @@ describe('Codex test agent runner', () => {
     })
 
     expect(run.result?.outcome).toBe('passed')
+  })
+
+  it('downgrades an unverified product validation claim to blocked', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-agent-field-gate-'))
+    directories.push(directory)
+    const sourceHome = resolve(directory, 'source-home')
+    await mkdir(sourceHome)
+    await writeFile(resolve(sourceHome, 'config.toml'), 'model = "fixture"\n', { mode: 0o600 })
+    const browserPath = resolve(directory, 'chromium')
+    await writeFile(browserPath, '')
+    const codexExecutable = await fakeCodexExecutable(directory)
+    let controlConfigPath = ''
+
+    const run = await runCodexTestAgent({
+      outputDirectory: resolve(directory, 'run'),
+      manifest: manifest('https://tasks.example.test'),
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: false, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false, codexHome: sourceHome, codexExecutable,
+      maxFinalizationTurns: 0,
+    }, {
+      browserExecutablePath: browserPath,
+      startThread: (options) => {
+        controlConfigPath = options.controlConfigPath
+        return {
+          id: 'thread-field-gate',
+          runStreamed: async () => {
+            const control = JSON.parse(await readFile(controlConfigPath, 'utf8')) as {
+              planPath: string; evidencePath: string; caseResultsPath: string; fieldCompositionPath: string
+            }
+            await writeFile(control.planPath, JSON.stringify({ steps: [{ id: 'submit', status: 'failed' }] }))
+            await writeFile(control.evidencePath, JSON.stringify([{ caseId: 'inspect-task', kind: 'observation', description: 'Validation error visible.' }]))
+            await writeFile(control.fieldCompositionPath, JSON.stringify([{
+              id: 'inspect-task:value', caseId: 'inspect-task', fieldId: 'value', status: 'blocked',
+            }]))
+            await writeFile(control.caseResultsPath, JSON.stringify([{
+              caseId: 'inspect-task', outcome: 'product_failed', summary: 'The application rejected the value.',
+              blockers: [], productDefects: ['Validation rejected the value.'], failureSource: 'product', failureKind: 'validation',
+              fieldGateIds: ['inspect-task:value'], recordedAt: '2026-08-01T00:01:00.000Z',
+            }]))
+            return streamedResponse('Execution complete.')
+          },
+        }
+      },
+    })
+
+    expect(run.result?.outcome).toBe('blocked')
+    expect(run.result?.cases[0]?.outcome).toBe('blocked')
+    expect(run.result?.cases[0]?.failureSource).toBe('agent_execution')
+    expect(run.result?.productDefects).toEqual([])
+    expect(run.result?.blockers.join(' ')).toContain('lacks a passed composite-field gate')
   })
 
   it('keeps unknown framework exceptions as failed instead of misclassifying them as a business block', async () => {

--- a/tests/codex-agent-workspace.test.ts
+++ b/tests/codex-agent-workspace.test.ts
@@ -116,8 +116,12 @@ describe('Codex agent workspace', () => {
     expect(controlConfig.caseResultsPath).toBe(workspace.caseResultsPath)
     expect(controlConfig.allowedOrigins).toEqual(profile.origins)
     expect(controlConfig.environmentRequirementsPath).toBe(workspace.environmentRequirementsPath)
+    expect(controlConfig.fieldCompositionPath).toBe(workspace.fieldCompositionPath)
+    expect(controlConfig.secretValuesPath).toBe(workspace.playwrightSecretsPath)
+    expect(controlConfig.testDataAccess).toBe('direct')
     expect(controlConfig.caseRisks).toEqual({ 'inspect-board': 'read' })
     expect(JSON.parse(await readFile(workspace.caseResultsPath, 'utf8'))).toEqual([])
+    expect(JSON.parse(await readFile(workspace.fieldCompositionPath, 'utf8'))).toEqual([])
     expect(mergedState.cookies).toHaveLength(2)
     expect(mergedState.origins).toHaveLength(2)
     expect(mergedState.origins.find((item: { origin: string }) => item.origin === 'https://two.example.test').indexedDB).toHaveLength(1)
@@ -163,10 +167,12 @@ describe('Codex agent workspace', () => {
     const evidence = [{ caseId: 'inspect-board', kind: 'observation', description: 'Prior evidence' }]
     const decisions = [{ caseId: 'inspect-board', outcome: 'blocked', summary: 'Interrupted', blockers: ['network'], productDefects: [], recordedAt: '2026-08-01T00:00:00.000Z' }]
     const plan = { summary: 'Recover', steps: [{ id: 'recover', status: 'in_progress' }] }
+    const fieldGates = [{ id: 'inspect-board:value', caseId: 'inspect-board', fieldId: 'value', status: 'passed' }]
     await writeFile(initial.mutationLedgerPath, JSON.stringify(ledger))
     await writeFile(initial.evidenceIndexPath, JSON.stringify(evidence))
     await writeFile(initial.caseResultsPath, JSON.stringify(decisions))
     await writeFile(initial.planPath, JSON.stringify(plan))
+    await writeFile(initial.fieldCompositionPath, JSON.stringify(fieldGates))
 
     const resumed = await prepareCodexAgentWorkspace({ ...options, secrets: { 'fixture.accessCode': 'rotated-value' }, resume: true })
 
@@ -174,6 +180,7 @@ describe('Codex agent workspace', () => {
     expect(JSON.parse(await readFile(resumed.evidenceIndexPath, 'utf8'))).toEqual(evidence)
     expect(JSON.parse(await readFile(resumed.caseResultsPath, 'utf8'))).toEqual(decisions)
     expect(JSON.parse(await readFile(resumed.planPath, 'utf8'))).toEqual(plan)
+    expect(JSON.parse(await readFile(resumed.fieldCompositionPath, 'utf8'))).toEqual(fieldGates)
     expect(await readFile(resumed.playwrightSecretsPath, 'utf8')).toContain('rotated-value')
   })
 

--- a/tests/decision-contract.test.ts
+++ b/tests/decision-contract.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { decisionFieldContractProblem } from '../src/agent/decision-contract.js'
+import type { CodexTestCaseDecision, CodexTestFieldCompositionGate } from '../src/agent/types.js'
+
+function decision(overrides: Partial<CodexTestCaseDecision> = {}): CodexTestCaseDecision {
+  return {
+    caseId: 'submit-form',
+    outcome: 'blocked',
+    summary: 'The representation gate blocked submission.',
+    blockers: ['Composite field representation is invalid.'],
+    productDefects: [],
+    failureSource: 'agent_execution',
+    failureKind: 'validation',
+    fieldGateIds: ['submit-form:logical-value'],
+    recordedAt: '2026-08-02T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function gate(status: 'passed' | 'blocked'): CodexTestFieldCompositionGate {
+  return {
+    id: 'submit-form:logical-value',
+    caseId: 'submit-form',
+    fieldId: 'logical-value',
+    logicalValueRef: 'workflow.logicalValue',
+    purpose: 'Represent one logical value across visible controls',
+    components: [],
+    rendered: [],
+    evidence: ['snapshot:form'],
+    status,
+    reasons: status === 'blocked' ? ['duplicate static component'] : [],
+    checkedAt: '2026-08-02T00:00:00.000Z',
+  }
+}
+
+describe('case decision field representation contract', () => {
+  it('accepts an agent-execution block backed by a blocked gate', () => {
+    expect(decisionFieldContractProblem(decision(), [gate('blocked')])).toBeUndefined()
+  })
+
+  it('rejects a product validation defect backed by a blocked gate', () => {
+    const problem = decisionFieldContractProblem(decision({
+      outcome: 'product_failed',
+      blockers: [],
+      productDefects: ['The application rejected the value.'],
+      failureSource: 'product',
+    }), [gate('blocked')])
+
+    expect(problem).toContain('lacks a passed composite-field gate')
+  })
+
+  it('accepts a product validation defect only after a passed gate', () => {
+    expect(decisionFieldContractProblem(decision({
+      outcome: 'product_failed',
+      blockers: [],
+      productDefects: ['The application rejected a verified representation.'],
+      failureSource: 'product',
+    }), [gate('passed')])).toBeUndefined()
+  })
+
+  it('accepts a passed case that references its passed composite-field gate', () => {
+    const passed = decision({
+      outcome: 'passed',
+      summary: 'The submitted representation was accepted.',
+      blockers: [],
+      productDefects: [],
+      fieldGateIds: ['submit-form:logical-value'],
+    })
+    delete passed.failureSource
+    delete passed.failureKind
+    expect(decisionFieldContractProblem(passed, [gate('passed')])).toBeUndefined()
+  })
+})

--- a/tests/field-composition.test.ts
+++ b/tests/field-composition.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import { validateFieldCompositionGate } from '../src/agent/field-composition.js'
+
+describe('composite field representation gate', () => {
+  it('blocks a static selector value repeated inside a secret input representation', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'contact-login',
+      fieldId: 'contact-identity',
+      logicalValueRef: 'workflow.contact',
+      purpose: 'Enter one logical contact identity across visible controls',
+      components: [
+        { id: 'region', role: 'selector', label: 'Region', source: 'static', observedValue: 'R-7', representation: 'component', contribution: 'segment' },
+        { id: 'identity', role: 'input', label: 'Identity', source: 'secret', representation: 'suffix', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'region', valueKind: 'static', literalValue: 'R-7' },
+        { componentId: 'identity', valueKind: 'secret', valueLength: 12, secretAlias: 'AUTO_TEST_VALUE_001' },
+      ],
+      evidence: ['snapshot:contact-form'],
+      secretValues: { AUTO_TEST_VALUE_001: 'R-7abcdefghi' },
+    })
+
+    expect(gate.status).toBe('blocked')
+    expect(gate.reasons.join(' ')).toContain('do not reconstruct the logical source value')
+  })
+
+  it('passes a currency selector and component-specific amount representation', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'create-budget',
+      fieldId: 'budget-value',
+      logicalValueRef: 'workflow.budget',
+      purpose: 'Enter a budget split across currency and amount controls',
+      components: [
+        { id: 'currency', role: 'selector', label: 'Currency', source: 'static', observedValue: 'CUR', representation: 'component', contribution: 'context' },
+        { id: 'amount', role: 'input', label: 'Amount', source: 'secret', representation: 'component', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'currency', valueKind: 'static', literalValue: 'CUR' },
+        { componentId: 'amount', valueKind: 'secret', valueLength: 6, secretAlias: 'AUTO_TEST_VALUE_001' },
+      ],
+      evidence: ['snapshot:budget-form'],
+      secretValues: { AUTO_TEST_VALUE_001: '123400' },
+    })
+
+    expect(gate.status).toBe('passed')
+    expect(gate.reasons).toEqual([])
+  })
+
+  it('blocks unknown date-time component semantics without recording raw derived values', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'schedule-job',
+      fieldId: 'scheduled-at',
+      logicalValueRef: 'workflow.scheduledAt',
+      purpose: 'Represent a schedule across date and time-zone controls',
+      components: [
+        { id: 'zone', role: 'selector', label: 'Time zone', source: 'static', observedValue: 'Zone-A', representation: 'component', contribution: 'context' },
+        { id: 'time', role: 'input', label: 'Local time', source: 'derived', representation: 'unknown', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'zone', valueKind: 'static', literalValue: 'Zone-A' },
+        { componentId: 'time', valueKind: 'derived', valueLength: 16 },
+      ],
+      evidence: ['snapshot:schedule-form'],
+    })
+
+    expect(gate.status).toBe('blocked')
+    expect(gate.reasons.join(' ')).toContain('unknown representation')
+  })
+
+  it('strips raw non-static values from a blocked gate record', () => {
+    const rawSecret = 'must-not-persist'
+    const gate = validateFieldCompositionGate({
+      caseId: 'account-lookup',
+      fieldId: 'account-identity',
+      logicalValueRef: 'workflow.account',
+      purpose: 'Represent an account identity across type and value controls',
+      components: [
+        { id: 'type', role: 'selector', label: 'Account type', source: 'static', observedValue: 'External', representation: 'component', contribution: 'context' },
+        { id: 'account', role: 'input', label: 'Account', source: 'secret', observedValue: rawSecret, representation: 'component', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'type', valueKind: 'static', literalValue: 'External' },
+        { componentId: 'account', valueKind: 'secret', valueLength: rawSecret.length, literalValue: rawSecret, secretAlias: 'AUTO_TEST_VALUE_001' },
+      ],
+      evidence: ['snapshot:account-form'],
+      secretValues: { AUTO_TEST_VALUE_001: rawSecret },
+    })
+
+    expect(gate.status).toBe('blocked')
+    expect(JSON.stringify(gate)).not.toContain(rawSecret)
+  })
+
+  it('passes a directly derived value when all segment components reconstruct the source', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'contact-login',
+      fieldId: 'contact-identity',
+      logicalValueRef: 'workflow.contact',
+      purpose: 'Enter one logical contact identity across visible controls',
+      components: [
+        { id: 'region', role: 'selector', label: 'Region', source: 'static', observedValue: 'R-7', representation: 'component', contribution: 'segment' },
+        { id: 'identity', role: 'input', label: 'Identity', source: 'secret', representation: 'suffix', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'region', valueKind: 'static', literalValue: 'R-7' },
+        { componentId: 'identity', valueKind: 'derived', valueLength: 6, secretAlias: 'AUTO_TEST_VALUE_001', literalValue: 'abcdef' },
+      ],
+      evidence: ['snapshot:contact-form'],
+      secretValues: {
+        AUTO_TEST_VALUE_001: 'R-7abcdef',
+      },
+    })
+
+    expect(gate.status).toBe('passed')
+    expect(gate.reasons).toEqual([])
+  })
+
+  it('supports a composite value represented by multiple editable inputs', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'schedule-job',
+      fieldId: 'schedule-window',
+      logicalValueRef: 'workflow.scheduleWindow',
+      purpose: 'Represent one schedule value across date and time inputs',
+      components: [
+        { id: 'date', role: 'input', label: 'Date', source: 'derived', representation: 'component', contribution: 'segment' },
+        { id: 'time', role: 'input', label: 'Time', source: 'derived', representation: 'component', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'date', valueKind: 'derived', literalValue: '2026-08-02', secretAlias: 'AUTO_TEST_VALUE_001' },
+        { componentId: 'time', valueKind: 'derived', literalValue: 'T21:15', secretAlias: 'AUTO_TEST_VALUE_001' },
+      ],
+      evidence: ['snapshot:schedule-window'],
+      secretValues: { AUTO_TEST_VALUE_001: '2026-08-02T21:15' },
+    })
+
+    expect(gate.status).toBe('passed')
+  })
+
+  it('blocks a gate that has no authoritative logical source alias', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'name-entry',
+      fieldId: 'display-name',
+      logicalValueRef: 'workflow.displayName',
+      purpose: 'Represent a display name across two inputs',
+      components: [
+        { id: 'first', role: 'input', label: 'First', source: 'derived', representation: 'component', contribution: 'segment' },
+        { id: 'last', role: 'input', label: 'Last', source: 'derived', representation: 'component', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'first', valueKind: 'derived', literalValue: 'Test' },
+        { componentId: 'last', valueKind: 'derived', literalValue: 'User' },
+      ],
+      evidence: ['snapshot:name-entry'],
+    })
+
+    expect(gate.status).toBe('blocked')
+    expect(gate.reasons).toContain('composite field must reference exactly one logical source alias')
+  })
+
+  it('validates an explicitly empty logical value instead of skipping reconstruction', () => {
+    const gate = validateFieldCompositionGate({
+      caseId: 'empty-value',
+      fieldId: 'composite-empty',
+      logicalValueRef: 'workflow.empty',
+      purpose: 'Represent an empty logical value across visible controls',
+      components: [
+        { id: 'mode', role: 'selector', label: 'Mode', source: 'static', observedValue: 'None', representation: 'component', contribution: 'context' },
+        { id: 'value', role: 'input', label: 'Value', source: 'derived', representation: 'component', contribution: 'segment' },
+      ],
+      rendered: [
+        { componentId: 'mode', valueKind: 'static', literalValue: 'None' },
+        { componentId: 'value', valueKind: 'empty', literalValue: '', secretAlias: 'AUTO_TEST_VALUE_001' },
+      ],
+      evidence: ['snapshot:empty-value'],
+      secretValues: { AUTO_TEST_VALUE_001: '' },
+    })
+
+    expect(gate.status).toBe('passed')
+  })
+})

--- a/tests/test-data-access.test.ts
+++ b/tests/test-data-access.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { getRunScopedTestValue, parseAgentSecretValues } from '../src/agent/test-data-access.js'
+
+describe('run-scoped test-data access', () => {
+  it('parses the private alias file without changing values', () => {
+    expect(parseAgentSecretValues('AUTO_TEST_VALUE_001="A value"\nAUTO_TEST_VALUE_002="line\\nvalue"\n')).toEqual({
+      AUTO_TEST_VALUE_001: 'A value',
+      AUTO_TEST_VALUE_002: 'line\nvalue',
+    })
+  })
+
+  it('returns only explicitly requested values in direct mode', () => {
+    const values = { AUTO_TEST_VALUE_001: 'run-value', AUTO_TEST_VALUE_002: 'other-value' }
+    expect(getRunScopedTestValue('direct', values, 'AUTO_TEST_VALUE_001')).toBe('run-value')
+    expect(() => getRunScopedTestValue('direct', values, 'AUTO_TEST_VALUE_999')).toThrow(/Unknown run-scoped/)
+  })
+
+  it('refuses value disclosure in opaque mode', () => {
+    expect(() => getRunScopedTestValue('opaque', { AUTO_TEST_VALUE_001: 'run-value' }, 'AUTO_TEST_VALUE_001')).toThrow(/disabled/)
+  })
+})


### PR DESCRIPTION
## Summary
- default Codex-native runs to direct, run-scoped Excel/Profile test-data access with an opaque opt-out
- add a generic composite-field representation gate and evidence-based failure classification
- preserve gate state across resume, redact transient derived values, and document Windows acceptance behavior

## Verification
- npm run check
- git diff --check

## Acceptance boundary
- Deterministic Linux/Windows CI validates packaging and framework behavior.
- The real Windows charging scenario still needs a fresh post-merge run before claiming this change resolves that live case.