### PR TITLE
fix: ignore Codex skill budget advisory

### DIFF
--- a/src/agent/host.ts
+++ b/src/agent/host.ts
@@ -249,6 +249,7 @@ function usageFrom(value: unknown): AgentUsage | undefined {
 const advisoryHostMessagePatterns = [
   /^Model metadata for `[^`]+` not found\. Defaulting to fallback metadata\b/i,
   /^Heads up: Long threads and multiple compactions can cause the model to be less accurate\./i,
+  /^Skill descriptions were shortened to fit the skills context budget\./i,
 ]
 
 const incompatibleSessionMessagePatterns = [

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -196,6 +196,14 @@ describe('AgentHost contract', () => {
       message: 'Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.',
     })).toMatchObject({ type: 'other' })
     expect(normalizeAgentEvent({
+      type: 'item.completed',
+      item: {
+        id: 'skill-budget-warning',
+        type: 'error',
+        message: 'Skill descriptions were shortened to fit the skills context budget. Codex can still see every skill, but some descriptions are shorter.',
+      },
+    })).toMatchObject({ type: 'other', message: expect.stringContaining('skills context budget') })
+    expect(normalizeAgentEvent({
       type: 'message_update',
       message: { role: 'assistant', content: [{ type: 'text', text: 'partial' }] },
     })).toMatchObject({ type: 'other' })


### PR DESCRIPTION
## Summary
- normalize the Codex skill-description budget warning as a non-fatal host advisory
- keep real AgentHost errors unchanged
- cover the exact Windows canary event shape with a regression test

## Verification
- npm run check
- npx vitest run tests/agent-host.test.ts
- local delegated review: 1/1 reviewable source file covered; no findings

Docs are unaffected because this only corrects internal Codex event severity and adds no command or user-visible contract.