### PR TITLE
fix: resume guard and pending-mutation recovery on native path

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -763,18 +763,22 @@ export async function runCodexTestAgent(
     const batchSize = state.executionMode === 'case_windows'
       ? state.caseBatchSize ?? DEFAULT_CODEX_CASE_BATCH_SIZE
       : options.caseBatchSize ?? DEFAULT_CODEX_CASE_BATCH_SIZE
-    if (options.resume && state.executionMode !== 'case_windows' && options.caseBatchSize !== undefined) {
+    // A run that crashed before its execution mode was persisted leaves
+    // executionMode undefined; resuming with the original --case-batch-size
+    // is the same command, not a mode switch. Only block an explicit switch
+    // away from a native (single_thread) run.
+    if (options.resume && state.executionMode === 'single_thread' && options.caseBatchSize !== undefined) {
       throw new Error('Resume native Codex runs cannot switch to case-window mode; resume with the original command or start a new run')
     }
     if (options.resume && state.executionMode === 'case_windows' && options.caseBatchSize !== undefined && options.caseBatchSize !== batchSize) {
       throw new Error('Resume case batch size does not match the existing Codex test state')
     }
-    const caseWindows = buildCodexCaseWindows(options.manifest, batchSize)
     // A persistent Codex thread is the native execution path. Case windows
     // remain an explicit capacity/recovery fallback instead of silently
     // replacing the agent's cross-case working context for every long suite.
     const useCaseWindows = state.executionMode === 'case_windows' || options.caseBatchSize !== undefined
     if (useCaseWindows) {
+      const caseWindows = buildCodexCaseWindows(options.manifest, batchSize)
       await mkdir(resolve(workspace.privateDirectory, 'case-batches'), { recursive: true, mode: 0o700 })
       const completedBatchIds = new Set(state.completedBatchIds ?? [])
       const batchResults: CodexTestAgentResult[] = []
@@ -1104,6 +1108,20 @@ export async function runCodexTestAgent(
     await runTurn(thread, input, eventsPath, redactionSecrets, progress, persistThreadId, undefined, receiptRecorder)
     state = updateCodexTestState(state, { ...(thread.id ? { threadId: thread.id } : {}), stage: 'finalizing' })
     await writePrivateJson(statePath, state)
+    const ledgerBeforeFinalization = await readMutationLedger(workspace.mutationLedgerPath)
+    if (ledgerBeforeFinalization.some((entry) => entry.status === 'pending')) {
+      progress.report('stage', '仍有未核销业务写入，正在由同一线程恢复')
+      await runTurn(
+        thread,
+        [{ type: 'text', text: codexTestAgentResumePrompt(fullAgentAccess) }],
+        eventsPath,
+        redactionSecrets,
+        progress,
+        persistThreadId,
+        undefined,
+        receiptRecorder,
+      )
+    }
     progress.report('stage', '浏览器执行阶段结束，正在让同一 Codex 线程直接生成结构化测试交付')
     const maxFinalizationTurns = options.maxFinalizationTurns ?? 2
     let result: CodexTestAgentResult | undefined

--- a/tests/codex-agent-runner.test.ts
+++ b/tests/codex-agent-runner.test.ts
@@ -39,28 +39,26 @@ function twoCaseManifest(origin: string): WorkflowIntakeManifest {
   return workflow
 }
 
-function streamedResponse(response: string): { events: AsyncGenerator<ThreadEvent> } {
+function streamedResponse(
+  response: string,
+  options: { threadId?: string; includeCaseBookkeeping?: boolean } = {},
+): { events: AsyncGenerator<ThreadEvent> } {
+  const threadId = options.threadId ?? 'thread-fixture'
+  const includeCaseBookkeeping = options.includeCaseBookkeeping ?? true
+  const interactionId = includeCaseBookkeeping ? 'receipt-interaction' : 'unattributed-interaction'
+  const observationId = includeCaseBookkeeping ? 'receipt-observation' : 'unattributed-observation'
   return {
     events: (async function* () {
-      yield { type: 'thread.started', thread_id: 'thread-fixture' } as ThreadEvent
+      yield { type: 'thread.started', thread_id: threadId } as ThreadEvent
       yield { type: 'turn.started' } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'case-begin', type: 'mcp_tool_call', server: 'auto-test-control', tool: 'case_execution_begin', arguments: { caseId: 'inspect-task' }, result: {}, status: 'completed' } } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'receipt-interaction', type: 'mcp_tool_call', server: 'playwright', tool: 'browser_click', arguments: {}, result: {}, status: 'completed' } } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'receipt-observation', type: 'mcp_tool_call', server: 'playwright', tool: 'browser_snapshot', arguments: {}, result: {}, status: 'completed' } } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'case-end', type: 'mcp_tool_call', server: 'auto-test-control', tool: 'case_execution_end', arguments: { caseId: 'inspect-task' }, result: {}, status: 'completed' } } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'message', type: 'agent_message', text: response } } as ThreadEvent
