### PR TITLE
fix: warn instead of blocking when a model profile env key is unset

### DIFF
--- a/src/cli/agent-test.ts
+++ b/src/cli/agent-test.ts
@@ -471,7 +471,7 @@ export async function runAgentTestCli(options: AgentTestCliOptions): Promise<num
     if (selection) {
       const apiKey = process.env[selection.profile.envKey]
       if (apiKey === undefined) {
-        throw new Error(`模型 Profile“${selection.profile.id}”需要环境变量 ${selection.profile.envKey}，但当前未设置。`)
+        printProgress(`警告：模型 Profile“${selection.profile.id}”的环境变量 ${selection.profile.envKey} 未设置；若该供应商需要密钥，运行将在首次模型调用时被阻断。`)
       }
       modelProfile = selection.profile
       printProgress(`使用模型 Profile“${selection.profile.id}”（${selection.profile.model}）`)


### PR DESCRIPTION
## Summary

Downgrades the model-profile env-key guard from a hard `throw` to a warning.

## Problem

The multi-provider PR (#24) added a guard that throws when the selected model profile's `envKey` env var is not set. This breaks **keyless local-proxy providers** (e.g. a `cliproxyapi` on `127.0.0.1` whose `env_key` is declared in config but never set in the environment) when registered as a model profile — selecting the default would block the run even though the proxy doesn't need a key.

## Fix

Warn and proceed. Providers that genuinely require a key still fail with a clear `infrastructure` block at first model call (already classified by `isOperationalBlock`).

## Verification

- `npm run check`: typecheck clean, 307 tests pass, build clean.
- No behavior change for providers with a set key; keyless local proxies now run instead of blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)