### PR TITLE
fix: gate agent runs on control mcp capability

### DIFF
--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -104,7 +104,7 @@ Provider 探针通过只证明宿主启动层；不能替代真实页面执行�
 
 ## Control MCP 能力预检
 
-真实 AgentHost 在每个物理执行线程的第一轮业务提示前，会先发送一次只读能力预检。Core 必须在归一化事件流中观察到已完成的 `auto-test-control.test_contract` `tool_completed` 事件，才会发送浏览器探索和业务执行提示；模型的文字声称、`list_mcp_resources` 结果、Provider 探针通过或宿主静态 `mcp: true` 能力声明都不算预检通过。未观察到该事件时，Run 会直接生成 `blocked` 的 `infrastructure` 结果，并说明 Provider/AgentHost 没有把 Control MCP 工具暴露给模型。
+真实 AgentHost 在每个物理执行线程的第一轮业务提示前，会先发送一次只读能力预检。Core 必须在归一化事件流中观察到恰好一次已完成的 `auto-test-control.test_contract` `tool_completed` 事件，且不能出现其他工具、shell 命令或文件改动事件，才会发送浏览器探索和业务执行提示；模型的文字声称、`list_mcp_resources` 结果、Provider 探针通过或宿主静态 `mcp: true` 能力声明都不算预检通过。未满足该合同时，Run 会直接生成 `blocked` 的 `infrastructure` 结果，并说明 Provider/AgentHost 没有正确提供 Control MCP 工具。
 
 这条预检只验证工具通道和不可变契约，不解释业务语义、规划步骤或裁决结果。它尤其用于识别“Control MCP 进程本身正常，但第三方 Responses Provider 丢弃本地工具定义”的兼容性问题。更换兼容 Provider 后，应在同一输入和环境下重新执行；未发生业务写入的预检阻断可以直接从原目录恢复。
 

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -102,6 +102,14 @@ AgentHost 在页面、网络响应或浏览器存储中观察到的运行期凭�
 
 Provider 探针通过只证明宿主启动层；不能替代真实页面执行。一个 canary 的 `passed` 只能证明该平台、该宿主、该 commit/包版本和该输入包的结果，不能推出任意网站或任意 OMP/Codex 版本都一次成功。
 
+## Control MCP 能力预检
+
+真实 AgentHost 在每个物理执行线程的第一轮业务提示前，会先发送一次只读能力预检。Core 必须在归一化事件流中观察到已完成的 `auto-test-control.test_contract` `tool_completed` 事件，才会发送浏览器探索和业务执行提示；模型的文字声称、`list_mcp_resources` 结果、Provider 探针通过或宿主静态 `mcp: true` 能力声明都不算预检通过。未观察到该事件时，Run 会直接生成 `blocked` 的 `infrastructure` 结果，并说明 Provider/AgentHost 没有把 Control MCP 工具暴露给模型。
+
+这条预检只验证工具通道和不可变契约，不解释业务语义、规划步骤或裁决结果。它尤其用于识别“Control MCP 进程本身正常，但第三方 Responses Provider 丢弃本地工具定义”的兼容性问题。更换兼容 Provider 后，应在同一输入和环境下重新执行；未发生业务写入的预检阻断可以直接从原目录恢复。
+
+Core 读取 `.agent-private/mutation-ledger.json` 时会运行时验证其必须是合法数组且每个条目符合 Ledger 合同。Agent 或辅助脚本把该文件覆盖为对象、坏 JSON 或不完整条目时，结果会 fail closed 为 `agent_execution` blocked，并保留明确的制品违规原因；不会再因 `.some()` 等类型错误丢失权威结果文件。只有 Control MCP 登记的 Ledger 才是业务写入事实源。
+
 ## 同合同比较
 
 先用同一 Excel、sidecar、URL、Environment Profile 和 `--case-limit` 分别执行两个独立 Run：

--- a/docs/windows-acceptance-runbook.md
+++ b/docs/windows-acceptance-runbook.md
@@ -33,7 +33,7 @@ Linux/macOS 的 Codex 运行时只会把本次 Run 的 `.agent-private` 作为 s
 
 Windows 默认 Provider 的模型 API 探针最多等待 120 秒，并在长时间等待时输出心跳。stdout/stderr 使用本次探针的临时文件捕获，后台继承句柄不会让已退出的主进程继续占用启动窗口；只有 Codex/API 调用本身未结束才会触发超时、恢复上一版 Provider 配置并明确报错。stdout+stderr 总量超过 4 MiB 同样会终止进程树、回滚配置并清理捕获文件。这不是业务测试结果。OMP 和显式 Model Profile 不运行该 Codex 默认探针，而是在 AgentHost 运行前准备自己的 Provider 绑定；两者都必须用真实 canary 验证协议、鉴权和模型能力。只有已经确认网关健康但首个响应确实较慢时，才为单次诊断临时设置 `AUTO_TEST_CODEX_PROBE_TIMEOUT_SECONDS`（1 到 3600），不要用它掩盖额度、限流、网络或流式响应故障。
 
-启动层通过后，真实 AgentHost 还必须在第一个业务执行提示前完成只读 Control MCP 预检。验收时从 `codex-agent.events.jsonl` 精确查找 `server=auto-test-control`、`tool=test_contract` 且 `status=completed` 的事件；没有该事件就不能宣称业务通过，框架应生成 `blocked` 且 `failureSource=infrastructure` 的结构化结果。该门只确认 MCP 工具通道可用，不替代页面执行、业务断言或 Ledger 验收。
+启动层通过后，真实 AgentHost 还必须在第一个业务执行提示前完成只读 Control MCP 预检。验收时从 `codex-agent.events.jsonl` 精确确认恰好一次 `server=auto-test-control`、`tool=test_contract` 且 `status=completed` 的事件，并且该预检回合没有其他工具、shell 命令或文件改动事件；否则不能宣称业务通过，框架应生成 `blocked` 且 `failureSource=infrastructure` 的结构化结果。该门只确认 MCP 工具通道可用，不替代页面执行、业务断言或 Ledger 验收。
 
 如果默认 Key 额度不足，但另一个 Key 使用同一个 Provider Base URL，可在本次验收命令中临时指定：
 

