### PR TITLE
fix: scope easy registration to user-supplied targets, not discovered origins

### DIFF
--- a/src/cli/easy.ts
+++ b/src/cli/easy.ts
@@ -8,16 +8,14 @@ import { chromium } from '@playwright/test'
 import crossSpawn from 'cross-spawn'
 import { runAgentTestCli } from './agent-test.js'
 import {
-  environmentProfileMatches,
   normalizeTargetUrls,
   registerEnvironment,
   riskForPolicy,
   safeProfileId,
   type EasyRiskLevel,
-  type EnvironmentProfileMatch,
 } from '../usability/environment-registration.js'
 import { friendlyRunSummary } from '../usability/result-summary.js'
-import { preflightEasyWorkflow } from '../usability/workflow-preflight.js'
+import { planEasyRegistration, preflightEasyWorkflow } from '../usability/workflow-preflight.js'
 import { defaultEnvironmentProfileRegistryPath, type EnvironmentProfile } from '../workflow/environment-profile.js'
 
 interface EasyRunOptions {
@@ -210,47 +208,36 @@ export async function runEasyWorkflow(options: EasyRunOptions): Promise<number> 
   const preflight = await preflightEasyWorkflow(filePath, suppliedUrls)
   const urls = preflight.targetUrls
   if (preflight.discoveredOrigins.length > 0) {
-    console.log(`从测试用例中发现还需要访问：${preflight.discoveredOrigins.join('、')}`)
+    console.log(
+      `从测试用例中发现还会访问：${preflight.discoveredOrigins.join('、')}（仅提示，不会要求为此注册登录）`,
+    )
   }
-  let profileId = options.profileId
-  const profileMatches = await environmentProfileMatches(urls)
-  if (profileId) {
-    const requested = profileMatches.find((match) => match.profile.id === profileId)
-    if (!requested) throw new Error(`未找到环境：${profileId}`)
-    if (requested.missingOrigins.length > 0) {
-      if (!input.isTTY) throw new Error(profileCoverageError(requested))
-      console.log(`环境“${profileId}”尚未覆盖：${requested.missingOrigins.join('、')}`)
-      console.log('现在进入环境更新向导；直接使用默认选项会保留已有登录状态和权限范围。')
-      profileId = await registerInteractive(urls, { existingProfile: requested.profile })
-    }
-  } else {
-    const profiles = profileMatches.filter((match) => match.missingOrigins.length === 0).map((match) => match.profile)
-    if (profiles.length === 1) profileId = profiles[0]!.id
-    else if (profiles.length > 1) {
-      console.log(`找到多个匹配环境：${profiles.map((profile) => profile.id).join('、')}`)
-      profileId = await ask('请输入本次使用的环境名称', profiles[0]!.id)
-    } else if (input.isTTY) {
-      const related = profileMatches
-        .filter((match) => match.coveredOrigins.length > 0)
-        .sort((left, right) =>
-          left.missingOrigins.length - right.missingOrigins.length || left.profile.id.localeCompare(right.profile.id),
-        )
-      let registrationDefaults: { profileId?: string; existingProfile?: EnvironmentProfile } = {}
-      if (related.length > 0) {
-        console.log('已有环境尚未覆盖测试用例需要的全部网站：')
-        for (const match of related) console.log(`  ${match.profile.id}：缺少 ${match.missingOrigins.join('、')}`)
-        const suggestedProfileId = related.length === 1
-          ? related[0]!.profile.id
-          : await ask('请输入要更新的环境名称', related[0]!.profile.id)
-        const existingProfile = related.find((match) => match.profile.id === suggestedProfileId)?.profile
-        registrationDefaults = existingProfile ? { existingProfile } : { profileId: suggestedProfileId }
-        console.log('现在进入环境更新向导；直接使用默认选项会保留已有登录状态和权限范围。')
-      } else {
-        console.log('这些网站尚未注册，先用向导完成一次环境注册。')
+  const plan = await planEasyRegistration({
+    suppliedUrls,
+    isTTY: input.isTTY,
+    ...(options.profileId ? { profileId: options.profileId } : {}),
+  })
+  let profileId: string | undefined
+  switch (plan.kind) {
+    case 'error':
+      throw new Error(plan.message)
+    case 'use':
+      profileId = plan.profileId
+      break
+    case 'choose':
+      console.log(`找到多个匹配环境：${plan.profiles.map((profile) => profile.id).join('、')}`)
+      profileId = await ask('请输入本次使用的环境名称', plan.profiles[0]!.id)
+      break
+    case 'register': {
+      console.log(plan.message)
+      let defaults = plan.defaults
+      if (plan.related && plan.related.length > 1) {
+        const suggestedProfileId = await ask('请输入要更新的环境名称', plan.related[0]!.profile.id)
+        const existingProfile = plan.related.find((match) => match.profile.id === suggestedProfileId)?.profile
+        defaults = existingProfile ? { existingProfile } : { profileId: suggestedProfileId }
       }
-      profileId = await registerInteractive(urls, registrationDefaults)
-    } else {
-      throw new Error(profileRegistrationError(profileMatches, urls))
+      profileId = await registerInteractive(plan.registrationUrls, defaults)
+      break
     }
   }
   const outputDirectory = resolve(options.outputDirectory ?? defaultRunDirectory(filePath))
@@ -298,17 +285,6 @@ export async function runEasyWorkflow(options: EasyRunOptions): Promise<number> 
     console.log(`运行诊断：${resolve(outputDirectory, options.legacyRuntime ? 'run-events.jsonl' : 'codex-agent.events.jsonl')}`)
   }
   return exitCode
-}
-
-function profileCoverageError(match: EnvironmentProfileMatch): string {
-  return `环境“${match.profile.id}”缺少网站：${match.missingOrigins.join('、')}`
-}
-
-function profileRegistrationError(matches: EnvironmentProfileMatch[], urls: string[]): string {
-  const related = matches.find((match) => match.coveredOrigins.length > 0)
-  if (related) return `${profileCoverageError(related)}。请先运行 npm run easy，选择“注册或更新测试环境”。`
-  const origins = [...new Set(urls.map((url) => new URL(url).origin))]
-  return `以下网站尚未注册：${origins.join('、')}。请先运行 npm run easy，选择“注册或更新测试环境”。`
 }
 
 async function runInteractive(): Promise<void> {

--- a/src/usability/workflow-preflight.ts
+++ b/src/usability/workflow-preflight.ts
@@ -1,5 +1,11 @@
+import { type EnvironmentProfile } from '../workflow/environment-profile.js'
 import { intakeWorkflowXlsx } from '../workflow/intake.js'
-import { normalizeTargetUrls, targetOrigins } from './environment-registration.js'
+import {
+  environmentProfileMatches,
+  normalizeTargetUrls,
+  targetOrigins,
+  type EnvironmentProfileMatch,
+} from './environment-registration.js'
 
 export interface EasyWorkflowPreflight {
   targetUrls: string[]
@@ -19,4 +25,94 @@ export async function preflightEasyWorkflow(
   const suppliedOrigins = new Set(targetOrigins(normalizedSuppliedUrls))
   const discoveredOrigins = targetOrigins(targetUrls).filter((origin) => !suppliedOrigins.has(origin))
   return { targetUrls, discoveredOrigins }
+}
+
+export interface EasyRegistrationDefaults {
+  profileId?: string
+  existingProfile?: EnvironmentProfile
+}
+
+export type EasyRegistrationPlan =
+  | { kind: 'use'; profileId: string }
+  | { kind: 'choose'; profiles: EnvironmentProfile[] }
+  | {
+      kind: 'register'
+      registrationUrls: string[]
+      defaults: EasyRegistrationDefaults
+      related?: EnvironmentProfileMatch[]
+      message: string
+    }
+  | { kind: 'error'; message: string }
+
+/**
+ * Decide how the easy workflow should obtain a registered environment.
+ *
+ * Registration and login are scoped to the URLs the user explicitly pasted
+ * (`suppliedUrls`). Origins merely discovered in the test-case workbook are
+ * surfaced by `preflightEasyWorkflow` as a notice and never expand the
+ * registration requirement, so an incidental link (e.g. a YouTube URL in test
+ * data) cannot block the run.
+ */
+export async function planEasyRegistration(params: {
+  suppliedUrls: string[]
+  profileId?: string
+  isTTY: boolean
+  registryPath?: string
+}): Promise<EasyRegistrationPlan> {
+  const registrationUrls = normalizeTargetUrls(params.suppliedUrls)
+  const profileMatches = await environmentProfileMatches(registrationUrls, params.registryPath)
+  if (params.profileId) {
+    const requested = profileMatches.find((match) => match.profile.id === params.profileId)
+    if (!requested) return { kind: 'error', message: `未找到环境：${params.profileId}` }
+    if (requested.missingOrigins.length === 0) return { kind: 'use', profileId: params.profileId }
+    if (!params.isTTY) return { kind: 'error', message: profileCoverageError(requested) }
+    return {
+      kind: 'register',
+      registrationUrls,
+      defaults: { existingProfile: requested.profile },
+      message: `环境“${params.profileId}”尚未覆盖：${requested.missingOrigins.join('、')}\n现在进入环境更新向导；直接使用默认选项会保留已有登录状态和权限范围。`,
+    }
+  }
+  const profiles = profileMatches
+    .filter((match) => match.missingOrigins.length === 0)
+    .map((match) => match.profile)
+  if (profiles.length === 1) return { kind: 'use', profileId: profiles[0]!.id }
+  if (profiles.length > 1) return { kind: 'choose', profiles }
+  if (params.isTTY) {
+    const related = profileMatches
+      .filter((match) => match.coveredOrigins.length > 0)
+      .sort((left, right) =>
+        left.missingOrigins.length - right.missingOrigins.length || left.profile.id.localeCompare(right.profile.id),
+      )
+    if (related.length > 0) {
+      return {
+        kind: 'register',
+        registrationUrls,
+        defaults: related.length === 1 ? { existingProfile: related[0]!.profile } : {},
+        related,
+        message:
+          '已有环境尚未覆盖测试用例需要的全部网站：\n' +
+          related.map((match) => `  ${match.profile.id}：缺少 ${match.missingOrigins.join('、')}`).join('\n') +
+          '\n现在进入环境更新向导；直接使用默认选项会保留已有登录状态和权限范围。',
+      }
+    }
+    return {
+      kind: 'register',
+      registrationUrls,
+      defaults: {},
+      message: '这些网站尚未注册，先用向导完成一次环境注册。',
+    }
+  }
+  return { kind: 'error', message: profileRegistrationError(profileMatches, registrationUrls) }
+}
+
+export function profileCoverageError(match: EnvironmentProfileMatch): string {
+  return `环境“${match.profile.id}”缺少网站：${match.missingOrigins.join('、')}`
+}
+
+export function profileRegistrationError(matches: EnvironmentProfileMatch[], urls: string[]): string {
+  const related = matches.find((match) => match.coveredOrigins.length > 0)
+  if (related) return `${profileCoverageError(related)}。请先运行 npm run easy，选择“注册或更新测试环境”。`
+  const origins = [...new Set(urls.map((url) => new URL(url).origin))]
+  return `以下网站尚未注册：${origins.join('、')}。请先运行 npm run easy，选择“注册或更新测试环境”。`
 }

--- a/tests/easy-workflow-preflight.test.ts
+++ b/tests/easy-workflow-preflight.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { utils, write } from '@e965/xlsx'
 import { afterEach, describe, expect, it } from 'vitest'
-import { preflightEasyWorkflow } from '../src/usability/workflow-preflight.js'
+import { policyForRisk, upsertEnvironmentProfile } from '../src/usability/environment-registration.js'
+import { planEasyRegistration, preflightEasyWorkflow } from '../src/usability/workflow-preflight.js'
 
 const temporaryDirectories: string[] = []
 
@@ -35,5 +36,108 @@ describe('easy workflow preflight', () => {
       'https://h5.example.test/login',
     ])
     expect(result.discoveredOrigins).toEqual(['https://h5.example.test'])
+  })
+})
+
+describe('easy registration plan', () => {
+  it('does not require registration for origins merely discovered in the workbook', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-reg-scope-'))
+    temporaryDirectories.push(directory)
+    const filePath = resolve(directory, 'cases.xlsx')
+    const workbook = utils.book_new()
+    utils.book_append_sheet(
+      workbook,
+      utils.aoa_to_sheet([
+        ['步骤', '说明'],
+        ['登录后台', '打开 https://lta.example.test/ 并登录'],
+        ['参考教程', '见 https://www.youtube.com/watch?v=example'],
+      ]),
+      'Flow',
+    )
+    await writeFile(filePath, write(workbook, { type: 'buffer', bookType: 'xlsx' }))
+
+    const suppliedUrls = ['https://lta.example.test/']
+    const preflight = await preflightEasyWorkflow(filePath, suppliedUrls)
+    // preflight still surfaces the incidental YouTube origin as a notice
+    expect(preflight.discoveredOrigins).toContain('https://www.youtube.com')
+
+    const registryPath = resolve(directory, 'environment-profiles.json')
+    await upsertEnvironmentProfile(
+      {
+        id: 'lta-staging',
+        origins: ['https://lta.example.test'],
+        auth: [],
+        policy: policyForRisk('read'),
+      },
+      registryPath,
+    )
+
+    // The supplied target is covered; the discovered YouTube origin must NOT force registration.
+    const plan = await planEasyRegistration({ suppliedUrls, isTTY: true, registryPath })
+    expect(plan).toMatchObject({ kind: 'use', profileId: 'lta-staging' })
+  })
+
+  it('requests registration when no profile covers the supplied target (TTY)', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-reg-new-'))
+    temporaryDirectories.push(directory)
+    const registryPath = resolve(directory, 'environment-profiles.json')
+    const plan = await planEasyRegistration({
+      suppliedUrls: ['https://fresh.example.test/'],
+      isTTY: true,
+      registryPath,
+    })
+    expect(plan.kind).toBe('register')
+    if (plan.kind === 'register') {
+      expect(plan.registrationUrls).toEqual(['https://fresh.example.test/'])
+      expect(plan.defaults).toEqual({})
+    }
+  })
+
+  it('errors when no profile covers the supplied target and there is no TTY', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-reg-notty-'))
+    temporaryDirectories.push(directory)
+    const registryPath = resolve(directory, 'environment-profiles.json')
+    const plan = await planEasyRegistration({
+      suppliedUrls: ['https://fresh.example.test/'],
+      isTTY: false,
+      registryPath,
+    })
+    expect(plan.kind).toBe('error')
+    if (plan.kind === 'error') expect(plan.message).toContain('尚未注册')
+  })
+
+  it('uses an explicitly requested profile when it covers the supplied target', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-reg-explicit-'))
+    temporaryDirectories.push(directory)
+    const registryPath = resolve(directory, 'environment-profiles.json')
+    await upsertEnvironmentProfile(
+      {
+        id: 'lta-staging',
+        origins: ['https://lta.example.test'],
+        auth: [],
+        policy: policyForRisk('read'),
+      },
+      registryPath,
+    )
+    const plan = await planEasyRegistration({
+      suppliedUrls: ['https://lta.example.test/'],
+      profileId: 'lta-staging',
+      isTTY: true,
+      registryPath,
+    })
+    expect(plan).toMatchObject({ kind: 'use', profileId: 'lta-staging' })
+  })
+
+  it('errors when an explicitly requested profile is missing', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-reg-missing-'))
+    temporaryDirectories.push(directory)
+    const registryPath = resolve(directory, 'environment-profiles.json')
+    const plan = await planEasyRegistration({
+      suppliedUrls: ['https://lta.example.test/'],
+      profileId: 'does-not-exist',
+      isTTY: true,
+      registryPath,
+    })
+    expect(plan.kind).toBe('error')
   })
 })


