### PR TITLE
fix(launcher): clean Chromium-download prompt instead of red stderr error

### DIFF
--- a/scripts/launch-windows.ps1
+++ b/scripts/launch-windows.ps1
@@ -799,15 +799,18 @@ function Test-PlaywrightChromiumReady {
   if (-not $script:NodeExecutable -or -not (Test-Path $script:NodeExecutable)) { return $false }
   $browserCheck = Join-Path $RepositoryRoot 'scripts\check-playwright-browser.cjs'
   if (-not (Test-Path $browserCheck)) { return $false }
+  # A missing or unlaunchable browser is an expected condition on first run.
+  # Suppress the probe's stderr so it does not render as a red native-command
+  # error; the caller prints a normal informational message and downloads
+  # Chromium when this returns false.
   $previousErrorActionPreference = $ErrorActionPreference
   try {
-    $ErrorActionPreference = 'Continue'
-    $checkOutput = (& $script:NodeExecutable $browserCheck 2>&1 | Out-String).Trim()
+    $ErrorActionPreference = 'SilentlyContinue'
+    $checkOutput = (& $script:NodeExecutable $browserCheck 2>$null | Out-String).Trim()
   } finally {
     $ErrorActionPreference = $previousErrorActionPreference
   }
   if ($checkOutput -match '(?m)^AUTO_TEST_CHROMIUM_READY\s*$') { return $true }
-  if ($checkOutput) { Write-Host $checkOutput }
   return $false
 }
 
@@ -821,6 +824,7 @@ function Ensure-ProjectRuntime {
 
   $browserReady = Test-PlaywrightChromiumReady
   if (-not $browserReady) {
+    Write-Host '[安装] Chromium 未安装,开始下载……'
     Install-PlaywrightChromium
     if (-not (Test-PlaywrightChromiumReady)) {
       throw 'Chromium 安装命令已结束，但没有找到可用的浏览器文件。'


### PR DESCRIPTION
## Summary

On a fresh Windows machine the Playwright Chromium probe is expected to fail (the browser is not installed yet), but the probe wrote its "Chromium readiness check failed" message to **stderr**. PowerShell's `2>&1` rendered that as a red `NativeCommandError`, which looks like a real failure even though the launcher immediately proceeds to download Chromium.

Reported during a first-run setup on a new Windows machine, where the red error confused the user even though the download was progressing normally.

## Changes (`scripts/launch-windows.ps1`)

- `Test-PlaywrightChromiumReady`: redirect the probe's stderr to `$null` and use `SilentlyContinue` so a missing/unlaunchable browser does not render as a red native-command error; stop echoing the captured error text.
- `Ensure-ProjectRuntime`: print a normal `[安装] Chromium 未安装,开始下载……` line before `Install-PlaywrightChromium` when the probe returns false.

The expected `[OK] Auto-Test 项目依赖和浏览器已就绪` message after a successful download is unchanged.

## Verification

- `npm run check`: typecheck clean, **400 tests pass** (48 files), build clean.
- The `windows-launcher` test asserting `if (Test-PlaywrightChromiumReady)` is preserved.
- Windows `windows-verify` CI runs the launcher bootstrap as the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)