### PR TITLE
fix(windows): close timed-out probe streams

### DIFF
--- a/scripts/launch-windows.ps1
+++ b/scripts/launch-windows.ps1
@@ -543,6 +543,10 @@ function Stop-CodexProbeProcess([Diagnostics.Process] $Process) {
     try { $Process.Kill() } catch {}
   }
   try { $Process.WaitForExit(5000) | Out-Null } catch {}
+  # Detached descendants can keep inherited pipe handles open after the probe
+  # process exits. Close our readers so timeout cleanup never waits for EOF.
+  try { $Process.StandardOutput.Close() } catch {}
+  try { $Process.StandardError.Close() } catch {}
 }
 
 function Test-CodexProvider {
@@ -582,10 +586,6 @@ function Test-CodexProvider {
       throw "$($_.Exception.Message) 已恢复上一版配置。"
     }
   } finally {
-    if ($probeInvocation -and $probeProcess -and $probeProcess.HasExited) {
-      try { $probeInvocation.StandardOutput.GetAwaiter().GetResult() | Out-Null } catch {}
-      try { $probeInvocation.StandardError.GetAwaiter().GetResult() | Out-Null } catch {}
-    }
     if ($probeProcess) { $probeProcess.Dispose() }
   }
 }

--- a/tests/windows-launcher.test.ts
+++ b/tests/windows-launcher.test.ts
@@ -23,6 +23,8 @@ describe('Windows portable launcher', () => {
     expect(script).toContain('$startInfo.RedirectStandardError = $true')
     expect(script).toContain('$process.StandardOutput.ReadToEndAsync()')
     expect(script).toContain('$process.StandardError.ReadToEndAsync()')
+    expect(script).toContain('$Process.StandardOutput.Close()')
+    expect(script).toContain('$Process.StandardError.Close()')
     expect(script).not.toContain("& $codexExecutable exec 'Reply with exactly AUTO_TEST_API_READY.'")
     expect(script).toContain("scripts\\check-playwright-browser.cjs")
     expect(script).toContain('& $script:NodeExecutable $playwrightCli install chromium')


### PR DESCRIPTION
## Summary

- close redirected Codex stdout/stderr readers after terminating a timed-out probe
- avoid waiting for EOF from detached descendants that may retain inherited pipe handles
- preserve full stream completion on successful probes before validating the response

## Verification

- `npm run check` (37 test files, 238 tests, TypeScript build)
- `git diff --check`
- real Windows Provider probe completed successfully in 21.33 seconds with exit code 0
- the prior real timeout run demonstrated the stale-reader hang this change removes

## Documentation

No documentation change: the documented 120-second timeout, heartbeat, termination, and rollback contract is unchanged; this fixes cleanup so the existing contract is actually honored.

## Review

- OCR intentionally not run per the current task constraint
- deterministic Linux and Windows CI are the merge gates