### PR DESCRIPTION
## 问题
`npm run easy` 的 preflight 会从测试用例 Excel 每个单元格里提取所有 URL(含 youtube 等外部链接)并入 `targetUrls`。原先注册向导以 `targetUrls` 为注册/登录范围,导致用户被迫为这些无关站点也登录并"到达目标页面",youtube 无法满足于是阻塞运行(`操作失败：以下网站尚未返回目标页面：https://www.youtube.com`)。

## 修复
注册/登录范围限定为用户显式粘贴的 `suppliedUrls`;`discoveredOrigins` 仅作提示打印,不进入 `environmentProfileMatches` / `registerInteractive`,不阻塞。测试运行仍用完整 `urls`(`scopeEnvironmentProfile` 是非阻塞过滤,不受影响)。

## 变更
- 抽出 `planEasyRegistration`(决策逻辑移至 `workflow-preflight.ts`,非 CLI 模块可单测);`easy.ts` 改为按 plan 分派 `use`/`choose`/`register`/`error`,并移除原内联决策与重复的 error helper。
- `discoveredOrigins` 提示语改为"发现还会访问:…(仅提示,不会要求为此注册登录)"。

## 验证
- 新增 5 个单测:含 youtube 链接 + profile 只覆盖 supplied target 时断言 `kind=use`(不触发注册);无覆盖 TTY->`register`;无覆盖非 TTY->`error`;显式 `profileId` 命中->`use`、未命中->`error`。
- `npm run check`(typecheck + 285 项 vitest + build)通过;`git diff --check` 通过。