### PR TITLE
fix: include generated result headers in workbook range

### DIFF
--- a/src/agent/result-workbook.ts
+++ b/src/agent/result-workbook.ts
@@ -322,14 +322,17 @@ function setCellsInRow(xml: string, rowNumber: number, cells: string[], referenc
   return `${xml.slice(0, bounds.contentStart)}${retained}${cells.join('')}${xml.slice(bounds.end)}`
 }
 
-function updateDimension(xml: string, finalColumn: number, finalRow: number): string {
+function updateDimension(xml: string, finalColumn: number, firstRow: number, finalRow: number): string {
   const match = /<dimension\b[^>]*\bref=(["'])(.*?)\1[^>]*\/?\s*>/.exec(xml)
   if (!match) return xml
   const references = match[2]!.split(':')
-  const first = references[0]!.replace(/\$/g, '')
+  const currentFirst = references[0]!.replace(/\$/g, '')
   const currentLast = references.at(-1)!.replace(/\$/g, '')
+  const currentFirstColumn = columnIndex(currentFirst) ?? 0
+  const currentFirstRow = Number(/\d+$/.exec(currentFirst)?.[0] ?? firstRow)
   const currentColumn = columnIndex(currentLast) ?? finalColumn
   const currentRow = Number(/\d+$/.exec(currentLast)?.[0] ?? finalRow)
+  const first = `${utils.encode_col(currentFirstColumn)}${Math.min(currentFirstRow, firstRow)}`
   const last = `${utils.encode_col(Math.max(currentColumn, finalColumn))}${Math.max(currentRow, finalRow)}`
   return `${xml.slice(0, match.index)}${match[0]!.replace(match[2]!, `${first}:${last}`)}${xml.slice(match.index! + match[0]!.length)}`
 }
@@ -400,7 +403,7 @@ function patchWorksheet(xml: string, manifest: WorkflowIntakeManifest, result: C
     const references = columns.map((column) => `${utils.encode_col(column)}${phase.sourceRow}`)
     patched = setCellsInRow(patched, phase.sourceRow, output.map((value, index) => encodeInlineCell(references[index]!, value)), references)
   }
-  return updateDimension(patched, Math.max(...columns), Math.max(...sourceRows, headerRow))
+  return updateDimension(patched, Math.max(...columns), Math.min(...sourceRows, headerRow), Math.max(...sourceRows, headerRow))
 }
 
 export async function writeResultWorkbook(options: {

--- a/tests/result-workbook.test.ts
+++ b/tests/result-workbook.test.ts
@@ -72,6 +72,22 @@ async function sourceWorkbook(directory: string): Promise<{ path: string; conten
   return { path, content }
 }
 
+async function offsetSourceWorkbook(directory: string): Promise<{ path: string; content: Buffer }> {
+  const workbook = utils.book_new()
+  const sheet = {
+    B2: { t: 's', v: 'same-id' },
+    C2: { t: 's', v: 'First duplicate' },
+    B3: { t: 's', v: 'same-id' },
+    C3: { t: 's', v: 'Second duplicate' },
+    '!ref': 'B2:C3',
+  }
+  utils.book_append_sheet(workbook, sheet, 'Cases')
+  const content = Buffer.from(write(workbook, { type: 'buffer', bookType: 'xlsx' }))
+  const path = resolve(directory, 'offset-cases.xlsx')
+  await writeFile(path, content)
+  return { path, content }
+}
+
 function digest(content: Buffer): string {
   return createHash('sha256').update(content).digest('hex')
 }
@@ -110,5 +126,26 @@ describe('result workbook writeback', () => {
     expect(sheet.C2?.f).toBe('1+1')
     expect(sheet['!merges']).toContainEqual(utils.decode_range('A4:B4'))
     expect(workbook.Sheets.Auxiliary?.A2?.v).toBe('完全不改写')
+  })
+
+  it('extends the worksheet dimension when it inserts a header above the original range', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-result-workbook-offset-'))
+    directories.push(directory)
+    const source = await offsetSourceWorkbook(directory)
+
+    const artifact = await writeResultWorkbook({
+      sourceFilePath: source.path,
+      outputDirectory: directory,
+      manifest: manifest(),
+      result: result('passed'),
+    })
+
+    const output = await readFile(artifact.path)
+    const workbook = read(output, { type: 'buffer', cellText: true })
+    const sheet = workbook.Sheets.Cases!
+    expect(sheet['!ref']).toBe('B1:I3')
+    expect(sheet.D1?.v).toBe('Auto-Test 状态')
+    expect(sheet.D2?.v).toBe('通过')
+    expect(sheet.D3?.v).toBe('通过')
   })
 })


### PR DESCRIPTION
## Summary
- expand result workbook worksheet dimensions upward when Auto-Test inserts a header row before the source range
- add a synthetic offset-range fixture covering source data beginning at `B2`

## Verification
- `npm run check`
- `git diff --check`

This fixes a generic OOXML delivery issue observed during the Windows DeepSeek canary. It does not change business execution or any domain-specific behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复源工作表从非首行、非首列开始时，写入结果后工作表范围计算不完整的问题。
  - 现在结果区域会正确覆盖表头及所有结果行，并保留原有起始位置。
  - 确保新增状态表头和各行状态值均能在正确的工作表范围内显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->