### PR TITLE
fix: rotate incompatible agent sessions on resume

### DIFF
--- a/docs/autonomous-workflow.md
+++ b/docs/autonomous-workflow.md
@@ -57,15 +57,17 @@ Runner 不实现第二个 Planner、Locator 解释器、字段组合引擎或业
 
 ## 恢复契约
 
-`codex-agent.state.json` 使用 `version: "2.0"`，保存 `completedCaseIds`、`threadGeneration`、`activeEpoch`、`checkpointPath` 和最近一次 `turn.completed.usage`。旧版 `single_thread/case_windows`、`activeBatch`、`completedBatchIds` 和 `case-batches` 状态不再兼容；恢复旧状态会 fail closed，要求新建 Run。
+`codex-agent.state.json` 使用 `version: "2.0"`，保存 `completedCaseIds`、`threadGeneration`、`activeEpoch`、`checkpointPath`、无密钥的 `sessionBindingFingerprint` 和最近一次 `turn.completed.usage`。旧版 `single_thread/case_windows`、`activeBatch`、`completedBatchIds` 和 `case-batches` 状态不再兼容；恢复旧状态会 fail closed，要求新建 Run。
 
 恢复流程：
 
 1. 校验原始 workflow ID、source SHA、Environment Profile 和 Mutation Ledger；
 2. 读取逐 case store，将已完成 case 从待执行集合移除；
-3. active epoch 有 thread ID 时恢复该 thread，否则从最近 checkpoint 启动下一代 thread；
+3. active epoch 有 thread ID 且 AgentHost/Provider/模型绑定指纹未变化时恢复该 thread，否则保留逻辑 Run 并启动下一代 thread；
 4. 仍有 pending Mutation 时，选定 AgentHost 先重新观察真实业务状态，禁止盲目重放写入；
 5. 读取所有逐 case 记录，按 Manifest 不可变顺序聚合最终结果。
+
+早期 v2 状态可能没有绑定指纹。此时 Runner 先尝试恢复旧物理 session；若宿主明确返回 `session_incompatible`，Runner 最多轮换一次物理 thread，并先发送标准 resume prompt 重建上下文和核对 Ledger，再继续原 active epoch。普通业务错误、页面操作错误或未分类 Agent 错误不会触发该轮换；新 thread 仍不兼容时按基础设施阻断结束，禁止无限重启。
 
 如果最终 JSON 响应在传输中断，但 epoch recovery artifact 已存在，Runner 只在确定性校验通过后采用它。Runner 不从日志、标题或页面残片补造 case 结果。
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -106,7 +106,7 @@ OMP 使用 `omp --mode rpc` 启动持久 JSONL 会话。Auto-Test 会在 run 工
 
 主要文件：
 
-- `codex-agent.state.json`：Run 状态、线程代数、完成 case、active epoch、checkpoint 和最近一次 turn usage；
+- `codex-agent.state.json`：Run 状态、线程代数、完成 case、active epoch、无密钥的 AgentHost/模型绑定指纹、checkpoint 和最近一次 turn usage；
 - `codex-agent.result.json`：完整 `passed`、`product_failed` 或 `blocked` 结果；
 - `.agent-private/case-results/`：逐 case 事实源，每个 case 一个幂等 JSON 记录；
 - `.agent-private/execution-epochs/`：每个 epoch 的有界结构化结果；
@@ -127,7 +127,7 @@ npm run easy -- run \
   --resume
 ```
 
-恢复会校验 workflow/source 身份和 Ledger。已写入逐 case store 的 case 不会重跑；active epoch 会恢复原 thread，容量轮换后的新 epoch 会从 checkpoint 和原工作区继续。旧版 `version: 1.0` 状态、`activeBatch`、`completedBatchIds` 等状态不再兼容，恢复会 fail closed 并要求新建 Run。
+恢复会校验 workflow/source 身份和 Ledger。已写入逐 case store 的 case 不会重跑；active epoch 通常恢复原 thread，容量轮换后的新 epoch 会从 checkpoint 和原工作区继续。若基础设施恢复需要切换模型 Profile，逻辑 Run、active epoch、工作区和 Ledger 保持不变，但与新 AgentHost/Provider/模型绑定不兼容的物理 session 会被下一代 thread 替换；新 thread 必须先执行 resume 协议并核对 pending Mutation。早期 v2 状态没有绑定指纹时，Runner 只在宿主明确报告 session 不兼容后轮换一次；普通执行错误不会触发轮换。旧版 `version: 1.0` 状态、`activeBatch`、`completedBatchIds` 等状态不再兼容，恢复会 fail closed 并要求新建 Run。
 
 需要比较两个宿主时，先用同一输入包执行两个独立 Run，再执行 `npm run agent:compare -- --run <codex-run> --run <omp-run>`。比较器只读取结构化结果、证据和 Ledger，不启动新的 Agent，也不重复业务写入。两个 Run 必须同时提供 immutable `test-manifest.json`、一致的 `workflowId`/`sourceSha256`、Excel 与同名 sidecar/image 的 `input-bundle.json`、Manifest hash、Environment selection hash、平台、架构、Auto-Test 包版本、commit 和 `agent-host-selection.json`。缺少或不一致的任一合同输入时，比较器会 fail closed，结果为 `invalid`，不会继续给出宿主等价性结论。
 

--- a/docs/windows-acceptance-runbook.md
+++ b/docs/windows-acceptance-runbook.md
@@ -153,7 +153,9 @@ Get-ChildItem "$Run\*-Auto-Test-结果.xlsx" | Select-Object FullName
   --headed
 ```
 