-      yield { type: 'turn.completed', usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } } as ThreadEvent
-    })(),
-  }
-}
-
-function streamedResponseWithoutCaseBookkeeping(response: string): { events: AsyncGenerator<ThreadEvent> } {
-  return {
-    events: (async function* () {
-      yield { type: 'thread.started', thread_id: 'thread-native-no-bookkeeping' } as ThreadEvent
-      yield { type: 'turn.started' } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'unattributed-interaction', type: 'mcp_tool_call', server: 'playwright', tool: 'browser_click', arguments: {}, result: {}, status: 'completed' } } as ThreadEvent
-      yield { type: 'item.completed', item: { id: 'unattributed-observation', type: 'mcp_tool_call', server: 'playwright', tool: 'browser_snapshot', arguments: {}, result: {}, status: 'completed' } } as ThreadEvent
+      if (includeCaseBookkeeping) {
+        yield { type: 'item.completed', item: { id: 'case-begin', type: 'mcp_tool_call', server: 'auto-test-control', tool: 'case_execution_begin', arguments: { caseId: 'inspect-task' }, result: {}, status: 'completed' } } as ThreadEvent
+      }
+      yield { type: 'item.completed', item: { id: interactionId, type: 'mcp_tool_call', server: 'playwright', tool: 'browser_click', arguments: {}, result: {}, status: 'completed' } } as ThreadEvent
+      yield { type: 'item.completed', item: { id: observationId, type: 'mcp_tool_call', server: 'playwright', tool: 'browser_snapshot', arguments: {}, result: {}, status: 'completed' } } as ThreadEvent
+      if (includeCaseBookkeeping) {
+        yield { type: 'item.completed', item: { id: 'case-end', type: 'mcp_tool_call', server: 'auto-test-control', tool: 'case_execution_end', arguments: { caseId: 'inspect-task' }, result: {}, status: 'completed' } } as ThreadEvent
+      }
       yield { type: 'item.completed', item: { id: 'message', type: 'agent_message', text: response } } as ThreadEvent
       yield { type: 'turn.completed', usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } } as ThreadEvent
     })(),
@@ -679,13 +677,13 @@ describe('Codex test agent runner', () => {
       startThread: () => ({
         id: 'thread-native-no-bookkeeping',
         runStreamed: async (_input, options) => options?.outputSchema
-          ? streamedResponseWithoutCaseBookkeeping(JSON.stringify(finalResult(workflow, {
+          ? streamedResponse(JSON.stringify(finalResult(workflow, {
               cases: [{
                 caseId: 'inspect-task', title: 'Inspect task', outcome: 'passed', summary: 'Observed without journal calls.',
                 evidence: [{ kind: 'observation', description: 'Case-specific live state was observed.' }],
               }],
-            })))
-          : streamedResponseWithoutCaseBookkeeping('Native execution complete.'),
+            })), { threadId: 'thread-native-no-bookkeeping', includeCaseBookkeeping: false })
+          : streamedResponse('Native execution complete.', { threadId: 'thread-native-no-bookkeeping', includeCaseBookkeeping: false }),
       }),
     })
 
