### PR TITLE
fix: stop reading completed agent turns

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -124,6 +124,7 @@ async function runTurn(
         throw new AgentHostError(hostId, event.message ?? 'AgentHost session is incompatible with the current model binding', 'session_incompatible')
       }
       if (event.type === 'error' && !isNonFatalAgentHostError(event.message ?? '')) throw new Error(event.message ?? 'agent host error')
+      if (event.type === 'turn_completed') break
     }
     if (!finalResponse) throw new Error('Agent host returned no final response')
     return finalResponse

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -373,6 +373,8 @@ process.stdin.on('end', () => {
               events: (async function* () {
                 yield { type: 'thread_started' as const, threadId: 'portable-no-control-mcp' }
                 yield { type: 'agent_message' as const, text: 'No Control MCP tool is available.' }
+                yield { type: 'turn_completed' as const }
+                throw new Error('terminal AgentHost events must end turn consumption')
               })(),
             }
           },


### PR DESCRIPTION
## Summary

- stop consuming an AgentHost event stream after its terminal turn_completed event
- preserve the existing fail-closed Control MCP preflight when a provider leaves the stream open
- cover a host that emits the terminal event and then fails if Core requests another event

## Verification

- targeted AgentHost tests: 18 passed
- full npm run check: 48 files, 404 tests; typecheck and build passed
- Windows eaadf5e canary reproduced the issue before this fix: terminal event observed, no Control MCP/browser/business action, empty Mutation Ledger, manual interruption produced blocked / infrastructure

## Documentation

No command or product contract changed. The Windows runbooks already state that a failed Control MCP capability preflight must fail closed as blocked / infrastructure; this fix makes the implementation reach that documented terminal state when a provider does not close its event stream.