-恢复会继续使用原始材料副本、Agent 工作区文件、证据和 Mutation Ledger，并先重新观察 active epoch 未完成业务写入的真实状态。若浏览器执行已结束、但最终 JSON 响应在传输中断，框架只能在对应 epoch artifact 或全量 `agent-workspace\case-results.json` 通过身份、case 覆盖、证据路径和 Ledger 终态校验后采用结果，不能从日志或页面猜测。Excel、URL、Profile 和风险策略必须保持不变；旧版 v1 状态不支持恢复。不要删除原输出目录或 Ledger，不要改用新输出目录盲目重跑，也不要手工把 `blocked` 改成 `passed`。
+恢复会继续使用原始材料副本、Agent 工作区文件、证据和 Mutation Ledger，并先重新观察 active epoch 未完成业务写入的真实状态。若浏览器执行已结束、但最终 JSON 响应在传输中断，框架只能在对应 epoch artifact 或全量 `agent-workspace\case-results.json` 通过身份、case 覆盖、证据路径和 Ledger 终态校验后采用结果，不能从日志或页面猜测。Excel、URL、Environment Profile 和风险策略必须保持不变；模型 Profile 可以在额度、容量或 Provider 故障后显式切换。旧版 v1 状态不支持恢复。不要删除原输出目录或 Ledger，不要改用新输出目录盲目重跑，也不要手工把 `blocked` 改成 `passed`。
+
+模型 Profile 变化时，`codex-agent.state.json` 中的无密钥绑定指纹用于判断旧物理 session 是否还能恢复。绑定不同时，Runner 保留同一个逻辑 Run、active epoch、工作区和 Ledger，启动下一代 thread，并在继续执行前发送 resume prompt 核对 pending Mutation。早期 v2 状态没有指纹时，仅在宿主明确返回 session 不兼容后执行一次轮换；普通业务或代理执行错误不得触发轮换，第二次不兼容必须以基础设施阻断结束。
 
 `product_failed` 表示已确认产品结果不符合预期，应修复产品或调整测试数据后重新验收；它不是基础设施恢复入口。即使本轮还有其他用例 `blocked`，终端摘要仍会保留已确认产品差异，并按输入材料、环境/权限/测试数据、基础设施和 AgentHost 执行交付分别显示阻断数量与首个直接原因。
 

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -225,7 +225,9 @@ OMP 与 Codex 使用同一个 Auto-Test Model Profile 选择层；真正的请�
   --headed
 ```
 
-恢复继续使用同一个逻辑 Run 和 Mutation Ledger。框架会先校验已有交付；如果输入身份、证据、环境需求和 Ledger 全部完整且没有 pending Mutation，就直接生成正式结果。否则恢复 active epoch 的 thread，或从 checkpoint 启动下一代 thread；已经写入逐 case store 的 case 不会重跑。Excel、URL、Profile、风险策略和原有 origin 必须保持不变；旧版 v1 状态不支持恢复，其他环境替换或权限收窄都会拒绝恢复。
+恢复继续使用同一个逻辑 Run 和 Mutation Ledger。框架会先校验已有交付；如果输入身份、证据、环境需求和 Ledger 全部完整且没有 pending Mutation，就直接生成正式结果。否则恢复 active epoch 的 thread，或从 checkpoint 启动下一代 thread；已经写入逐 case store 的 case 不会重跑。若原模型额度或 Provider 不可用，可以在同一命令中显式选择另一个可用模型 Profile。Runner 会保留原 active epoch、工作区和 Ledger；当已保存的物理 session 与新 AgentHost/Provider/模型绑定不兼容时，只启动一代新 thread，先执行 resume 协议并核对 pending Mutation，再继续原 epoch。普通页面或 Agent 执行错误不会触发 thread 轮换，替换后的 session 仍不兼容也不会无限重试。
+
+Excel、URL、Environment Profile、风险策略和原有 origin 必须保持不变；这里的 Environment Profile 不等于可为基础设施恢复而切换的模型 Profile。旧版 v1 状态不支持恢复，其他业务环境替换或权限收窄都会拒绝恢复。
 
 只有排查旧链路兼容性时才使用：
 

--- a/src/agent/codex-host.ts
+++ b/src/agent/codex-host.ts
@@ -11,7 +11,7 @@ import type {
   AgentInputPart,
   AgentHostStream,
 } from './host.js'
-import { AgentHostError, normalizeAgentEvent } from './host.js'
+import { AgentHostError, isAgentSessionIncompatibleMessage, normalizeAgentEvent } from './host.js'
 import { resolveCodexExecutable } from './codex-executable.js'
 import { CodexModelProviderAdapter } from './codex-provider.js'
 import { controlServerPath, packageFilePath } from './runtime-paths.js'
@@ -65,6 +65,14 @@ function toCodexInput(input: AgentInputPart[]): Input {
   return input.map((part) => part.type === 'text'
     ? { type: 'text', text: part.text }
     : { type: 'local_image', path: part.path }) as Input
+}
+
+function rethrowCodexSessionError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error)
+  if (isAgentSessionIncompatibleMessage(message)) {
+    throw new AgentHostError('codex', message, 'session_incompatible')
+  }
+  throw error
 }
 
 function restrictedPlaywrightTools(fullAgentAccess: boolean): string[] | undefined {
@@ -190,10 +198,19 @@ class CodexSession implements AgentHostSession {
   }
 
   async run(input: AgentInputPart[], options?: { outputSchema?: unknown }): Promise<AgentHostStream> {
-    const stream = await this.thread.runStreamed(toCodexInput(input), options)
+    let stream: Awaited<ReturnType<CodexThreadLike['runStreamed']>>
+    try {
+      stream = await this.thread.runStreamed(toCodexInput(input), options)
+    } catch (error) {
+      rethrowCodexSessionError(error)
+    }
     return {
       events: (async function* (): AsyncGenerator<AgentEvent> {
-        for await (const event of stream.events) yield normalizeAgentEvent(event)
+        try {
+          for await (const event of stream.events) yield normalizeAgentEvent(event)
+        } catch (error) {
+          rethrowCodexSessionError(error)
+        }
       })(),
     }
   }

--- a/src/agent/host.ts
+++ b/src/agent/host.ts
@@ -64,6 +64,7 @@ export type AgentEventType =
   | 'turn_started'
   | 'turn_completed'
   | 'turn_failed'
+  | 'session_incompatible'
   | 'error'
   | 'agent_message'
   | 'tool_started'
@@ -203,6 +204,7 @@ export type AgentHostErrorKind =
   | 'transport'
   | 'process'
   | 'quota'
+  | 'session_incompatible'
   | 'capability'
   | 'configuration'
   | 'protocol'
@@ -249,9 +251,28 @@ const advisoryHostMessagePatterns = [
   /^Heads up: Long threads and multiple compactions can cause the model to be less accurate\./i,
 ]
 
+const incompatibleSessionMessagePatterns = [
+  /^This (?:session|thread) was (?:recorded|created|started) with (?:model|provider) .+ but is resuming with .+[.]?$/i,
+  /\bCannot resume (?:session|thread)\b.*\b(?:different|incompatible)\b.*\b(?:model|provider)\b/i,
+  /\b(?:session|thread)\b.*\b(?:model|provider)\b.*\b(?:mismatch|incompatible)\b/i,
+]
+
 /** These Codex advisories do not stop the following turn from running. */
 function isAdvisoryHostMessage(message: string): boolean {
   return advisoryHostMessagePatterns.some((pattern) => pattern.test(message))
+}
+
+/** Host adapters use this only for physical-session compatibility failures. */
+export function isAgentSessionIncompatibleMessage(message: string): boolean {
+  return incompatibleSessionMessagePatterns.some((pattern) => pattern.test(message))
+}
+
+function normalizedFailureEvent(message: string, raw: unknown, id?: string): AgentEvent {
+  if (isAdvisoryHostMessage(message)) return eventWithRaw({ type: 'other', ...(id ? { id } : {}), message }, raw)
+  if (isAgentSessionIncompatibleMessage(message)) {
+    return eventWithRaw({ type: 'session_incompatible', ...(id ? { id } : {}), message }, raw)
+  }
+  return eventWithRaw({ type: 'error', ...(id ? { id } : {}), message }, raw)
 }
 
 function normalizeItemEvent(raw: Record<string, unknown>, item: Record<string, unknown>): AgentEvent {
@@ -297,9 +318,7 @@ function normalizeItemEvent(raw: Record<string, unknown>, item: Record<string, u
   if (itemType === 'agent_message') return eventWithRaw({ type: 'agent_message', id: itemId, text: stringValue(item.text) ?? '' }, raw)
   if (itemType === 'error') {
     const message = stringValue(item.message) ?? 'agent item failed'
-    return isAdvisoryHostMessage(message)
-      ? eventWithRaw({ type: 'other', id: itemId, message }, raw)
-      : eventWithRaw({ type: 'error', id: itemId, message }, raw)
+    return normalizedFailureEvent(message, raw, itemId)
   }
   return eventWithRaw({ type: 'other', id: itemId }, raw)
 }
@@ -382,7 +401,7 @@ export function normalizeAgentEvent(value: unknown): AgentEvent {
   if (!recordValue(value)) return { type: 'error', message: 'Agent host emitted a non-object event', raw: value }
   const raw = value as Record<string, unknown>
   if (isAgentEvent(raw) && [
-    'thread_started', 'turn_started', 'turn_completed', 'turn_failed', 'agent_message',
+    'thread_started', 'turn_started', 'turn_completed', 'turn_failed', 'session_incompatible', 'agent_message',
     'tool_started', 'tool_completed', 'command_started', 'command_completed', 'file_change_started',
     'file_change_completed', 'reasoning_started', 'todo_started', 'other',
   ].includes(raw.type)) return raw as AgentEvent
@@ -392,13 +411,14 @@ export function normalizeAgentEvent(value: unknown): AgentEvent {
   if (raw.type === 'turn.completed') return eventWithRaw({ type: 'turn_completed', usage: usageFrom(raw.usage) }, raw)
   if (raw.type === 'turn.failed') {
     const error = recordValue(raw.error)
-    return eventWithRaw({ type: 'turn_failed', message: stringValue(error?.message) ?? stringValue(raw.message) ?? 'agent turn failed' }, raw)
+    const message = stringValue(error?.message) ?? stringValue(raw.message) ?? 'agent turn failed'
+    return isAgentSessionIncompatibleMessage(message)
+      ? eventWithRaw({ type: 'session_incompatible', message }, raw)
+      : eventWithRaw({ type: 'turn_failed', message }, raw)
   }
   if (raw.type === 'error' || raw.type === 'extension_error') {
     const message = stringValue(raw.message) ?? stringValue(raw.error) ?? 'agent host error'
-    return isAdvisoryHostMessage(message)
-      ? eventWithRaw({ type: 'other', message }, raw)
-      : eventWithRaw({ type: 'error', message }, raw)
+    return normalizedFailureEvent(message, raw)
   }
   if (raw.type === 'notice') {
     return eventWithRaw({ type: 'other', message: stringValue(raw.message) }, raw)
@@ -483,6 +503,6 @@ export class AgentHostError extends Error {
     this.name = 'AgentHostError'
     this.hostId = hostId
     this.kind = kind
-    this.retryable = kind === 'transport' || kind === 'process' || kind === 'quota'
+    this.retryable = kind === 'transport' || kind === 'process' || kind === 'quota' || kind === 'session_incompatible'
   }
 }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1,4 +1,5 @@
 import { chromium } from '@playwright/test'
+import { createHash } from 'node:crypto'
 import { access, chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, dirname, resolve } from 'node:path'
 import type { EnvironmentProfile } from '../workflow/environment-profile.js'
@@ -96,6 +97,7 @@ function isNonFatalAgentHostError(message: string): boolean {
 
 async function runTurn(
   thread: AgentHostSession,
+  hostId: AgentHostId,
   input: AgentInputPart[],
   eventsPath: string,
   secrets: string[],
@@ -116,6 +118,9 @@ async function runTurn(
       if (event.type === 'thread_started' && event.threadId) await onThreadStarted?.(event.threadId)
       if (event.type === 'agent_message') finalResponse = event.text ?? ''
       if (event.type === 'turn_failed') throw new Error(event.message ?? 'agent turn failed')
+      if (event.type === 'session_incompatible') {
+        throw new AgentHostError(hostId, event.message ?? 'AgentHost session is incompatible with the current model binding', 'session_incompatible')
+      }
       if (event.type === 'error' && !isNonFatalAgentHostError(event.message ?? '')) throw new Error(event.message ?? 'agent host error')
     }
     if (!finalResponse) throw new Error('Agent host returned no final response')
@@ -525,6 +530,20 @@ function hostInput(
   }]
 }
 
+function sessionBindingFingerprint(host: AgentHost, runtime: AgentHostRuntime): string {
+  const binding = runtime.provider
+    ? {
+        profileId: runtime.provider.profileId,
+        providerId: runtime.provider.providerId,
+        baseUrl: runtime.provider.baseUrl,
+        api: runtime.provider.api,
+        model: runtime.provider.model,
+        modelSelector: runtime.provider.modelSelector,
+      }
+    : { model: runtime.model ?? null }
+  return createHash('sha256').update(JSON.stringify({ hostId: host.id, binding })).digest('hex')
+}
+
 export async function runAgentTest(
   options: AgentTestOptions,
   dependencies: AgentTestDependencies = {},
@@ -790,6 +809,7 @@ export async function runAgentTest(
     })
     await writePrivateJson(statePath, state)
 
+    const currentSessionBindingFingerprint = sessionBindingFingerprint(host, runtime)
     let thread: AgentHostSession | undefined
     let threadId = state.threadId ?? resumeThreadId
     for (const epoch of epochs) {
@@ -803,7 +823,16 @@ export async function runAgentTest(
       await activateExecutionEpoch(workspace, epoch)
       const resumingEpoch = options.resume && state.activeEpoch?.id === epoch.id
       const initialEpochStage = resumingEpoch ? state.activeEpoch!.stage : 'executing'
-      const epochThreadId = resumingEpoch ? state.activeEpoch?.threadId ?? threadId : undefined
+      const storedEpochThreadId = resumingEpoch ? state.activeEpoch?.threadId ?? threadId : undefined
+      const bindingChanged = Boolean(
+        storedEpochThreadId &&
+        state.sessionBindingFingerprint &&
+        state.sessionBindingFingerprint !== currentSessionBindingFingerprint,
+      )
+      const epochThreadId = bindingChanged ? undefined : storedEpochThreadId
+      if (bindingChanged) {
+        progress.report('warning', '当前 Provider/模型绑定与已保存的物理 AgentHost session 不同，正在保留原 Run 并启动新的恢复线程')
+      }
       if (epochThreadId && !host.capabilities.sessionResume) {
         throw new Error(`${host.displayName} 不支持恢复既有会话；为避免重复业务写入，本次 Run 已安全阻断`)
       }
@@ -811,7 +840,7 @@ export async function runAgentTest(
         ? await host.resume({ ...threadOptions, resumeId: epochThreadId })
         : await host.start(threadOptions)
       activeThread = thread
-      threadId = epochThreadId ?? thread.id ?? threadId
+      threadId = epochThreadId ?? thread.id ?? undefined
       const { threadId: _previousThreadId, ...stateWithoutPreviousThread } = state
       const epochUsage: CodexTurnUsage = { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 }
       const persistThreadId = async (id: string): Promise<void> => {
@@ -825,7 +854,10 @@ export async function runAgentTest(
       const stateForEpoch = epochThreadId ? state : stateWithoutPreviousThread
       state = updateCodexTestState(stateForEpoch, {
         stage: 'executing',
-        ...(!epochThreadId ? { threadGeneration: state.threadGeneration + 1 } : {}),
+        ...(!epochThreadId ? {
+          threadGeneration: state.threadGeneration + 1,
+          sessionBindingFingerprint: currentSessionBindingFingerprint,
+        } : {}),
         activeEpoch: {
           id: epoch.id,
           index: epoch.index,
@@ -844,6 +876,78 @@ export async function runAgentTest(
         epochUsage.outputTokens = usage.outputTokens
         state = updateCodexTestState(state, { lastUsage: { ...epochUsage } })
         await writePrivateJson(statePath, state)
+      }
+      // A logical Run may cold-resume on one replacement physical session,
+      // but only after the original resume attempt proves incompatible.
+      let resumeCompatibilityPending = Boolean(epochThreadId)
+      let sessionRotationAttempted = false
+      const invokeEpochTurn = async (
+        input: AgentInputPart[],
+        outputSchema?: unknown,
+      ): Promise<string> => {
+        if (!thread) throw new Error('AgentHost thread is unavailable for the active execution epoch')
+        return runTurn(
+          thread,
+          host.id,
+          input,
+          eventsPath,
+          redactionSecrets,
+          progress,
+          persistThreadId,
+          outputSchema,
+          receiptRecorder,
+          recordUsage,
+          scrubEpochArtifacts,
+        )
+      }
+      const confirmSessionBinding = async (): Promise<void> => {
+        if (state.sessionBindingFingerprint === currentSessionBindingFingerprint) return
+        state = updateCodexTestState(state, { sessionBindingFingerprint: currentSessionBindingFingerprint })
+        await writePrivateJson(statePath, state)
+      }
+      const rotateIncompatibleSession = async (): Promise<string> => {
+        sessionRotationAttempted = true
+        resumeCompatibilityPending = false
+        await thread?.close?.()
+        thread = await host.start(threadOptions)
+        activeThread = thread
+        threadId = thread.id ?? undefined
+        if (!state.activeEpoch) throw new Error('Cannot rotate an AgentHost session without an active execution epoch')
+        const { threadId: _oldThreadId, ...stateWithoutThread } = state
+        const { threadId: _oldEpochThreadId, ...activeEpochWithoutThread } = state.activeEpoch
+        state = updateCodexTestState(stateWithoutThread, {
+          threadGeneration: state.threadGeneration + 1,
+          sessionBindingFingerprint: currentSessionBindingFingerprint,
+          activeEpoch: {
+            ...activeEpochWithoutThread,
+            ...(thread.id ? { threadId: thread.id } : {}),
+          },
+          ...(thread.id ? { threadId: thread.id } : {}),
+        })
+        await writePrivateJson(statePath, state)
+        progress.report('warning', `已保留逻辑 Run、epoch 和 Mutation Ledger，并启动 thread generation ${state.threadGeneration} 恢复现场`)
+        return invokeEpochTurn(
+          hostInput(host, runtime, agentTestResumePrompt(fullAgentAccess, epoch, deliveryPath), []),
+        )
+      }
+      const runEpochTurn = async (
+        input: AgentInputPart[],
+        outputSchema?: unknown,
+        isResumePrompt = false,
+      ): Promise<string> => {
+        try {
+          const response = await invokeEpochTurn(input, outputSchema)
+          if (resumeCompatibilityPending) {
+            resumeCompatibilityPending = false
+            await confirmSessionBinding()
+          }
+          return response
+        } catch (error) {
+          const sessionIncompatible = error instanceof AgentHostError && error.kind === 'session_incompatible'
+          if (!sessionIncompatible || !resumeCompatibilityPending || sessionRotationAttempted) throw error
+          const recoveredResponse = await rotateIncompatibleSession()
+          return isResumePrompt ? recoveredResponse : invokeEpochTurn(input, outputSchema)
+        }
       }
 
       if (initialEpochStage === 'executing') {
@@ -866,7 +970,7 @@ export async function runAgentTest(
                 ...(workspace.runValuesPath ? { runValuesPath: workspace.runValuesPath } : {}),
                 ...(options.maxIterations !== undefined ? { maxIterations: options.maxIterations } : {}),
               }), imagePathsForExecutionEpoch(workspace, scopedManifest))
-        await runTurn(thread, input, eventsPath, redactionSecrets, progress, persistThreadId, undefined, receiptRecorder, recordUsage, scrubEpochArtifacts)
+        await runEpochTurn(input, undefined, resumingEpoch)
         state = updateCodexTestState(state, {
           stage: 'finalizing',
           activeEpoch: { ...state.activeEpoch!, stage: 'finalizing', ...(thread.id ? { threadId: thread.id } : {}) },
@@ -880,17 +984,10 @@ export async function runAgentTest(
       const ledgerBeforeFinalization = await readMutationLedger(workspace.mutationLedgerPath)
       if (ledgerBeforeFinalization.some((entry) => entry.status === 'pending')) {
         progress.report('stage', `epoch ${epoch.id} 存在未核销业务写入，正在由同一线程恢复核对`)
-        await runTurn(
-          thread,
+        await runEpochTurn(
           hostInput(host, runtime, agentTestResumePrompt(fullAgentAccess, epoch, deliveryPath), []),
-          eventsPath,
-          redactionSecrets,
-          progress,
-          persistThreadId,
           undefined,
-          receiptRecorder,
-          recordUsage,
-          scrubEpochArtifacts,
+          true,
         )
       }
 
@@ -903,17 +1000,9 @@ export async function runAgentTest(
           ? agentTestFinalPrompt(epoch)
           : `${agentTestFinalPrompt(epoch)}\n\nThe previous result had these deterministic contract problems:\n- ${deliveryProblems.join('\n- ')}\nCorrect only this epoch from existing evidence. Do not repeat business writes.`
         try {
-          const finalResponse = await runTurn(
-            thread,
+          const finalResponse = await runEpochTurn(
             hostInput(host, runtime, prompt, []),
-            eventsPath,
-            redactionSecrets,
-            progress,
-            persistThreadId,
             host.capabilities.structuredOutput ? agentTestStructuredOutputSchema : undefined,
-            receiptRecorder,
-            recordUsage,
-            scrubEpochArtifacts,
           )
           const candidate = parseAgentTestCandidate(finalResponse)
           const requirements = await reconcileEnvironmentRequirementCaseLinks(workspace.environmentRequirementsPath, candidate.cases)
@@ -1016,7 +1105,7 @@ export async function runAgentTest(
         })
         await writePrivateJson(statePath, state)
         progress.report('stage', `正在保存 ${epoch.id} 的 AgentHost 工作记忆 checkpoint`)
-        await runTurn(thread, hostInput(host, runtime, agentTestCheckpointPrompt(epoch, checkpointPath), []), eventsPath, redactionSecrets, progress, persistThreadId, undefined, receiptRecorder, recordUsage, scrubEpochArtifacts)
+        await runEpochTurn(hostInput(host, runtime, agentTestCheckpointPrompt(epoch, checkpointPath), []))
         const { activeEpoch: _checkpointedEpoch, ...checkpointedState } = state
         state = updateCodexTestState(checkpointedState, { stage: 'executing', checkpointPath })
         await writePrivateJson(statePath, state)

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -119,6 +119,8 @@ export interface CodexTestAgentState {
   finishedAt?: string
   threadId?: string
   threadGeneration: number
+  /** Secret-free identity of the AgentHost/model binding used by threadId. */
+  sessionBindingFingerprint?: string
   resultPath?: string
   resultWorkbookPath?: string
   outcome?: CodexTestOutcome

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -172,6 +172,17 @@ describe('AgentHost contract', () => {
     expect(normalizeAgentEvent({
       type: 'item.completed',
       item: {
+        id: 'session-model-mismatch',
+        type: 'error',
+        message: 'This session was recorded with model deepseek-v4-flash but is resuming with gpt-5.6-sol.',
+      },
+    })).toMatchObject({
+      type: 'session_incompatible',
+      message: expect.stringContaining('resuming with gpt-5.6-sol'),
+    })
+    expect(normalizeAgentEvent({
+      type: 'item.completed',
+      item: {
         id: 'metadata-warning',
         type: 'error',
         message: 'Model metadata for `deepseek-v4-flash` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.',
@@ -274,6 +285,7 @@ process.stdin.on('end', () => {
   it('classifies host errors so only operational transport classes are retryable', () => {
     expect(new AgentHostError('codex', 'quota', 'quota').retryable).toBe(true)
     expect(new AgentHostError('omp', 'transport', 'transport').retryable).toBe(true)
+    expect(new AgentHostError('codex', 'model changed', 'session_incompatible').retryable).toBe(true)
     expect(new AgentHostError('omp', 'unsupported mode', 'capability').retryable).toBe(false)
     expect(new AgentHostError('codex', 'bad executable', 'configuration').retryable).toBe(false)
     expect(new AgentHostError('omp', 'bad protocol', 'protocol').retryable).toBe(false)

--- a/tests/codex-agent-runner.test.ts
+++ b/tests/codex-agent-runner.test.ts
@@ -90,6 +90,37 @@ async function fixtureFiles(directory: string): Promise<{ sourceHome: string; br
   return { sourceHome, browserPath, codexExecutable }
 }
 
+async function createInterruptedExecution(
+  directory: string,
+  workflow: WorkflowIntakeManifest,
+  files: Awaited<ReturnType<typeof fixtureFiles>>,
+): Promise<{ outputDirectory: string; threadGeneration: number }> {
+  const outputDirectory = resolve(directory, 'run')
+  const run = await runCodexTestAgent({
+    outputDirectory, manifest: workflow,
+    profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+    secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+    agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable,
+    modelProfile: profile(), environment: { FIXTURE_KEY: 'fixture-key' },
+  }, {
+    browserExecutablePath: files.browserPath,
+    startThread: () => ({
+      id: 'thread-old',
+      runStreamed: async () => failedEventStream('network connection lost', 'thread-old'),
+    }),
+  })
+  expect(run.result?.outcome).toBe('blocked')
+  expect(run.state.activeEpoch).toMatchObject({ id: 'epoch-0001', stage: 'executing', threadId: 'thread-old' })
+  return { outputDirectory, threadGeneration: run.state.threadGeneration }
+}
+
+async function removeSessionBindingFingerprint(outputDirectory: string): Promise<void> {
+  const statePath = resolve(outputDirectory, 'codex-agent.state.json')
+  const state = JSON.parse(await readFile(statePath, 'utf8')) as Record<string, unknown>
+  delete state.sessionBindingFingerprint
+  await writeFile(statePath, JSON.stringify(state))
+}
+
 describe('adaptive Codex epochs', () => {
   it('plans capacity-bounded epochs without a fixed case count', () => {
     const workflow = manifest()
@@ -211,6 +242,207 @@ describe('adaptive Codex epochs', () => {
     expect(resumedThreadId).toBe('thread-2')
     expect(resumed.result?.cases.map((item) => item.caseId)).toEqual(['case-one', 'case-two'])
     expect(await readFile(firstRecordPath, 'utf8')).toBe(firstRecordBefore)
+  })
+
+  it('rotates one incompatible physical session while preserving the logical run and pending Ledger', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-session-rotation-'))
+    directories.push(directory)
+    const workflow = manifest()
+    workflow.phases = workflow.phases.slice(0, 1)
+    workflow.phases[0]!.risk = 'write'
+    const files = await fixtureFiles(directory)
+    const interrupted = await createInterruptedExecution(directory, workflow, files)
+    await removeSessionBindingFingerprint(interrupted.outputDirectory)
+    const ledgerPath = resolve(interrupted.outputDirectory, '.agent-private', 'mutation-ledger.json')
+    await writeFile(ledgerPath, JSON.stringify([{
+      id: 'pending-before-provider-switch', caseId: 'case-one', description: 'Fixture write awaiting live reconciliation',
+      risk: 'write', status: 'pending', createdAt: '2026-08-08T00:00:00.000Z', updatedAt: '2026-08-08T00:00:00.000Z', evidence: [],
+    }]))
+
+    let resumedOld = 0
+    let startedNew = 0
+    const newThreadPrompts: string[] = []
+    let stateObservedByNewThread: Record<string, unknown> | undefined
+    let pendingLedgerObserved = false
+    let newThreadTurn = 0
+    const resumed = await runCodexTestAgent({
+      outputDirectory: interrupted.outputDirectory, manifest: workflow,
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+      agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable,
+      modelProfile: profile(), environment: { FIXTURE_KEY: 'fixture-key' }, resume: true,
+    }, {
+      browserExecutablePath: files.browserPath,
+      resumeThread: ({ threadId }) => {
+        resumedOld += 1
+        expect(threadId).toBe('thread-old')
+        return {
+          id: threadId,
+          runStreamed: async () => failedEventStream(
+            'This session was recorded with model deepseek-v4-flash but is resuming with gpt-5.6-sol.',
+            threadId,
+          ),
+        }
+      },
+      startThread: () => {
+        startedNew += 1
+        return {
+          id: 'thread-new',
+          runStreamed: async (input, options) => {
+            const prompt = typeof input === 'string'
+              ? input
+              : input.filter((item) => item.type === 'text').map((item) => item.text).join('\n')
+            newThreadPrompts.push(prompt)
+            if (newThreadTurn++ === 0) {
+              stateObservedByNewThread = JSON.parse(await readFile(resolve(interrupted.outputDirectory, 'codex-agent.state.json'), 'utf8')) as Record<string, unknown>
+              const ledger = JSON.parse(await readFile(ledgerPath, 'utf8')) as Array<Record<string, unknown>>
+              pendingLedgerObserved = ledger[0]?.status === 'pending'
+              await writeFile(ledgerPath, JSON.stringify([{ ...ledger[0], status: 'compensated', updatedAt: '2026-08-08T00:01:00.000Z' }]))
+              return eventStream('Recovered the live state and reconciled the pending mutation.', 'thread-new')
+            }
+            return options?.outputSchema
+              ? eventStream(resultFor(workflow, ['case-one']), 'thread-new')
+              : eventStream('Recovery complete.', 'thread-new')
+          },
+        }
+      },
+    })
+
+    expect(resumedOld).toBe(1)
+    expect(startedNew).toBe(1)
+    expect(newThreadPrompts[0]).toContain('Resume the interrupted Auto-Test execution')
+    expect(pendingLedgerObserved).toBe(true)
+    expect(stateObservedByNewThread).toMatchObject({
+      threadId: 'thread-new',
+      threadGeneration: interrupted.threadGeneration + 1,
+      activeEpoch: { id: 'epoch-0001', caseIds: ['case-one'], stage: 'executing', threadId: 'thread-new' },
+    })
+    expect(resumed.state.threadGeneration).toBe(interrupted.threadGeneration + 1)
+    expect(resumed.state.threadId).toBe('thread-new')
+    expect(resumed.result?.outcome).toBe('passed')
+    expect(resumed.result?.mutations).toContainEqual(expect.objectContaining({
+      id: 'pending-before-provider-switch', status: 'compensated',
+    }))
+  })
+
+  it('starts a recovery generation without touching the old session when the saved binding fingerprint changed', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-session-fingerprint-'))
+    directories.push(directory)
+    const workflow = manifest()
+    workflow.phases = workflow.phases.slice(0, 1)
+    const files = await fixtureFiles(directory)
+    const interrupted = await createInterruptedExecution(directory, workflow, files)
+    let resumedOld = 0
+    let startedNew = 0
+    const prompts: string[] = []
+    let turn = 0
+    const replacementProfile: ModelProfile = {
+      ...profile(), id: 'replacement', providerId: 'replacement', model: 'replacement-model',
+      baseUrl: 'https://replacement-provider.example.test',
+    }
+
+    const resumed = await runCodexTestAgent({
+      outputDirectory: interrupted.outputDirectory, manifest: workflow,
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+      agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable,
+      modelProfile: replacementProfile, environment: { FIXTURE_KEY: 'fixture-key' }, resume: true,
+    }, {
+      browserExecutablePath: files.browserPath,
+      resumeThread: () => {
+        resumedOld += 1
+        throw new Error('a known incompatible binding must not resume the old physical session')
+      },
+      startThread: () => {
+        startedNew += 1
+        return {
+          id: 'thread-fingerprint-replacement',
+          runStreamed: async (input, options) => {
+            prompts.push(typeof input === 'string'
+              ? input
+              : input.filter((item) => item.type === 'text').map((item) => item.text).join('\n'))
+            if (turn++ === 0) return eventStream('Recovered from the saved run workspace.', 'thread-fingerprint-replacement')
+            return options?.outputSchema
+              ? eventStream(resultFor(workflow, ['case-one']), 'thread-fingerprint-replacement')
+              : eventStream('Recovery complete.', 'thread-fingerprint-replacement')
+          },
+        }
+      },
+    })
+
+    expect(resumedOld).toBe(0)
+    expect(startedNew).toBe(1)
+    expect(prompts[0]).toContain('Resume the interrupted Auto-Test execution')
+    expect(resumed.state.threadGeneration).toBe(interrupted.threadGeneration + 1)
+    expect(resumed.state.threadId).toBe('thread-fingerprint-replacement')
+    expect(resumed.result?.outcome).toBe('passed')
+  })
+
+  it('does not rotate a resumed physical session for an ordinary agent execution error', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-session-no-rotation-'))
+    directories.push(directory)
+    const workflow = manifest()
+    workflow.phases = workflow.phases.slice(0, 1)
+    const files = await fixtureFiles(directory)
+    const interrupted = await createInterruptedExecution(directory, workflow, files)
+    await removeSessionBindingFingerprint(interrupted.outputDirectory)
+    let startedNew = 0
+
+    const resumed = await runCodexTestAgent({
+      outputDirectory: interrupted.outputDirectory, manifest: workflow,
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+      agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable,
+      modelProfile: profile(), environment: { FIXTURE_KEY: 'fixture-key' }, resume: true,
+    }, {
+      browserExecutablePath: files.browserPath,
+      resumeThread: ({ threadId }) => ({
+        id: threadId,
+        runStreamed: async () => failedEventStream('The requested page assertion failed.', threadId),
+      }),
+      startThread: () => {
+        startedNew += 1
+        throw new Error('ordinary execution errors must not create a replacement session')
+      },
+    })
+
+    expect(startedNew).toBe(0)
+    expect(resumed.state.status).toBe('failed')
+    expect(resumed.state.threadGeneration).toBe(interrupted.threadGeneration)
+    expect(resumed.state.threadId).toBe('thread-old')
+  })
+
+  it('attempts at most one replacement when the new physical session is also incompatible', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-session-single-retry-'))
+    directories.push(directory)
+    const workflow = manifest()
+    workflow.phases = workflow.phases.slice(0, 1)
+    const files = await fixtureFiles(directory)
+    const interrupted = await createInterruptedExecution(directory, workflow, files)
+    await removeSessionBindingFingerprint(interrupted.outputDirectory)
+    const mismatch = 'This session was recorded with model old-model but is resuming with new-model.'
+    let startedNew = 0
+
+    const resumed = await runCodexTestAgent({
+      outputDirectory: interrupted.outputDirectory, manifest: workflow,
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+      agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable,
+      modelProfile: profile(), environment: { FIXTURE_KEY: 'fixture-key' }, resume: true,
+    }, {
+      browserExecutablePath: files.browserPath,
+      resumeThread: ({ threadId }) => ({ id: threadId, runStreamed: async () => failedEventStream(mismatch, threadId) }),
+      startThread: () => {
+        startedNew += 1
+        return { id: 'thread-still-incompatible', runStreamed: async () => failedEventStream(mismatch, 'thread-still-incompatible') }
+      },
+    })
+
+    expect(startedNew).toBe(1)
+    expect(resumed.state.status).toBe('completed')
+    expect(resumed.result?.outcome).toBe('blocked')
+    expect(resumed.state.threadGeneration).toBe(interrupted.threadGeneration + 1)
+    expect(resumed.state.threadId).toBe('thread-still-incompatible')
   })
 
   it('stops later epochs and returns a complete blocked result when a mutation remains pending', async () => {


### PR DESCRIPTION
## Summary
- classify physical AgentHost session/model incompatibility explicitly
- preserve the logical run, active epoch, workspace, and Mutation Ledger while rotating at most one physical session
- fingerprint secret-free host/provider/model bindings and cold-resume when a known binding changes
- document Windows model-profile recovery semantics

## Verification
- npm run check
- targeted AgentHost and adaptive-runner tests: 29 passed
- local delegated review: 4/4 reviewable source files covered; no remaining findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持在模型 Profile、Provider 或 AgentHost 变化时恢复运行，并自动创建新线程。
  - 恢复过程中保留原运行状态、工作区和待处理变更记录。
  - 新线程会执行恢复校验，确认关键配置与待处理变更保持一致。

- **错误修复**
  - 明确区分会话不兼容与普通执行错误，避免无关错误触发线程轮换。
  - 限制连续不兼容时的重试次数，防止无限重试。

- **文档**
  - 更新快速入门、恢复流程及 Windows 验收指南，补充模型切换与会话恢复规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->