@@ -943,6 +941,139 @@ describe('Codex test agent runner', () => {
     expect(resumed.result?.mutations).toContainEqual(expect.objectContaining({ id: 'pending-action', status: 'compensated' }))
     const evidence = JSON.parse(await readFile(evidencePath, 'utf8')) as Array<{ description: string }>
     expect(evidence.map((item) => item.description)).toContain('Evidence recorded before interruption.')
+  })
+
+  it('resumes a case-batch-size run that crashed before its execution mode was persisted', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-agent-resume-prep-crash-'))
+    directories.push(directory)
+    const sourceHome = resolve(directory, 'source-home')
+    await mkdir(sourceHome)
+    await writeFile(resolve(sourceHome, 'config.toml'), 'model = "fixture"\n', { mode: 0o600 })
+    const browserPath = resolve(directory, 'chromium')
+    await writeFile(browserPath, '')
+    const codexExecutable = await fakeCodexExecutable(directory)
+    const outputDirectory = resolve(directory, 'run')
+    const workflow = manifest('https://tasks.example.test')
+    const profile = { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: false, allowDestructive: false } }
+
+    // A missing codex executable makes the first run fail during preparation,
+    // before executionMode is ever persisted. State is left with executionMode undefined.
+    const crashed = await runCodexTestAgent({
+      outputDirectory,
+      manifest: workflow,
+      profile,
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false, codexHome: sourceHome,
+      codexExecutable: resolve(directory, 'missing-codex'),
+      caseBatchSize: 1,
+    }, { browserExecutablePath: browserPath })
+    expect(crashed.state.status).toBe('failed')
+    expect(crashed.state.executionMode).toBeUndefined()
+
+    // Resuming with the original --case-batch-size must not trip the
+    // "cannot switch to case-window mode" guard.
+    let startedThreads = 0
+    const resumed = await runCodexTestAgent({
+      outputDirectory,
+      manifest: workflow,
+      profile,
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false, codexHome: sourceHome, codexExecutable,
+      caseBatchSize: 1,
+      resume: true,
+    }, {
+      browserExecutablePath: browserPath,
+      startThread: () => {
+        const batchIndex = startedThreads++
+        const phase = workflow.phases[batchIndex]!
+        let turn = 0
+        return {
+          id: null,
+          runStreamed: async (_input, options) => {
+            turn++
+            if (options?.outputSchema) {
+              const scoped = { ...workflow, phases: [phase] }
+              return singleCaseExecutionResponse(JSON.stringify(finalResult(scoped, {
+                cases: [{
+                  caseId: phase.id,
+                  title: phase.title,
+                  outcome: 'passed',
+                  summary: `Observed ${phase.id}.`,
+                  evidence: [{ kind: 'observation', description: `Observed ${phase.id}.` }],
+                }],
+              })), phase.id, 'resume-prep')
+            }
+            return singleCaseExecutionResponse('Window work complete.', phase.id, 'resume-prep')
+          },
+        }
+      },
+    })
+
+    expect(startedThreads).toBe(1)
+    expect(resumed.state).toMatchObject({ status: 'completed', executionMode: 'case_windows', caseBatchSize: 1 })
+    expect(resumed.result?.outcome).toBe('passed')
+  })
+
+  it('recovers pending business writes on the native single-thread path before final delivery', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-agent-native-mutation-recovery-'))
+    directories.push(directory)
+    const sourceHome = resolve(directory, 'source-home')
+    await mkdir(sourceHome)
+    await writeFile(resolve(sourceHome, 'config.toml'), 'model = "fixture"\n', { mode: 0o600 })
+    const browserPath = resolve(directory, 'chromium')
+    await writeFile(browserPath, '')
+    const codexExecutable = await fakeCodexExecutable(directory)
+    const outputDirectory = resolve(directory, 'run')
+    const workflow = manifest('https://tasks.example.test', 'write')
+    const profile = { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } }
+    const ledgerPath = resolve(outputDirectory, '.agent-private', 'mutation-ledger.json')
+
+    let recoveryPrompt = ''
+    let nonSchemaTurn = 0
+    const run = await runCodexTestAgent({
+      outputDirectory,
+      manifest: workflow,
+      profile,
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false, codexHome: sourceHome, codexExecutable,
+      maxFinalizationTurns: 0,
+    }, {
+      browserExecutablePath: browserPath,
+      startThread: () => ({
+        id: 'thread-native-mutation',
+        runStreamed: async (input, options) => {
+          if (options?.outputSchema) {
+            return streamedResponse(JSON.stringify(finalResult(workflow, {
+              cases: [{
+                caseId: 'inspect-task', title: 'Inspect task', outcome: 'passed', summary: 'Observed after recovery.',
+                evidence: [{ kind: 'observation', description: 'Live state verified after write recovery.' }],
+              }],
+            })))
+          }
+          nonSchemaTurn += 1
+          if (nonSchemaTurn === 1) {
+            // Execution turn: leave a pending business write.
+            await writeFile(ledgerPath, JSON.stringify([{
+              id: 'pending-write', caseId: 'inspect-task', description: 'Created a test record', risk: 'write', status: 'pending',
+              createdAt: '2026-08-04T00:00:00.000Z', updatedAt: '2026-08-04T00:00:00.000Z', evidence: [],
+            }]))
+            return streamedResponse('Execution complete with a pending write.')
+          }
+          // Second non-schema turn is the recovery turn fired by the harness
+          // because the Mutation Ledger still has a pending entry.
+          recoveryPrompt = typeof input === 'string'
+            ? input
+            : input.filter((item) => item.type === 'text').map((item) => item.text).join('\n')
+          await writeFile(ledgerPath, JSON.stringify([{
+            id: 'pending-write', caseId: 'inspect-task', description: 'Created a test record', risk: 'write', status: 'compensated',
+            createdAt: '2026-08-04T00:00:00.000Z', updatedAt: '2026-08-04T00:01:00.000Z', evidence: ['Verified restored state'],
+          }]))
+          return streamedResponse('Recovery complete.')
+        },
+      }),
+    })
+
+    expect(recoveryPrompt).toContain('Resume the interrupted Auto-Test execution')
+    expect(run.state).toMatchObject({ status: 'completed', executionMode: 'single_thread' })
+    expect(run.result?.outcome).toBe('passed')
+    expect(run.result?.mutations).toContainEqual(expect.objectContaining({ id: 'pending-write', status: 'compensated' }))
   })
 
   it('lets the Codex CLI finish its own reconnect sequence', async () => {


### PR DESCRIPTION
## Summary

Fixes two defects introduced by `efcb8a5` ("refactor: keep Codex in one native test thread") on the default single-thread path, plus two minor cleanups surfaced by code review.

## Changes

**1. Resume guard false-positive** (`src/agent/runner.ts`)
A `--case-batch-size` run that crashed during workspace preparation left `executionMode` undefined (`initialCodexTestState` never sets it; state is persisted before prep completes). Resuming with the *original* `--case-batch-size` tripped the "cannot switch to case-window mode" guard and blocked a legitimate same-command resume. The guard now only blocks an explicit switch away from a `single_thread` run, not an unset mode.

**2. Lost mutation-recovery turn** (`src/agent/runner.ts`)
The single-thread path went straight from execution to finalization, so pending Mutation Ledger entries were only caught by `enforceMutationLedger` (forced `blocked`) with no recovery turn fed back to the agent. Ported the case-window path's pre-finalization recovery turn (`codexTestAgentResumePrompt`) so the agent can compensate writes before delivery — consistent with the case-window path and the thin-harness side-effect-recovery invariant.

**3. Cleanup** — moved `buildCodexCaseWindows` inside the `if (useCaseWindows)` branch (it was computed and discarded on every native run).

**4. Cleanup** — parameterized the `streamedResponse` test fixture to remove the duplicated `streamedResponseWithoutCaseBookkeeping` generator.

## Tests

- `resumes a case-batch-size run that crashed before its execution mode was persisted` — verifies the guard no longer blocks a same-command resume after a prep crash.
- `recovers pending business writes on the native single-thread path before final delivery` — verifies the recovery turn fires and the agent compensates before delivery.

## Verification

- `npm run check` (typecheck + vitest + build): **280 tests pass across 42 files**, typecheck clean, build clean.
- No CLI flags, execution semantics, result contracts, or docs changed; findings 3/4 from review (optional receipts, removed audit turn) are intentional philosophy choices and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)