--- a/docs/windows-acceptance-runbook.md
+++ b/docs/windows-acceptance-runbook.md
@@ -33,6 +33,8 @@ Linux/macOS 的 Codex 运行时只会把本次 Run 的 `.agent-private` 作为 s
 
 Windows 默认 Provider 的模型 API 探针最多等待 120 秒，并在长时间等待时输出心跳。stdout/stderr 使用本次探针的临时文件捕获，后台继承句柄不会让已退出的主进程继续占用启动窗口；只有 Codex/API 调用本身未结束才会触发超时、恢复上一版 Provider 配置并明确报错。stdout+stderr 总量超过 4 MiB 同样会终止进程树、回滚配置并清理捕获文件。这不是业务测试结果。OMP 和显式 Model Profile 不运行该 Codex 默认探针，而是在 AgentHost 运行前准备自己的 Provider 绑定；两者都必须用真实 canary 验证协议、鉴权和模型能力。只有已经确认网关健康但首个响应确实较慢时，才为单次诊断临时设置 `AUTO_TEST_CODEX_PROBE_TIMEOUT_SECONDS`（1 到 3600），不要用它掩盖额度、限流、网络或流式响应故障。
 
+启动层通过后，真实 AgentHost 还必须在第一个业务执行提示前完成只读 Control MCP 预检。验收时从 `codex-agent.events.jsonl` 精确查找 `server=auto-test-control`、`tool=test_contract` 且 `status=completed` 的事件；没有该事件就不能宣称业务通过，框架应生成 `blocked` 且 `failureSource=infrastructure` 的结构化结果。该门只确认 MCP 工具通道可用，不替代页面执行、业务断言或 Ledger 验收。
+
 如果默认 Key 额度不足，但另一个 Key 使用同一个 Provider Base URL，可在本次验收命令中临时指定：
 
 ```powershell
@@ -133,6 +135,8 @@ Get-ChildItem "$Run\*-Auto-Test-结果.xlsx" | Select-Object FullName
 - 每个测试用例均为 `passed`，且有对应业务证据；
 - Mutation Ledger 没有 `pending` 条目；
 - 测试材料要求的最终业务状态已验证，例如零活动订单、测试数据已删除、设备或连接器已恢复。
+
+另外，`.agent-private\mutation-ledger.json` 必须是 Core 校验通过的合法数组；若 Agent/脚本覆盖了 Ledger 形状，结果必须是 `blocked / agent_execution`，即使页面看起来已完成也不能算通过。
 
 `execution-plan.json`、`field-compositions.json`、Control MCP evidence checkpoint 或 AgentHost 生成的临时脚本可以存在，也可以不存在；它们不能替代最终业务证据，也不是通过条件。
 

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -116,6 +116,8 @@ Windows 上的 Codex CLI 0.146.0 对 `workspace-write` 的原生策略会拒绝�
 
 Linux x64 已按“默认 Codex 执行并清理，再由 OMP 在同一输入合同上单独执行”的顺序完成一次真实写入型 canary；Windows 仍须独立复验。OMP 的结果必须同时保留 `agent-host-selection.json` 中的 `workspaceIsolation: prompt_only`，不能因结果为 `passed` 就宣称其具备 Codex 同等级的操作系统隔离。
 
+发送真实页面探索和业务执行提示前，Windows 每个 Codex/OMP 物理线程都会先执行一次只读 Control MCP 能力预检。必须在 `codex-agent.events.jsonl` 中看到已完成的 `auto-test-control.test_contract` 调用；只看到 Provider 探针成功、浏览器打开或模型说“已读取契约”都不够。若预检没有该事件，框架会返回 `blocked / infrastructure`，通常表示当前 Provider 的工具调用兼容性不足，应切换到支持本地 MCP 工具的 Model Profile 后用原输出目录恢复。
+
 框架不会再为手机号、日期、组合输入框或其他页面形态增加业务字段规则。选定 AgentHost 直接读取原始测试材料，根据页面证据决定如何填写和验证；需要复杂处理时可以在当前 run 的隔离工作区编写一次性 Playwright/JavaScript 辅助代码，不得写入 Auto-Test 仓库或被测应用源代码。旧的 `case_result_record` checkpoint、复合字段 Gate 和动态计划仍可作为诊断记录；它们不替代新的浏览器执行回执，也不单独决定通过。
 
 每次运行目录中的 `agent-workspace/input/` 保存原始测试材料的本次运行副本，运行值只保存在 `.agent-private\run-values.json`，`codex-agent.events.jsonl` 保存脱敏后的宿主、shell 和工具事件，`agent-workspace/execution-receipts.json` 保存 Runner 被动捕获的 Playwright 完成调用元数据，`codex-agent.result.json` 保存选定 AgentHost 生成且由框架校验的最终结果，`agent-host-selection.json` 保存实际宿主和能力，`agent-workspace/evidence/` 保存页面证据。每个 Agent turn 结束后，框架会清洗 Agent 生成的文本制品，包括输入 Secret、Authorization/Cookie/API key、运行期 `access_token`/`refresh_token` 和 JWT；JSON/JSONL 清洗后仍保持可解析，证据文件名包含运行 Secret 时会同步调整生成文件名和交付引用，immutable `test-manifest.json` 和 `input/` 原始输入不会被改写。`.agent-private` 私有恢复材料同样不会被清洗。截图、PDF 等二进制证据不做自动内容擦除，外发前必须人工检查用户名、业务数据和其他敏感信息。长套件还会生成 `.agent-private\execution-epochs\`、`.agent-private\case-results\` 和 `.agent-private\checkpoints\`：前者保存有界 epoch 交付，中者是逐 case 恢复事实源，后者保存 thread 轮换时的 Agent 工作记忆。`--resume` 只有在 immutable `test-manifest.json` 的 `workflowId` 和 `sourceSha256` 一致、逐 epoch 交付无重复且覆盖全部 case、结果 schema 与聚合 outcome 一致、全部证据引用都存在于同一 run，并且权威 Ledger 没有 `pending` 时，Core 才会直接恢复最终结果；否则继续原宿主恢复或保持阻断，不会擅自采用旧交付。直接恢复不会启动浏览器或 AgentHost，也不会重做业务写入。结束时还会生成 `原文件名-Auto-Test-结果.xlsx`：这是原 Excel 的副本，按每条 case 的来源行追加“Auto-Test 状态、失败来源、失败类型、执行摘要、证据索引、环境需求”六列，原 Excel 不会被改写。最终 `agent-workspace/case-results.json` 保存按 Manifest 顺序聚合的全量版本化交付。测试结束时，窗口会先显示通过、产品不符预期和阻断的用例数，再分别提示测试材料、环境/权限/数据、基础设施或 Agent 执行交付的首个直接原因。模型额度、MCP、浏览器或网络不可用时会返回 `blocked`，不会把基础设施错误误报为测试通过。
@@ -125,6 +127,8 @@ Linux x64 已按“默认 Codex 执行并清理，再由 OMP 在同一输入合�
 启动窗口会持续显示带时间的执行进度，包括 AgentHost thread 状态、epoch 编号、线程代数、累计完成 case 数、读取页面结构、填写表单、运行测试辅助脚本、更新 run 工作区、记录证据、核对 Mutation Ledger、checkpoint 和生成最终结果。模型或页面动作暂时没有新事件时，窗口每约 20 秒输出一次“框架仍在运行”心跳，因此可以区分正常思考、自动重连、thread 轮换和明确阻断。进度只显示动作类别，不显示模型推理正文、命令内容、表单值、工具参数、Cookie、验证码或 API 信息。
 
 这些进度表示选定 AgentHost 仍在工作，不代表测试已经通过。最终结论以 `codex-agent.result.json`、其中引用的实际证据以及 Mutation Ledger 的终态为准；Execution Plan 和字段 Gate 不再是必需产物。
+
+如果 Agent 生成的 `.agent-private\mutation-ledger.json` 不是合法数组，Core 会显示“Mutation Ledger 制品违规”并将用例归为 `agent_execution`，同时生成结构化 blocked 结果；这不是被测网站缺陷，也不能通过手工把 Ledger 改成空数组来验收。应保留事件和原始 Ledger，修复宿主后从同一 Run 恢复。
 
 结束时直接显示以下三类结果：
 

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -116,7 +116,7 @@ Windows 上的 Codex CLI 0.146.0 对 `workspace-write` 的原生策略会拒绝�
 
 Linux x64 已按“默认 Codex 执行并清理，再由 OMP 在同一输入合同上单独执行”的顺序完成一次真实写入型 canary；Windows 仍须独立复验。OMP 的结果必须同时保留 `agent-host-selection.json` 中的 `workspaceIsolation: prompt_only`，不能因结果为 `passed` 就宣称其具备 Codex 同等级的操作系统隔离。
 
-发送真实页面探索和业务执行提示前，Windows 每个 Codex/OMP 物理线程都会先执行一次只读 Control MCP 能力预检。必须在 `codex-agent.events.jsonl` 中看到已完成的 `auto-test-control.test_contract` 调用；只看到 Provider 探针成功、浏览器打开或模型说“已读取契约”都不够。若预检没有该事件，框架会返回 `blocked / infrastructure`，通常表示当前 Provider 的工具调用兼容性不足，应切换到支持本地 MCP 工具的 Model Profile 后用原输出目录恢复。
+发送真实页面探索和业务执行提示前，Windows 每个 Codex/OMP 物理线程都会先执行一次只读 Control MCP 能力预检。必须在 `codex-agent.events.jsonl` 中看到恰好一次已完成的 `auto-test-control.test_contract` 调用且没有其他工具、shell 命令或文件改动事件；只看到 Provider 探针成功、浏览器打开或模型说“已读取契约”都不够。若预检未满足该合同，框架会返回 `blocked / infrastructure`，通常表示当前 Provider 的工具调用兼容性不足，应切换到支持本地 MCP 工具的 Model Profile 后用原输出目录恢复。
 
 框架不会再为手机号、日期、组合输入框或其他页面形态增加业务字段规则。选定 AgentHost 直接读取原始测试材料，根据页面证据决定如何填写和验证；需要复杂处理时可以在当前 run 的隔离工作区编写一次性 Playwright/JavaScript 辅助代码，不得写入 Auto-Test 仓库或被测应用源代码。旧的 `case_result_record` checkpoint、复合字段 Gate 和动态计划仍可作为诊断记录；它们不替代新的浏览器执行回执，也不单独决定通过。
 

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -107,6 +107,7 @@ async function runTurn(
   receiptRecorder?: ExecutionReceiptRecorder,
   onUsage?: (usage: CodexTurnUsage) => Promise<void> | void,
   afterTurn?: () => Promise<void>,
+  onEvent?: (event: AgentEvent) => Promise<void> | void,
 ): Promise<string> {
   try {
     const streamed = await thread.run(input, outputSchema ? { outputSchema } : undefined)
@@ -116,6 +117,7 @@ async function runTurn(
       progress.observe(event)
       if (event.type === 'turn_completed' && event.usage) await onUsage?.(event.usage)
       if (event.type === 'thread_started' && event.threadId) await onThreadStarted?.(event.threadId)
+      await onEvent?.(event)
       if (event.type === 'agent_message') finalResponse = event.text ?? ''
       if (event.type === 'turn_failed') throw new Error(event.message ?? 'agent turn failed')
       if (event.type === 'session_incompatible') {
@@ -258,10 +260,20 @@ function enforceEnvironmentRequirements(
 
 function isOperationalBlock(message: string, error?: unknown): boolean {
   if (error instanceof AgentHostError) return error.retryable
-  return /usage limit|quota|credit|rate.?limit|at capacity|capacity|context (?:length|window)|maximum context|too many tokens|token limit|output limit|try a different model|\b429\b|\b5\d\d\b|bad gateway|upstream|reconnect|timed? out|timeout|connection|network|dns|certificate|tls|unauthorized|forbidden|\b401\b|\b403\b|mcp|chromium executable|spawn .*enoent|no final response|不可用/i.test(message)
+  return /usage limit|quota|credit|rate.?limit|at capacity|capacity|context (?:length|window)|maximum context|too many tokens|token limit|output limit|try a different model|\b429\b|\b5\d\d\b|bad gateway|upstream|reconnect|timed? out|timeout|connection|network|dns|certificate|tls|unauthorized|forbidden|\b401\b|\b403\b|mcp|mutation ledger|chromium executable|spawn .*enoent|no final response|不可用/i.test(message)
+}
+
+function isMutationLedgerViolation(message: string): boolean {
+  return /mutation ledger is invalid|mutation ledger is not valid json/i.test(message)
 }
 
 function infrastructureBlockDetails(message: string): { reason: string; nextAction: string } {
+  if (/control mcp capability preflight/i.test(message)) {
+    return {
+      reason: '当前 Provider/AgentHost 没有向模型提供 Auto-Test Control MCP 工具。',
+      nextAction: '切换到已验证支持本地 MCP 工具调用的 Provider/AgentHost 后，使用原结果目录继续上次测试。',
+    }
+  }
   if (/context (?:length|window)|maximum context|too many tokens|token limit|output limit/i.test(message)) {
     return {
       reason: '当前执行 epoch 超出模型上下文或单次输出容量。',
@@ -369,12 +381,15 @@ function deliveryBlockedResult(
   ledger: CodexTestMutationLedgerEntry[],
   environmentRequirements: CodexTestEnvironmentRequirement[],
 ): CodexTestAgentResult {
+  const ledgerViolation = isMutationLedgerViolation(message)
   return enforceMutationLedger({
     version: '1.0',
     workflowId: manifest.workflowId,
     sourceSha256: manifest.source.sha256,
     outcome: 'blocked',
-    summary: 'The selected AgentHost completed execution but did not produce a complete evidence-based delivery result.',
+    summary: ledgerViolation
+      ? 'The selected AgentHost damaged the authoritative Mutation Ledger, so Auto-Test rejected the delivery result.'
+      : 'The selected AgentHost completed execution but did not produce a complete evidence-based delivery result.',
     startedAt: state.startedAt,
     finishedAt: new Date().toISOString(),
     cases: manifest.phases.map((phase) => ({
@@ -390,12 +405,52 @@ function deliveryBlockedResult(
     environmentRequirements,
     blockers: [message],
     productDefects: [],
-    nextActions: ['Resume the same AgentHost session and complete the structured evidence-based result without repeating verified writes.'],
+    nextActions: [ledgerViolation
+      ? 'Inspect the Agent events and Mutation Ledger before resuming; do not repeat business writes whose terminal state is unknown.'
+      : 'Resume the same AgentHost session and complete the structured evidence-based result without repeating verified writes.'],
   }, ledger)
 }
 
 async function readMutationLedger(path: string): Promise<CodexTestMutationLedgerEntry[]> {
-  return JSON.parse(await readFile(path, 'utf8')) as CodexTestMutationLedgerEntry[]
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8'))
+  } catch (error) {
+    throw new Error(`Mutation Ledger is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('Mutation Ledger is invalid: expected a JSON array of entries')
+  }
+  const invalidIndex = parsed.findIndex((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return true
+    const value = entry as Record<string, unknown>
+    return typeof value.id !== 'string' ||
+      typeof value.caseId !== 'string' ||
+      typeof value.description !== 'string' ||
+      (value.risk !== 'write' && value.risk !== 'destructive') ||
+      (value.status !== 'pending' && value.status !== 'compensated' && value.status !== 'accepted') ||
+      typeof value.createdAt !== 'string' ||
+      typeof value.updatedAt !== 'string' ||
+      !Array.isArray(value.evidence) ||
+      value.evidence.some((item) => typeof item !== 'string')
+  })
+  if (invalidIndex >= 0) {
+    throw new Error(`Mutation Ledger is invalid: entry ${invalidIndex} does not match the run contract`)
+  }
+  return parsed as CodexTestMutationLedgerEntry[]
+}
+
+const controlMcpPreflightPrompt = [
+  'This is a read-only Auto-Test capability preflight.',
+  'Call auto-test-control.test_contract exactly once and do not call any other tool.',
+  'After the tool returns, reply with a short confirmation only.',
+].join(' ')
+
+function isCompletedControlContractCall(event: AgentEvent): boolean {
+  return event.type === 'tool_completed' &&
+    event.status === 'completed' &&
+    event.server === 'auto-test-control' &&
+    event.tool === 'test_contract'
 }
 
 async function readJsonOr<T>(path: string, fallback: T): Promise<T> {
@@ -810,6 +865,10 @@ export async function runAgentTest(
     await writePrivateJson(statePath, state)
 
     const currentSessionBindingFingerprint = sessionBindingFingerprint(host, runtime)
+    // Legacy injected thread factories are deterministic unit-test seams; a
+    // real AgentHost must prove that its configured Control MCP reaches the
+    // model before any browser or business operation is attempted.
+    const capabilityPreflightRequired = !(dependencies.startThread || dependencies.resumeThread)
     let thread: AgentHostSession | undefined
     let threadId = state.threadId ?? resumeThreadId
     for (const epoch of epochs) {
@@ -881,11 +940,38 @@ export async function runAgentTest(
       // but only after the original resume attempt proves incompatible.
       let resumeCompatibilityPending = Boolean(epochThreadId)
       let sessionRotationAttempted = false
+      let capabilityPreflightCompleted = false
+      const verifyControlMcpCapability = async (): Promise<void> => {
+        if (!capabilityPreflightRequired || capabilityPreflightCompleted) return
+        if (!thread) throw new Error('AgentHost thread is unavailable for the Control MCP capability preflight')
+        let contractCallObserved = false
+        await runTurn(
+          thread,
+          host.id,
+          [{ type: 'text', text: controlMcpPreflightPrompt }],
+          eventsPath,
+          redactionSecrets,
+          progress,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (event) => {
+            if (isCompletedControlContractCall(event)) contractCallObserved = true
+          },
+        )
+        if (!contractCallObserved) {
+          throw new Error('Auto-Test Control MCP capability preflight failed: no completed auto-test-control.test_contract call was observed')
+        }
+        capabilityPreflightCompleted = true
+      }
       const invokeEpochTurn = async (
         input: AgentInputPart[],
         outputSchema?: unknown,
       ): Promise<string> => {
         if (!thread) throw new Error('AgentHost thread is unavailable for the active execution epoch')
+        await verifyControlMcpCapability()
         return runTurn(
           thread,
           host.id,
@@ -911,6 +997,7 @@ export async function runAgentTest(
         await thread?.close?.()
         thread = await host.start(threadOptions)
         activeThread = thread
+        capabilityPreflightCompleted = false
         threadId = thread.id ?? undefined
         if (!state.activeEpoch) throw new Error('Cannot rotate an AgentHost session without an active execution epoch')
         const { threadId: _oldThreadId, ...stateWithoutThread } = state
@@ -1144,12 +1231,22 @@ export async function runAgentTest(
   } catch (error) {
     const message = redactAgentValue(error instanceof Error ? error.message : String(error), redactionSecrets)
     if (isOperationalBlock(message, error)) {
-      progress.report('warning', '模型、浏览器、MCP 或本地网络暂时不可用，正在保存可恢复的 blocked 结果')
-      const ledger = mutationLedgerPath ? await readMutationLedger(mutationLedgerPath).catch(() => []) : []
+      progress.report('warning', isMutationLedgerViolation(message)
+        ? 'Mutation Ledger 交付制品不符合合同，正在保存 agent_execution blocked 结果'
+        : '模型、浏览器、MCP 或本地网络暂时不可用，正在保存可恢复的 blocked 结果')
+      let ledger: CodexTestMutationLedgerEntry[] = []
+      if (mutationLedgerPath) {
+        ledger = await readMutationLedger(mutationLedgerPath).catch(() => [])
+      }
       const environmentRequirements = environmentRequirementsPath
         ? await readJsonOr<CodexTestEnvironmentRequirement[]>(environmentRequirementsPath, [])
         : []
-      const result = redactAgentJsonArtifact(blockedResult(options.manifest, state, message, ledger, environmentRequirements), redactionSecrets)
+      const result = redactAgentJsonArtifact(
+        isMutationLedgerViolation(message)
+          ? deliveryBlockedResult(options.manifest, state, message, ledger, environmentRequirements)
+          : blockedResult(options.manifest, state, message, ledger, environmentRequirements),
+        redactionSecrets,
+      )
       await writePrivateJson(resultPath, result)
       state = updateCodexTestState(state, {
         status: 'completed', stage: 'completed', outcome: 'blocked', resultPath, finishedAt: new Date().toISOString(),

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -422,6 +422,9 @@ async function readMutationLedger(path: string): Promise<CodexTestMutationLedger
   if (!Array.isArray(parsed)) {
     throw new Error('Mutation Ledger is invalid: expected a JSON array of entries')
   }
+  const isIsoTimestamp = (value: unknown): value is string => typeof value === 'string' &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+    !Number.isNaN(Date.parse(value))
   const invalidIndex = parsed.findIndex((entry) => {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return true
     const value = entry as Record<string, unknown>
@@ -430,8 +433,8 @@ async function readMutationLedger(path: string): Promise<CodexTestMutationLedger
       typeof value.description !== 'string' ||
       (value.risk !== 'write' && value.risk !== 'destructive') ||
       (value.status !== 'pending' && value.status !== 'compensated' && value.status !== 'accepted') ||
-      typeof value.createdAt !== 'string' ||
-      typeof value.updatedAt !== 'string' ||
+      !isIsoTimestamp(value.createdAt) ||
+      !isIsoTimestamp(value.updatedAt) ||
       !Array.isArray(value.evidence) ||
       value.evidence.some((item) => typeof item !== 'string')
   })
@@ -452,6 +455,20 @@ function isCompletedControlContractCall(event: AgentEvent): boolean {
     event.status === 'completed' &&
     event.server === 'auto-test-control' &&
     event.tool === 'test_contract'
+}
+
+function isToolEvent(event: AgentEvent): boolean {
+  return event.type === 'tool_started' || event.type === 'tool_completed'
+}
+
+function isPreflightActionEvent(event: AgentEvent): boolean {
+  return isToolEvent(event) ||
+    event.type === 'command_started' || event.type === 'command_completed' ||
+    event.type === 'file_change_started' || event.type === 'file_change_completed'
+}
+
+function isControlContractToolEvent(event: AgentEvent): boolean {
+  return isToolEvent(event) && event.server === 'auto-test-control' && event.tool === 'test_contract'
 }
 
 async function readJsonOr<T>(path: string, fallback: T): Promise<T> {
@@ -647,13 +664,15 @@ export async function runAgentTest(
   const injectedHost = options.agentHost ?? dependencies.agentHost
   const requestedHostId = options.agentHostId ?? state.agentHost
   const selectedHostId = injectedHost?.id ?? requestedHostId ?? 'codex'
+  const usesLegacyThreadFactory = !injectedHost && selectedHostId === 'codex' &&
+    Boolean(dependencies.startThread || dependencies.resumeThread)
   if (injectedHost && requestedHostId && injectedHost.id !== requestedHostId) {
     throw new Error(`AgentHost selection is ambiguous: injected ${injectedHost.id} but requested ${requestedHostId}`)
   }
   let host: AgentHost
   if (injectedHost) {
     host = injectedHost
-  } else if (selectedHostId === 'codex' && (dependencies.startThread || dependencies.resumeThread)) {
+  } else if (usesLegacyThreadFactory) {
     host = createLegacyCodexAgentHost({
       startThread: dependencies.startThread ?? (() => { throw new Error('Legacy startThread dependency is missing') }),
       resumeThread: dependencies.resumeThread ?? (() => { throw new Error('Legacy resumeThread dependency is missing') }),
@@ -869,7 +888,7 @@ export async function runAgentTest(
     // Legacy injected thread factories are deterministic unit-test seams; a
     // real AgentHost must prove that its configured Control MCP reaches the
     // model before any browser or business operation is attempted.
-    const capabilityPreflightRequired = !(dependencies.startThread || dependencies.resumeThread)
+    const capabilityPreflightRequired = !usesLegacyThreadFactory
     let thread: AgentHostSession | undefined
     let threadId = state.threadId ?? resumeThreadId
     for (const epoch of epochs) {
@@ -945,7 +964,8 @@ export async function runAgentTest(
       const verifyControlMcpCapability = async (): Promise<void> => {
         if (!capabilityPreflightRequired || capabilityPreflightCompleted) return
         if (!thread) throw new Error('AgentHost thread is unavailable for the Control MCP capability preflight')
-        let contractCallObserved = false
+        let completedContractCalls = 0
+        let unexpectedTool: string | undefined
         await runTurn(
           thread,
           host.id,
@@ -959,11 +979,18 @@ export async function runAgentTest(
           undefined,
           undefined,
           (event) => {
-            if (isCompletedControlContractCall(event)) contractCallObserved = true
+            if (isCompletedControlContractCall(event)) completedContractCalls += 1
+            else if (isPreflightActionEvent(event) && !isControlContractToolEvent(event)) {
+              unexpectedTool = [event.server, event.tool].filter(Boolean).join('.') || 'unknown'
+            }
           },
         )
-        if (!contractCallObserved) {
-          throw new Error('Auto-Test Control MCP capability preflight failed: no completed auto-test-control.test_contract call was observed')
+        if (completedContractCalls !== 1 || unexpectedTool) {
+          const details = [
+            ...(completedContractCalls !== 1 ? [`expected one completed auto-test-control.test_contract call, observed ${completedContractCalls}`] : []),
+            ...(unexpectedTool ? [`unexpected tool call observed: ${unexpectedTool}`] : []),
+          ]
+          throw new Error(`Auto-Test Control MCP capability preflight failed: ${details.join('; ')}`)
         }
         capabilityPreflightCompleted = true
       }
@@ -1234,15 +1261,20 @@ export async function runAgentTest(
     if (isOperationalBlock(message, error)) {
       progress.report('warning', '模型、浏览器、MCP 或本地网络暂时不可用，正在保存可恢复的 blocked 结果')
       let ledger: CodexTestMutationLedgerEntry[] = []
+      let ledgerError: string | undefined
       if (mutationLedgerPath) {
-        ledger = await readMutationLedger(mutationLedgerPath).catch(() => [])
+        try {
+          ledger = await readMutationLedger(mutationLedgerPath)
+        } catch (ledgerReadError) {
+          ledgerError = redactAgentValue(ledgerReadError instanceof Error ? ledgerReadError.message : String(ledgerReadError), redactionSecrets)
+        }
       }
       const environmentRequirements = environmentRequirementsPath
         ? await readJsonOr<CodexTestEnvironmentRequirement[]>(environmentRequirementsPath, [])
         : []
       const result = redactAgentJsonArtifact(
-        isMutationLedgerViolation(message)
-          ? deliveryBlockedResult(options.manifest, state, message, ledger, environmentRequirements)
+        ledgerError || isMutationLedgerViolation(message)
+          ? deliveryBlockedResult(options.manifest, state, ledgerError ?? message, ledger, environmentRequirements)
           : blockedResult(options.manifest, state, message, ledger, environmentRequirements),
         redactionSecrets,
       )

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -274,6 +274,12 @@ function infrastructureBlockDetails(message: string): { reason: string; nextActi
       nextAction: '切换到已验证支持本地 MCP 工具调用的 Provider/AgentHost 后，使用原结果目录继续上次测试。',
     }
   }
+  if (/mutation ledger/i.test(message)) {
+    return {
+      reason: '本次 Agent 执行破坏了 Auto-Test 的 Mutation Ledger 交付制品，核心拒绝继续判定业务结果。',
+      nextAction: '检查运行目录中的 Mutation Ledger 和 Agent 事件，修复宿主执行后使用原结果目录恢复；不要重复已发生的业务写入。',
+    }
+  }
   if (/context (?:length|window)|maximum context|too many tokens|token limit|output limit/i.test(message)) {
     return {
       reason: '当前执行 epoch 超出模型上下文或单次输出容量。',
@@ -381,15 +387,12 @@ function deliveryBlockedResult(
   ledger: CodexTestMutationLedgerEntry[],
   environmentRequirements: CodexTestEnvironmentRequirement[],
 ): CodexTestAgentResult {
-  const ledgerViolation = isMutationLedgerViolation(message)
   return enforceMutationLedger({
     version: '1.0',
     workflowId: manifest.workflowId,
     sourceSha256: manifest.source.sha256,
     outcome: 'blocked',
-    summary: ledgerViolation
-      ? 'The selected AgentHost damaged the authoritative Mutation Ledger, so Auto-Test rejected the delivery result.'
-      : 'The selected AgentHost completed execution but did not produce a complete evidence-based delivery result.',
+    summary: 'The selected AgentHost completed execution but did not produce a complete evidence-based delivery result.',
     startedAt: state.startedAt,
     finishedAt: new Date().toISOString(),
     cases: manifest.phases.map((phase) => ({
@@ -405,9 +408,7 @@ function deliveryBlockedResult(
     environmentRequirements,
     blockers: [message],
     productDefects: [],
-    nextActions: [ledgerViolation
-      ? 'Inspect the Agent events and Mutation Ledger before resuming; do not repeat business writes whose terminal state is unknown.'
-      : 'Resume the same AgentHost session and complete the structured evidence-based result without repeating verified writes.'],
+    nextActions: ['Resume the same AgentHost session and complete the structured evidence-based result without repeating verified writes.'],
   }, ledger)
 }
 
@@ -1231,9 +1232,7 @@ export async function runAgentTest(
   } catch (error) {
     const message = redactAgentValue(error instanceof Error ? error.message : String(error), redactionSecrets)
     if (isOperationalBlock(message, error)) {
-      progress.report('warning', isMutationLedgerViolation(message)
-        ? 'Mutation Ledger 交付制品不符合合同，正在保存 agent_execution blocked 结果'
-        : '模型、浏览器、MCP 或本地网络暂时不可用，正在保存可恢复的 blocked 结果')
+      progress.report('warning', '模型、浏览器、MCP 或本地网络暂时不可用，正在保存可恢复的 blocked 结果')
       let ledger: CodexTestMutationLedgerEntry[] = []
       if (mutationLedgerPath) {
         ledger = await readMutationLedger(mutationLedgerPath).catch(() => [])

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -388,7 +388,10 @@ process.stdin.on('end', () => {
       manifest: oneCaseManifest(),
       profile: { id: 'fixture', origins: ['https://agent.example.test'], auth: [], policy: { allowWrite: false, allowDestructive: false } },
       secrets: {}, environmentContext: '', imagePaths: [], headed: false, agentHost: host,
-    }, { browserExecutablePath: browserPath })
+    }, {
+      browserExecutablePath: browserPath,
+      startThread: () => { throw new Error('the injected real AgentHost must take precedence') },
+    })
 
     expect(prompts).toHaveLength(1)
     expect(prompts[0]).toContain('capability preflight')
@@ -397,6 +400,59 @@ process.stdin.on('end', () => {
     expect(run.result?.cases[0]).toMatchObject({ outcome: 'blocked', failureSource: 'infrastructure' })
     expect(run.result?.blockers[0]).toMatch(/没有向模型提供 Auto-Test Control MCP 工具/)
     expect(JSON.parse(await readFile(resolve(outputDirectory, '.agent-private', 'mutation-ledger.json'), 'utf8'))).toEqual([])
+  })
+
+  it('rejects a Control MCP preflight that also calls another tool', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-agent-host-preflight-extra-tool-'))
+    directories.push(directory)
+    const browserPath = resolve(directory, 'chromium')
+    await writeFile(browserPath, '')
+    const prompts: string[] = []
+    const host = {
+      id: 'portable',
+      displayName: 'Portable fixture host',
+      capabilities: {
+        streaming: true, sessionResume: true, structuredOutput: false, localImages: true, mcp: true,
+        shell: true, network: true, workspaceIsolation: 'prompt_only' as const, restrictedMode: false,
+      },
+      modelProvider: {
+        supportedApis: ['openai-responses'] as const,
+        async prepare(options: AgentHostProviderPrepareOptions) {
+          return { agentHome: options.agentHome, environment: {}, mcpEnvironment: {} }
+        },
+      },
+      async probe() {
+        return { ok: true as const, hostId: 'portable', executable: '/fixture/portable' }
+      },
+      async start() {
+        return {
+          id: 'portable-extra-tool',
+          async run(input: AgentInputPart[]) {
+            prompts.push(input.filter((part) => part.type === 'text').map((part) => part.text).join('\n'))
+            return {
+              events: (async function* () {
+                yield { type: 'tool_completed' as const, server: 'auto-test-control', tool: 'test_contract', status: 'completed' as const }
+                yield { type: 'tool_completed' as const, server: 'playwright', tool: 'browser_snapshot', status: 'completed' as const }
+                yield { type: 'agent_message' as const, text: 'preflight complete' }
+              })(),
+            }
+          },
+        }
+      },
+      async resume(): Promise<never> {
+        throw new Error('fixture must not resume')
+      },
+    } satisfies AgentHost
+    const run = await runAgentTest({
+      outputDirectory: resolve(directory, 'run'),
+      manifest: oneCaseManifest(),
+      profile: { id: 'fixture', origins: ['https://agent.example.test'], auth: [], policy: { allowWrite: false, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false, agentHost: host,
+    }, { browserExecutablePath: browserPath })
+
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).toContain('capability preflight')
+    expect(run.result?.cases[0]).toMatchObject({ outcome: 'blocked', failureSource: 'infrastructure' })
   })
 
   it('runs an unregistered third-party host through the generic provider runtime contract', async () => {

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -342,6 +342,63 @@ process.stdin.on('end', () => {
     expect(run.state.error).toMatch(/does not support model API openai-completions/)
   })
 
+  it('blocks before the business prompt when the model cannot call the Control MCP', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-agent-host-preflight-'))
+    directories.push(directory)
+    const browserPath = resolve(directory, 'chromium')
+    await writeFile(browserPath, '')
+    const prompts: string[] = []
+    const host = {
+      id: 'portable',
+      displayName: 'Portable fixture host',
+      capabilities: {
+        streaming: true, sessionResume: true, structuredOutput: false, localImages: true, mcp: true,
+        shell: true, network: true, workspaceIsolation: 'prompt_only' as const, restrictedMode: false,
+      },
+      modelProvider: {
+        supportedApis: ['openai-responses'] as const,
+        async prepare(options: AgentHostProviderPrepareOptions) {
+          return { agentHome: options.agentHome, environment: {}, mcpEnvironment: {} }
+        },
+      },
+      async probe() {
+        return { ok: true as const, hostId: 'portable', executable: '/fixture/portable' }
+      },
+      async start() {
+        return {
+          id: 'portable-no-control-mcp',
+          async run(input: AgentInputPart[]) {
+            prompts.push(input.filter((part) => part.type === 'text').map((part) => part.text).join('\n'))
+            return {
+              events: (async function* () {
+                yield { type: 'thread_started' as const, threadId: 'portable-no-control-mcp' }
+                yield { type: 'agent_message' as const, text: 'No Control MCP tool is available.' }
+              })(),
+            }
+          },
+        }
+      },
+      async resume(): Promise<never> {
+        throw new Error('fixture must not resume')
+      },
+    } satisfies AgentHost
+    const outputDirectory = resolve(directory, 'run')
+    const run = await runAgentTest({
+      outputDirectory,
+      manifest: oneCaseManifest(),
+      profile: { id: 'fixture', origins: ['https://agent.example.test'], auth: [], policy: { allowWrite: false, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false, agentHost: host,
+    }, { browserExecutablePath: browserPath })
+
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).toContain('capability preflight')
+    expect(prompts[0]).not.toContain('primary test engineer')
+    expect(run.state.status).toBe('completed')
+    expect(run.result?.cases[0]).toMatchObject({ outcome: 'blocked', failureSource: 'infrastructure' })
+    expect(run.result?.blockers[0]).toMatch(/没有向模型提供 Auto-Test Control MCP 工具/)
+    expect(JSON.parse(await readFile(resolve(outputDirectory, '.agent-private', 'mutation-ledger.json'), 'utf8'))).toEqual([])
+  })
+
   it('runs an unregistered third-party host through the generic provider runtime contract', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-agent-host-portable-'))
     directories.push(directory)
@@ -378,6 +435,15 @@ process.stdin.on('end', () => {
     const session = {
       id: 'portable-session',
       async run(input: AgentInputPart[]) {
+        if (input[0]?.type === 'text' && input[0].text.includes('capability preflight')) {
+          return {
+            events: (async function* () {
+              yield { type: 'thread_started' as const, threadId: 'portable-session' }
+              yield { type: 'tool_completed' as const, server: 'auto-test-control', tool: 'test_contract', status: 'completed' as const }
+              yield { type: 'agent_message' as const, text: 'preflight complete' }
+            })(),
+          }
+        }
         if (turn === 0) receivedExecutionInput = input
         const text = turn++ === 0 ? 'Portable execution completed.' : JSON.stringify(delivered)
         return {
@@ -677,7 +743,10 @@ process.stdin.on('end', () => {
     }
     const spawnProcess = (() => fakeOmpProcess(directory, (send, promptIndex) => {
       send({ type: 'agent_start' })
-      const text = promptIndex === 0 ? 'fixture execution complete' : JSON.stringify(result)
+      if (promptIndex === 0) {
+        send({ type: 'tool_completed', server: 'auto-test-control', tool: 'test_contract', status: 'completed' })
+      }
+      const text = promptIndex <= 1 ? 'fixture execution complete' : JSON.stringify(result)
       send({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text }] } })
       send({ type: 'agent_end', messages: [] })
     })) as unknown as typeof spawn

--- a/tests/codex-agent-runner.test.ts
+++ b/tests/codex-agent-runner.test.ts
@@ -487,6 +487,40 @@ describe('adaptive Codex epochs', () => {
     expect(run.result?.mutations).toContainEqual(expect.objectContaining({ id: 'pending-write', status: 'pending' }))
   })
 
+  it('fails closed with a structured agent-execution block when the Mutation Ledger is malformed', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-malformed-ledger-'))
+    directories.push(directory)
+    const workflow = manifest()
+    workflow.phases = workflow.phases.slice(0, 1)
+    const files = await fixtureFiles(directory)
+    const outputDirectory = resolve(directory, 'run')
+    const run = await runCodexTestAgent({
+      outputDirectory,
+      manifest: workflow,
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+      agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable, modelProfile: profile(), environment: { FIXTURE_KEY: 'fixture-key' },
+    }, {
+      browserExecutablePath: files.browserPath,
+      startThread: () => ({
+        id: 'thread-malformed-ledger',
+        runStreamed: async (_input, options) => {
+          if (!options?.outputSchema) {
+            await writeFile(resolve(outputDirectory, '.agent-private', 'mutation-ledger.json'), JSON.stringify({ overwritten: true }))
+            return eventStream('execution complete', 'thread-malformed-ledger')
+          }
+          return eventStream(resultFor(workflow, ['case-one']), 'thread-malformed-ledger')
+        },
+      }),
+    })
+
+    expect(run.state.status).toBe('completed')
+    expect(run.result?.outcome).toBe('blocked')
+    expect(run.result?.cases[0]).toMatchObject({ failureSource: 'agent_execution', failureKind: 'execution' })
+    expect(run.result?.blockers[0]).toMatch(/Mutation Ledger is invalid: expected a JSON array/)
+    expect(await readFile(resolve(outputDirectory, 'codex-agent.result.json'), 'utf8')).toContain('Mutation Ledger is invalid')
+  })
+
   it('resumes finalization without replaying the epoch execution turn', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-finalization-resume-'))
     directories.push(directory)

--- a/tests/codex-agent-runner.test.ts
+++ b/tests/codex-agent-runner.test.ts
@@ -507,7 +507,7 @@ describe('adaptive Codex epochs', () => {
         runStreamed: async (_input, options) => {
           if (!options?.outputSchema) {
             await writeFile(resolve(outputDirectory, '.agent-private', 'mutation-ledger.json'), JSON.stringify({ overwritten: true }))
-            return eventStream('execution complete', 'thread-malformed-ledger')
+            return failedEventStream('network connection lost', 'thread-malformed-ledger')
           }
           return eventStream(resultFor(workflow, ['case-one']), 'thread-malformed-ledger')
         },
@@ -519,6 +519,40 @@ describe('adaptive Codex epochs', () => {
     expect(run.result?.cases[0]).toMatchObject({ failureSource: 'agent_execution', failureKind: 'execution' })
     expect(run.result?.blockers[0]).toMatch(/Mutation Ledger is invalid: expected a JSON array/)
     expect(await readFile(resolve(outputDirectory, 'codex-agent.result.json'), 'utf8')).toContain('Mutation Ledger is invalid')
+  })
+
+  it('rejects Mutation Ledger entries with invalid timestamps', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-malformed-ledger-time-'))
+    directories.push(directory)
+    const workflow = manifest()
+    workflow.phases = workflow.phases.slice(0, 1)
+    const files = await fixtureFiles(directory)
+    const outputDirectory = resolve(directory, 'run')
+    const run = await runCodexTestAgent({
+      outputDirectory, manifest: workflow,
+      profile: { id: 'fixture', origins: ['https://tasks.example.test'], auth: [], policy: { allowWrite: true, allowDestructive: false } },
+      secrets: {}, environmentContext: '', imagePaths: [], headed: false,
+      agentSourceHome: files.sourceHome, agentExecutable: files.codexExecutable, modelProfile: profile(), environment: { FIXTURE_KEY: 'fixture-key' },
+    }, {
+      browserExecutablePath: files.browserPath,
+      startThread: () => ({
+        id: 'thread-malformed-ledger-time',
+        runStreamed: async (_input, options) => {
+          if (!options?.outputSchema) {
+            await writeFile(resolve(outputDirectory, '.agent-private', 'mutation-ledger.json'), JSON.stringify([{
+              id: 'invalid-time', caseId: 'case-one', description: 'Fixture write', risk: 'write', status: 'compensated',
+              createdAt: 'not-a-date', updatedAt: '2026-08-08T00:00:00.000Z', evidence: ['evidence/fixture.txt'],
+            }]))
+            return eventStream('execution complete', 'thread-malformed-ledger-time')
+          }
+          return eventStream(resultFor(workflow, ['case-one']), 'thread-malformed-ledger-time')
+        },
+      }),
+    })
+
+    expect(run.result?.outcome).toBe('blocked')
+    expect(run.result?.cases[0]).toMatchObject({ failureSource: 'agent_execution' })
+    expect(run.result?.blockers[0]).toMatch(/entry 0 does not match the run contract/)
   })
 
   it('resumes finalization without replaying the epoch execution turn', async () => {


### PR DESCRIPTION
## Summary\n\n- require every real AgentHost session to prove the model can call auto-test-control.test_contract before sending the business execution prompt\n- validate the authoritative Mutation Ledger at runtime and fail closed as agent_execution instead of crashing on malformed artifacts\n- document the Windows acceptance boundary and add AgentHost/runner regressions\n\n## Verification\n\n- npm run check\n- focused AgentHost and adaptive runner tests\n- git diff --check\n- local OpenCodeReview delegation: 1/1 reviewable core file covered; excluded tests and docs reviewed manually; no unresolved findings\n\n## Acceptance boundary\n\nThis change prevents an incompatible Provider/AgentHost from entering the normal business prompt and preserves a structured result when the Ledger contract is damaged. It does not claim that the current third-party Windows Provider supports local MCP tools or that the charging canary has passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增真实 AgentHost 启动前的只读 Control MCP 能力预检。
  - 会话轮换后自动重新执行预检，确保浏览器探索和业务操作具备必要能力。

- **错误处理**
  - 缺少预检时生成基础设施阻塞结果。
  - Mutation Ledger 格式非法或损坏时生成结构化阻塞结果，并保留明确原因。
  - 即使 Ledger 读取失败，也会持久化最终错误结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->