### PR TITLE
fix: bridge Codex MCP tools for flat Responses providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ npm run agent:test -- --file cases.xlsx --url https://app.example.test/ --profil
 
 `deepseek` 使用 `deepseek-v4-flash @ https://api.deepseek.com`；`volcengine` 使用 `glm-5.2 @ https://ark.cn-beijing.volces.com/api/coding/v3`，并同时识别 `ARK_API_KEY`、`VOLCENGINE_API_KEY` 和 `VOLCENGINE_ARK_API_KEY`。同一 Profile 可交给 `--agent-host codex` 或 `--agent-host omp`：Codex 以当前安装版 CLI 的 bundled catalog 为模板生成 `config.toml` 与完整 `models.json`，保留原生 agent instructions 并覆盖 Profile 能力；OMP 生成 `models.yml`，不会把宿主格式泄漏到 Core。两个内置模型目前都声明为文本输入；补充图片会保留在 run 工作区并在提示中给出路径，不会作为 Provider 会静默忽略的 inline image 发送。选择优先级是显式 `--model-profile`、恢复记录、自定义注册表的 `defaultProfileId`、内置 `deepseek`；注册表中的同名 `deepseek` 可覆盖内置公开元数据。模型 ID 是否已在订阅中开放仍以 Provider 的真实响应为准；必要时用自定义注册表或 `--model` 覆盖。容量不足会被归类为可恢复的 `infrastructure` 阻断：切换 Profile 后，以原 `--output-dir` 执行 `--resume`；裸恢复会复用上次有效的 Profile 和 `--model`，显式传入新值才会切换。升级前创建且没有 `model-selection.json` 的旧 Run 在裸恢复时继续使用原 AgentHost Provider，避免迁移后静默换模。已经写入逐 case 结果库的 case 不会重跑。详见 [跨场景自动化测试快速操作指南](docs/quick-start.md)。
 
+受管 Codex Profile 会在 AgentHost 边界把 Codex namespace MCP 工具转换为标准 Responses function tools，再把 Provider 的调用恢复给 Codex。第三方 Provider 不必实现 Codex 的 namespace 扩展，但必须支持标准 function tools、SSE 和工具结果续传。每个物理线程仍必须通过只读 `auto-test-control.test_contract` 能力预检；模型探针或旧包绕过 MCP 得到的页面结果不能替代该门。
+
 ## Legacy IR/Runtime
 
 以下 Phase 1 到 Phase 5 文档描述旧的 IR/Runtime 工具链。它仍保留用于兼容、审计和后续稳定回归加速，但不是新场景的默认首次执行路线。通过 `npm run easy -- run ... --legacy-runtime` 才会显式启动旧自治链路。

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -75,6 +75,8 @@ Provider 选择在 AgentHost 边界完成。Core 只传递 `AgentModelProviderDe
 
 新 Run 默认选择 `deepseek`，无论选用 Codex 还是 OMP；显式传入 `--model-profile volcengine` 可切换火山，显式参数、自定义注册表的 `defaultProfileId` 和同名 `deepseek` 定义都能覆盖内置默认元数据。Windows 私有包若使用其他 endpoint/model，会在当前启动进程发布一个不含 Key 的 `windows-private` 默认 Profile；精确匹配内置 DeepSeek 时则保留内置推理、容量和输入模态元数据。API Key 必须由当前进程环境提供，缺失时适配器会在模型请求前 fail closed。裸 `--resume` 优先复用 `model-selection.json` 中的 Profile 与模型覆盖；升级前没有该文件的旧 Run 继续使用原 AgentHost Provider，以避免迁移后静默换模。供应商是否开放精确模型 ID、账号额度和结构化输出兼容性仍需用真实 Provider canary 验证，不能由配置解析通过推断。
 
+Codex 使用受管 Model Profile 时，会在 AgentHost 内启动仅监听 `127.0.0.1` 的 Responses 工具兼容桥。Codex CLI 发出的 namespace MCP 工具会在请求边界展开为标准 Responses `function` 工具，Provider 返回的调用再恢复为 Codex 可路由的 namespace 调用；API Key 只作为请求头经过内存转发，不写入桥接日志或文件。第三方 Provider 因此不必实现 Codex 的 namespace 扩展，但至少必须正确支持标准 Responses function tools、流式 SSE、工具结果续传以及所选模型的工具调用。未选择 Model Profile 的 native Codex 配置不经过这层桥接，其 Provider 必须自行兼容 Codex 原生工具协议。
+
 ## OMP 前置条件
 
 Auto-Test 不把 OMP 二进制或用户 OMP 配置复制进仓库或公开包。内部私有 Windows 包可以携带一个默认 Provider 的一次性引导凭据；首次启动会导入 DPAPI 并删除解压目录中的明文文件，随后 Codex 或 OMP 都可消费对应 Model Profile。使用 OMP 前仍需在测试机安装 `omp` 并确认 `omp --version` 能运行。选择 Auto-Test `--model-profile` 时，OMP 适配器在私有 `agentHome/models.yml` 中生成本次 Profile，并通过选定环境变量认证；不选择 Profile 的 legacy/native Run 才会复制 OMP 自身的 provider/auth 文件。两种路径都会设置 `PI_CODING_AGENT_DIR` 与隔离 session 目录，不继承调用者的 OMP profile、用户 MCP、插件或历史 session。Auto-Test 会在每个 run 工作区生成 `.omp/mcp.json`，其中只包含本次 Playwright 和 `auto-test-control` MCP 的隔离命令与路径；不会复用用户的 Codex MCP 配置。
@@ -108,7 +110,7 @@ Provider 探针通过只证明宿主启动层；不能替代真实页面执行�
 
 真实 AgentHost 在每个物理执行线程的第一轮业务提示前，会先发送一次只读能力预检。Core 必须在归一化事件流中观察到恰好一次已完成的 `auto-test-control.test_contract` `tool_completed` 事件，且不能出现其他工具、shell 命令或文件改动事件，才会发送浏览器探索和业务执行提示；模型的文字声称、`list_mcp_resources` 结果、Provider 探针通过或宿主静态 `mcp: true` 能力声明都不算预检通过。未满足该合同时，Run 会直接生成 `blocked` 的 `infrastructure` 结果，并说明 Provider/AgentHost 没有正确提供 Control MCP 工具。
 
-这条预检只验证工具通道和不可变契约，不解释业务语义、规划步骤或裁决结果。它尤其用于识别“Control MCP 进程本身正常，但第三方 Responses Provider 丢弃本地工具定义”的兼容性问题。更换兼容 Provider 后，应在同一输入和环境下重新执行；未发生业务写入的预检阻断可以直接从原目录恢复。
+这条预检只验证工具通道和不可变契约，不解释业务语义、规划步骤或裁决结果。受管 Codex Profile 已把 namespace 工具转换为标准 function；若预检仍失败，应分别检查本地 MCP 启动、Provider 的标准 function/SSE/工具结果协议和模型是否实际发起工具调用。旧包在没有预检时通过 shell 或临时脚本得到的 `passed` 不能证明 Control MCP 通道可用。修复基础设施后，应在同一输入和环境下重新执行；未发生业务写入的预检阻断可以从原目录恢复。
 
 Core 读取 `.agent-private/mutation-ledger.json` 时会运行时验证其必须是合法数组且每个条目符合 Ledger 合同。Agent 或辅助脚本把该文件覆盖为对象、坏 JSON 或不完整条目时，结果会 fail closed 为 `agent_execution` blocked，并保留明确的制品违规原因；不会再因 `.some()` 等类型错误丢失权威结果文件。只有 Control MCP 登记的 Ledger 才是业务写入事实源。
 

--- a/docs/windows-acceptance-runbook.md
+++ b/docs/windows-acceptance-runbook.md
@@ -36,7 +36,7 @@ Linux/macOS 的 Codex 运行时只会把本次 Run 的 `.agent-private` 作为 s
 
 Windows 默认 Provider 的模型 API 探针最多等待 120 秒，并在长时间等待时输出心跳。stdout/stderr 使用本次探针的临时文件捕获，后台继承句柄不会让已退出的主进程继续占用启动窗口；只有 Codex/API 调用本身未结束才会触发超时、恢复上一版 Provider 配置并明确报错。stdout+stderr 总量超过 4 MiB 同样会终止进程树、回滚配置并清理捕获文件。这不是业务测试结果。OMP 和显式 Model Profile 不运行该 Codex 默认探针，而是在 AgentHost 运行前准备自己的 Provider 绑定；两者都必须用真实 canary 验证协议、鉴权和模型能力。只有已经确认网关健康但首个响应确实较慢时，才为单次诊断临时设置 `AUTO_TEST_CODEX_PROBE_TIMEOUT_SECONDS`（1 到 3600），不要用它掩盖额度、限流、网络或流式响应故障。
 
-启动层通过后，真实 AgentHost 还必须在第一个业务执行提示前完成只读 Control MCP 预检。验收时从 `codex-agent.events.jsonl` 精确确认恰好一次 `server=auto-test-control`、`tool=test_contract` 且 `status=completed` 的事件，并且该预检回合没有其他工具、shell 命令或文件改动事件；否则不能宣称业务通过，框架应生成 `blocked` 且 `failureSource=infrastructure` 的结构化结果。该门只确认 MCP 工具通道可用，不替代页面执行、业务断言或 Ledger 验收。
+启动层通过后，真实 AgentHost 还必须在第一个业务执行提示前完成只读 Control MCP 预检。受管 Codex Model Profile 会自动通过本机 loopback 桥把 namespace MCP 工具转换为 Provider 标准 function tools。验收时从 `codex-agent.events.jsonl` 精确确认恰好一次 `server=auto-test-control`、`tool=test_contract` 且 `status=completed` 的事件，并且该预检回合没有其他工具、shell 命令或文件改动事件；否则不能宣称业务通过，框架应生成 `blocked` 且 `failureSource=infrastructure` 的结构化结果。若仍提示工具不可用，依次检查本地 MCP 是否启动、Provider 是否支持标准 Responses function/SSE/工具结果续传、模型是否实际调用工具；不要用旧包绕过预检后的 `passed` 代替这项验收。该门只确认 MCP 工具通道可用，不替代页面执行、业务断言或 Ledger 验收。
 
 如果默认 Key 额度不足，但另一个 Key 使用同一个 Provider Base URL，可在本次验收命令中临时指定：
 

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -118,7 +118,7 @@ Windows 上的 Codex CLI 0.146.0 对 `workspace-write` 的原生策略会拒绝�
 
 Linux x64 已按“默认 Codex 执行并清理，再由 OMP 在同一输入合同上单独执行”的顺序完成一次真实写入型 canary；Windows 仍须独立复验。OMP 的结果必须同时保留 `agent-host-selection.json` 中的 `workspaceIsolation: prompt_only`，不能因结果为 `passed` 就宣称其具备 Codex 同等级的操作系统隔离。
 
-发送真实页面探索和业务执行提示前，Windows 每个 Codex/OMP 物理线程都会先执行一次只读 Control MCP 能力预检。必须在 `codex-agent.events.jsonl` 中看到恰好一次已完成的 `auto-test-control.test_contract` 调用且没有其他工具、shell 命令或文件改动事件；只看到 Provider 探针成功、浏览器打开或模型说“已读取契约”都不够。若预检未满足该合同，框架会返回 `blocked / infrastructure`，通常表示当前 Provider 的工具调用兼容性不足，应切换到支持本地 MCP 工具的 Model Profile 后用原输出目录恢复。
+发送真实页面探索和业务执行提示前，Windows 每个 Codex/OMP 物理线程都会先执行一次只读 Control MCP 能力预检。必须在 `codex-agent.events.jsonl` 中看到恰好一次已完成的 `auto-test-control.test_contract` 调用且没有其他工具、shell 命令或文件改动事件；只看到 Provider 探针成功、浏览器打开或模型说“已读取契约”都不够。若预检未满足该合同，框架会返回 `blocked / infrastructure`；应依次检查本地 MCP 启动、Provider 的标准 function/SSE/工具结果续传协议和模型工具调用能力，修复后用原输出目录恢复。
 
 每个 Codex Run 都会关闭 Apps、插件和远程插件目录，避免隔离 Agent Home 首次启动时同步 marketplace 或引入无关工具；测试能力只来自 Auto-Test 注入的 Playwright 和 Control MCP。
 

--- a/docs/windows-quick-start.md
+++ b/docs/windows-quick-start.md
@@ -45,6 +45,8 @@ supports_websockets = false
 
 Node.js 和 Codex CLI 都安装在 `%APPDATA%\auto-test\tools`，Codex 配置保存在 `%APPDATA%\auto-test\codex-home`。整个过程不需要管理员权限，不会安装或覆盖电脑上的全局 Node/Codex，也不会修改已有的 `%USERPROFILE%\.codex`。API Key 使用 Windows DPAPI 加密保存，仅当前 Windows 用户能够解密；启动时加载到 Auto-Test 当前进程的 `AUTO_TEST_MODEL_API_KEY`。只有 Base URL 去除尾部 `/` 后等于 `https://api.deepseek.com` 且模型等于 `deepseek-v4-flash` 时，启动器才在同一进程额外设置 `DEEPSEEK_API_KEY`，让完整的内置 DeepSeek Profile 复用该 Key。其他 endpoint/model 会发布一个不含 Key 的进程级 `windows-private` Profile，Codex 和 OMP 都通过各自适配器消费它；Key 不会被映射给 DeepSeek，也不会写入仓库、TOML 或明文用户环境变量。
 
+Windows 默认 Provider 和显式 Codex Model Profile 都属于受管 Profile。Codex AgentHost 会自动用本机 loopback 兼容桥把 Codex namespace MCP 工具转换为标准 Responses function tools，因此兼容 Provider 不需要实现 Codex 私有 namespace 扩展；Provider 仍必须支持标准 function tools、SSE 流和工具结果续传。该桥只监听 `127.0.0.1`，不记录 Key。模型探针只能证明最小模型请求可用，真实 Run 开始前的 Control MCP 能力预检才证明工具链可用。
+
 旧版本如果检测到 `cliproxyapi` 配置，会自动改用上述直连接入。只有本次使用 Codex 默认 Windows Provider 时才运行该探针；显式 `--model-profile` 不会被无关的旧默认 Provider 阻断，OMP 也不运行 Codex 专用探针。新默认配置通过探针后才会替换旧配置，验证失败会自动恢复。探针默认最多等待 120 秒，等待超过 20 秒后会持续显示安全心跳。stdout/stderr 写入本次探针的临时捕获文件，主进程退出后直接读取当前快照；因此脱离父进程的继承输出句柄不会延长探针等待，模型服务或流式响应本身卡住时仍会按上限终止并给出网络/Provider 诊断。单次探针的 stdout+stderr 上限为 4 MiB，异常超量会终止进程树、回滚 Provider 并清理捕获文件。
 
 只有确认私有网关正常但响应时间确实超过 120 秒时，才临时调高等待时间；取值范围为 1 到 3600 秒。这个参数不会修复额度不足、限流或断流，不应作为日常配置：

--- a/src/agent/codex-host.ts
+++ b/src/agent/codex-host.ts
@@ -14,6 +14,7 @@ import type {
 import { AgentHostError, isAgentSessionIncompatibleMessage, normalizeAgentEvent } from './host.js'
 import { resolveCodexExecutable } from './codex-executable.js'
 import { CodexModelProviderAdapter } from './codex-provider.js'
+import { startResponsesToolBridge, type ResponsesToolBridge } from './responses-tool-bridge.js'
 import { controlServerPath, packageFilePath } from './runtime-paths.js'
 
 const require = createRequire(import.meta.url)
@@ -118,7 +119,7 @@ export function codexWebSearchEnabled(runtime: AgentHostLaunchOptions['runtime']
 }
 
 export function startCodexSdkThread(
-  options: AgentHostLaunchOptions,
+  options: AgentHostLaunchOptions & { providerBaseUrlOverride?: string },
   platform: NodeJS.Platform = process.platform,
 ): Thread {
   if (!options.executable) throw new AgentHostError('codex', 'Codex executable was not resolved before starting a thread', 'configuration')
@@ -155,6 +156,11 @@ export function startCodexSdkThread(
         memories: false,
       },
       tools: { web_search: webSearchEnabled },
+      ...(options.providerBaseUrlOverride && options.runtime.provider ? {
+        model_providers: {
+          [options.runtime.provider.providerId]: { base_url: options.providerBaseUrlOverride },
+        },
+      } : {}),
       mcp_servers: {
         playwright: playwrightServer,
         'auto-test-control': {
@@ -192,7 +198,12 @@ export function startCodexSdkThread(
 }
 
 class CodexSession implements AgentHostSession {
-  constructor(private readonly thread: CodexThreadLike) {}
+  private closed = false
+
+  constructor(
+    private readonly thread: CodexThreadLike,
+    private readonly bridge?: ResponsesToolBridge,
+  ) {}
 
   get id(): string | null {
     return this.thread.id
@@ -214,6 +225,12 @@ class CodexSession implements AgentHostSession {
         }
       })(),
     }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return
+    this.closed = true
+    await this.bridge?.close()
   }
 }
 
@@ -248,14 +265,27 @@ export class CodexAgentHost implements AgentHost {
       : { ok: false, hostId: this.id, reason: reason ?? 'Codex CLI executable is unavailable' }
   }
 
-  async start(options: AgentHostLaunchOptions): Promise<AgentHostSession> {
+  private async open(options: AgentHostLaunchOptions): Promise<AgentHostSession> {
     const executable = await resolveCodexExecutable(options.executable, options.runtime.environment)
-    return new CodexSession(startCodexSdkThread({ ...options, executable }))
+    const bridge = options.runtime.provider ? await startResponsesToolBridge(options.runtime.provider.baseUrl) : undefined
+    try {
+      return new CodexSession(startCodexSdkThread({
+        ...options,
+        executable,
+        ...(bridge ? { providerBaseUrlOverride: bridge.baseUrl } : {}),
+      }), bridge)
+    } catch (error) {
+      await bridge?.close()
+      throw error
+    }
+  }
+
+  async start(options: AgentHostLaunchOptions): Promise<AgentHostSession> {
+    return this.open(options)
   }
 
   async resume(options: AgentHostLaunchOptions & { resumeId: string }): Promise<AgentHostSession> {
-    const executable = await resolveCodexExecutable(options.executable, options.runtime.environment)
-    return new CodexSession(startCodexSdkThread({ ...options, executable }))
+    return this.open(options)
   }
 }
 

--- a/src/agent/responses-tool-bridge.ts
+++ b/src/agent/responses-tool-bridge.ts
@@ -1,0 +1,258 @@
+import { createHash } from 'node:crypto'
+import { createServer, type IncomingHttpHeaders, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+const MAX_REQUEST_BYTES = 32 * 1024 * 1024
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection', 'content-encoding', 'content-length', 'keep-alive', 'proxy-authenticate',
+  'proxy-authorization', 'te', 'trailer', 'transfer-encoding', 'upgrade',
+])
+
+interface ToolIdentity {
+  namespace: string
+  name: string
+}
+
+export interface ResponsesToolMapping {
+  flatToNamespaced: Map<string, ToolIdentity>
+  namespacedToFlat: Map<string, string>
+}
+
+export interface ResponsesToolBridge {
+  baseUrl: string
+  close(): Promise<void>
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function namespacedKey(namespace: string, name: string): string {
+  return `${namespace}\u0000${name}`
+}
+
+function flatToolName(namespace: string, name: string, used: Set<string>): string {
+  const raw = `${namespace}__${name}`.replace(/[^A-Za-z0-9_-]/g, '_')
+  let candidate = raw.slice(0, 64)
+  if (raw.length > 64 || used.has(candidate)) {
+    const suffix = createHash('sha256').update(`${namespace}\u0000${name}`).digest('hex').slice(0, 12)
+    candidate = `${raw.slice(0, 51)}_${suffix}`
+  }
+  if (!candidate || used.has(candidate)) throw new Error(`Cannot uniquely flatten Responses tool ${namespace}.${name}`)
+  used.add(candidate)
+  return candidate
+}
+
+function rewriteFunctionCalls(value: unknown, mapping: ResponsesToolMapping, direction: 'flatten' | 'restore'): void {
+  if (Array.isArray(value)) {
+    for (const item of value) rewriteFunctionCalls(item, mapping, direction)
+    return
+  }
+  const item = record(value)
+  if (!item) return
+  if (item.type === 'function_call' && typeof item.name === 'string') {
+    if (direction === 'flatten' && typeof item.namespace === 'string') {
+      const flat = mapping.namespacedToFlat.get(namespacedKey(item.namespace, item.name))
+      if (!flat) throw new Error(`Responses history references an unavailable tool ${item.namespace}.${item.name}`)
+      item.name = flat
+      delete item.namespace
+    } else if (direction === 'restore' && item.namespace === undefined) {
+      const identity = mapping.flatToNamespaced.get(item.name)
+      if (identity) {
+        item.namespace = identity.namespace
+        item.name = identity.name
+      }
+    }
+  }
+  for (const child of Object.values(item)) rewriteFunctionCalls(child, mapping, direction)
+}
+
+/** Convert Codex namespace tools into the standard flat Responses function surface. */
+export function flattenResponsesTools(request: Record<string, unknown>): ResponsesToolMapping {
+  const mapping: ResponsesToolMapping = { flatToNamespaced: new Map(), namespacedToFlat: new Map() }
+  const tools = Array.isArray(request.tools) ? request.tools : []
+  const used = new Set(tools.flatMap((value) => {
+    const tool = record(value)
+    return typeof tool?.name === 'string' && tool.type !== 'namespace' ? [tool.name] : []
+  }))
+  const flattened: unknown[] = []
+
+  for (const value of tools) {
+    const namespace = record(value)
+    if (namespace?.type !== 'namespace') {
+      flattened.push(value)
+      continue
+    }
+    if (typeof namespace.name !== 'string' || !Array.isArray(namespace.tools)) {
+      throw new Error('Responses namespace tool is missing its name or child tools')
+    }
+    for (const childValue of namespace.tools) {
+      const child = record(childValue)
+      if (child?.type !== 'function' || typeof child.name !== 'string') {
+        throw new Error(`Responses namespace ${namespace.name} contains a non-function tool`)
+      }
+      const flat = flatToolName(namespace.name, child.name, used)
+      const identity = { namespace: namespace.name, name: child.name }
+      mapping.flatToNamespaced.set(flat, identity)
+      mapping.namespacedToFlat.set(namespacedKey(identity.namespace, identity.name), flat)
+      const namespaceDescription = typeof namespace.description === 'string' ? namespace.description.trim() : ''
+      const childDescription = typeof child.description === 'string' ? child.description.trim() : ''
+      flattened.push({
+        type: 'function',
+        name: flat,
+        description: [namespaceDescription, childDescription].filter(Boolean).join('\n\n'),
+        strict: child.strict === true,
+        parameters: record(child.parameters) ?? { type: 'object', properties: {} },
+      })
+    }
+  }
+
+  request.tools = flattened
+  rewriteFunctionCalls(request.input, mapping, 'flatten')
+  return mapping
+}
+
+/** Restore flat provider calls so Codex can route them to the original MCP server. */
+export function restoreResponsesToolCalls(value: unknown, mapping: ResponsesToolMapping): unknown {
+  rewriteFunctionCalls(value, mapping, 'restore')
+  return value
+}
+
+function upstreamResponsesUrl(baseUrl: string): URL {
+  const url = new URL(baseUrl)
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/responses`
+  url.hash = ''
+  return url
+}
+
+async function readRequest(request: AsyncIterable<Uint8Array>): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  let bytes = 0
+  for await (const chunk of request) {
+    const buffer = Buffer.from(chunk)
+    bytes += buffer.length
+    if (bytes > MAX_REQUEST_BYTES) throw new Error('Responses request exceeds 32 MiB')
+    chunks.push(buffer)
+  }
+  return Buffer.concat(chunks)
+}
+
+function forwardedHeaders(headers: IncomingHttpHeaders): Headers {
+  const result = new Headers()
+  for (const [name, values] of Object.entries(headers)) {
+    if (HOP_BY_HOP_HEADERS.has(name.toLowerCase()) || values === undefined) continue
+    for (const value of Array.isArray(values) ? values : [values]) result.append(name, value)
+  }
+  result.set('content-type', 'application/json')
+  return result
+}
+
+function copyResponseHeaders(source: Headers, target: import('node:http').ServerResponse): void {
+  source.forEach((value, name) => {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) target.setHeader(name, value)
+  })
+}
+
+function rewriteSseLine(line: string, mapping: ResponsesToolMapping): string {
+  const match = /^(data:\s*)(.*)$/.exec(line)
+  if (!match || match[2] === '[DONE]') return line
+  try {
+    const value = JSON.parse(match[2]!) as unknown
+    return `${match[1]}${JSON.stringify(restoreResponsesToolCalls(value, mapping))}`
+  } catch {
+    return line
+  }
+}
+
+async function pipeSse(
+  body: ReadableStream<Uint8Array>,
+  response: import('node:http').ServerResponse,
+  mapping: ResponsesToolMapping,
+): Promise<void> {
+  const decoder = new TextDecoder()
+  let pending = ''
+  for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+    pending += decoder.decode(chunk, { stream: true })
+    let newline = pending.indexOf('\n')
+    while (newline >= 0) {
+      const line = pending.slice(0, newline).replace(/\r$/, '')
+      response.write(`${rewriteSseLine(line, mapping)}\n`)
+      pending = pending.slice(newline + 1)
+      newline = pending.indexOf('\n')
+    }
+  }
+  pending += decoder.decode()
+  if (pending) response.write(rewriteSseLine(pending.replace(/\r$/, ''), mapping))
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return
+  server.closeAllConnections()
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+}
+
+/**
+ * Loopback-only transport bridge for Responses-compatible providers that
+ * implement standard function tools but not Codex's namespace extension.
+ */
+export async function startResponsesToolBridge(upstreamBaseUrl: string): Promise<ResponsesToolBridge> {
+  const upstreamUrl = upstreamResponsesUrl(upstreamBaseUrl)
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.method !== 'POST' || request.url !== '/responses') {
+        response.writeHead(404).end()
+        return
+      }
+      const body = JSON.parse((await readRequest(request)).toString('utf8')) as unknown
+      const payload = record(body)
+      if (!payload) throw new Error('Responses request body must be a JSON object')
+      const mapping = flattenResponsesTools(payload)
+      const upstream = await fetch(upstreamUrl, {
+        method: 'POST',
+        headers: forwardedHeaders(request.headers),
+        body: JSON.stringify(payload),
+        redirect: 'manual',
+      })
+      response.statusCode = upstream.status
+      copyResponseHeaders(upstream.headers, response)
+      if (!upstream.body) {
+        response.end()
+        return
+      }
+      if (upstream.headers.get('content-type')?.includes('text/event-stream')) {
+        await pipeSse(upstream.body, response, mapping)
+      } else {
+        const text = await upstream.text()
+        try {
+          response.write(JSON.stringify(restoreResponsesToolCalls(JSON.parse(text) as unknown, mapping)))
+        } catch {
+          response.write(text)
+        }
+      }
+      response.end()
+    } catch (error) {
+      if (response.headersSent) {
+        response.destroy(error instanceof Error ? error : undefined)
+        return
+      }
+      response.writeHead(502, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ error: { message: error instanceof Error ? error.message : String(error) } }))
+    }
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+  let closed = false
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    async close() {
+      if (closed) return
+      closed = true
+      await closeServer(server)
+    },
+  }
+}

--- a/src/agent/responses-tool-bridge.ts
+++ b/src/agent/responses-tool-bridge.ts
@@ -166,6 +166,32 @@ function rewriteSseLine(line: string, mapping: ResponsesToolMapping): string {
   }
 }
 
+async function writeResponse(
+  response: import('node:http').ServerResponse,
+  chunk: string,
+): Promise<boolean> {
+  if (response.destroyed || response.writableEnded) return false
+  if (response.write(chunk)) return true
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      response.off('drain', onDrain)
+      response.off('close', onClose)
+      response.off('error', onClose)
+    }
+    const onDrain = () => {
+      cleanup()
+      resolve(true)
+    }
+    const onClose = () => {
+      cleanup()
+      resolve(false)
+    }
+    response.once('drain', onDrain)
+    response.once('close', onClose)
+    response.once('error', onClose)
+  })
+}
+
 async function pipeSse(
   body: ReadableStream<Uint8Array>,
   response: import('node:http').ServerResponse,
@@ -174,17 +200,18 @@ async function pipeSse(
   const decoder = new TextDecoder()
   let pending = ''
   for await (const chunk of body as unknown as AsyncIterable<Uint8Array>) {
+    if (response.destroyed || response.writableEnded) return
     pending += decoder.decode(chunk, { stream: true })
     let newline = pending.indexOf('\n')
     while (newline >= 0) {
       const line = pending.slice(0, newline).replace(/\r$/, '')
-      response.write(`${rewriteSseLine(line, mapping)}\n`)
+      if (!await writeResponse(response, `${rewriteSseLine(line, mapping)}\n`)) return
       pending = pending.slice(newline + 1)
       newline = pending.indexOf('\n')
     }
   }
   pending += decoder.decode()
-  if (pending) response.write(rewriteSseLine(pending.replace(/\r$/, ''), mapping))
+  if (pending) await writeResponse(response, rewriteSseLine(pending.replace(/\r$/, ''), mapping))
 }
 
 async function closeServer(server: Server): Promise<void> {
@@ -200,6 +227,10 @@ async function closeServer(server: Server): Promise<void> {
 export async function startResponsesToolBridge(upstreamBaseUrl: string): Promise<ResponsesToolBridge> {
   const upstreamUrl = upstreamResponsesUrl(upstreamBaseUrl)
   const server = createServer(async (request, response) => {
+    const controller = new AbortController()
+    const abortUpstream = () => controller.abort()
+    request.once('aborted', abortUpstream)
+    response.once('close', abortUpstream)
     try {
       if (request.method !== 'POST' || request.url !== '/responses') {
         response.writeHead(404).end()
@@ -214,6 +245,7 @@ export async function startResponsesToolBridge(upstreamBaseUrl: string): Promise
         headers: forwardedHeaders(request.headers),
         body: JSON.stringify(payload),
         redirect: 'manual',
+        signal: controller.signal,
       })
       response.statusCode = upstream.status
       copyResponseHeaders(upstream.headers, response)
@@ -226,19 +258,23 @@ export async function startResponsesToolBridge(upstreamBaseUrl: string): Promise
       } else {
         const text = await upstream.text()
         try {
-          response.write(JSON.stringify(restoreResponsesToolCalls(JSON.parse(text) as unknown, mapping)))
+          await writeResponse(response, JSON.stringify(restoreResponsesToolCalls(JSON.parse(text) as unknown, mapping)))
         } catch {
-          response.write(text)
+          await writeResponse(response, text)
         }
       }
-      response.end()
+      if (!response.destroyed && !response.writableEnded) response.end()
     } catch (error) {
+      if (response.destroyed) return
       if (response.headersSent) {
         response.destroy(error instanceof Error ? error : undefined)
         return
       }
       response.writeHead(502, { 'content-type': 'application/json' })
       response.end(JSON.stringify({ error: { message: error instanceof Error ? error.message : String(error) } }))
+    } finally {
+      request.off('aborted', abortUpstream)
+      response.off('close', abortUpstream)
     }
   })
   await new Promise<void>((resolve, reject) => {

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -271,8 +271,8 @@ function isMutationLedgerViolation(message: string): boolean {
 function infrastructureBlockDetails(message: string): { reason: string; nextAction: string } {
   if (/control mcp capability preflight/i.test(message)) {
     return {
-      reason: '当前 Provider/AgentHost 没有向模型提供 Auto-Test Control MCP 工具。',
-      nextAction: '切换到已验证支持本地 MCP 工具调用的 Provider/AgentHost 后，使用原结果目录继续上次测试。',
+      reason: 'Control MCP 能力预检未观察到唯一且合规的 test_contract 调用。',
+      nextAction: '检查本地 MCP 启动、Provider 的标准 function/SSE/工具结果协议和模型工具调用能力后，使用原结果目录继续上次测试。',
     }
   }
   if (/mutation ledger/i.test(message)) {

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -401,7 +401,7 @@ process.stdin.on('end', () => {
     expect(prompts[0]).not.toContain('primary test engineer')
     expect(run.state.status).toBe('completed')
     expect(run.result?.cases[0]).toMatchObject({ outcome: 'blocked', failureSource: 'infrastructure' })
-    expect(run.result?.blockers[0]).toMatch(/没有向模型提供 Auto-Test Control MCP 工具/)
+    expect(run.result?.blockers[0]).toMatch(/能力预检未观察到唯一且合规的 test_contract 调用/)
     expect(JSON.parse(await readFile(resolve(outputDirectory, '.agent-private', 'mutation-ledger.json'), 'utf8'))).toEqual([])
   })
 

--- a/tests/codex-mcp-transport.test.ts
+++ b/tests/codex-mcp-transport.test.ts
@@ -1,0 +1,168 @@
+import { createRequire } from 'node:module'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { CodexAgentHost } from '../src/agent/codex-host.js'
+import { prepareCodexAgentWorkspace } from '../src/agent/workspace.js'
+import type { AgentEvent } from '../src/agent/host.js'
+import { toAgentModelProviderDescriptor, type ModelProfile } from '../src/workflow/model-profile.js'
+import type { WorkflowIntakeManifest } from '../src/workflow/types.js'
+
+const directories: string[] = []
+const servers: Server[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(async (server) => {
+    if (!server.listening) return
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }))
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+function manifest(): WorkflowIntakeManifest {
+  return {
+    version: '1.0', kind: 'workflow-intake', workflowId: 'mcp-transport-fixture',
+    source: { format: 'xlsx', fileName: 'fixture.xlsx', sheetName: 'Cases', sha256: 'c'.repeat(64) },
+    targetUrls: ['https://fixture.example.test/'], requiredCapabilities: [],
+    phases: [{
+      id: 'case-one', title: 'Read the test contract', sourceRow: 2, risk: 'read',
+      steps: [{ id: 'step-one', sourceText: 'Read the immutable test contract', confidence: 1 }],
+      resources: [], secretBindings: [], imageIds: [], review: { status: 'draft', ambiguities: [] },
+    }],
+    embeddedImages: [], supplementalImages: [], review: { status: 'draft', reasons: [] },
+  }
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+}
+
+async function requestJson(request: AsyncIterable<Uint8Array>): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(Buffer.from(chunk))
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+}
+
+function sendSse(response: import('node:http').ServerResponse, events: unknown[]): void {
+  response.writeHead(200, { 'content-type': 'text/event-stream' })
+  for (const event of events) response.write(`data: ${JSON.stringify(event)}\n\n`)
+  response.end()
+}
+
+describe('Codex managed-provider MCP transport', () => {
+  it.skipIf(process.platform === 'win32')('executes a real Control MCP call through a flat-function Responses provider', async () => {
+    const requests: Record<string, unknown>[] = []
+    const provider = createServer(async (request, response) => {
+      const body = await requestJson(request)
+      requests.push(body)
+      if (requests.length === 1) {
+        const tools = body.tools as Array<Record<string, unknown>>
+        const name = tools.find((tool) => typeof tool.name === 'string' && tool.name.includes('test_contract'))?.name
+        if (typeof name !== 'string') {
+          response.writeHead(400).end('missing flattened test_contract tool')
+          return
+        }
+        sendSse(response, [
+          { type: 'response.created', response: { id: 'response-1' } },
+          { type: 'response.output_item.done', item: { type: 'function_call', call_id: 'contract-call', name, arguments: '{}' } },
+          { type: 'response.completed', response: { id: 'response-1', usage: { input_tokens: 1, input_tokens_details: null, output_tokens: 1, output_tokens_details: null, total_tokens: 2 } } },
+        ])
+        return
+      }
+      sendSse(response, [
+        { type: 'response.created', response: { id: 'response-2' } },
+        { type: 'response.output_item.done', item: { type: 'message', role: 'assistant', id: 'message-1', content: [{ type: 'output_text', text: 'contract confirmed' }] } },
+        { type: 'response.completed', response: { id: 'response-2', usage: { input_tokens: 1, input_tokens_details: null, output_tokens: 1, output_tokens_details: null, total_tokens: 2 } } },
+      ])
+    })
+    servers.push(provider)
+    const providerBaseUrl = `${await listen(provider)}/v1`
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-codex-mcp-transport-'))
+    directories.push(directory)
+    const browserExecutablePath = resolve(directory, 'chromium')
+    await writeFile(browserExecutablePath, '')
+    await chmod(browserExecutablePath, 0o755)
+    const environment = {
+      PATH: process.env.PATH ?? '',
+      HOME: process.env.HOME ?? directory,
+      FIXTURE_PROVIDER_KEY: 'fixture-key',
+    }
+    const workflow = manifest()
+    const workspace = await prepareCodexAgentWorkspace({
+      outputDirectory: resolve(directory, 'run'),
+      manifest: workflow,
+      profile: {
+        id: 'fixture', origins: ['https://fixture.example.test'], auth: [],
+        policy: { allowWrite: false, allowDestructive: false },
+      },
+      secrets: {}, headed: false, browserExecutablePath, environment,
+    })
+    const modelProfile: ModelProfile = {
+      id: 'fixture', model: 'fixture-model', providerId: 'fixture_provider',
+      baseUrl: providerBaseUrl, api: 'openai-responses', envKey: 'FIXTURE_PROVIDER_KEY',
+      inputModalities: ['text'], supportsWebsockets: false,
+    }
+    const executable = resolve(dirname(createRequire(import.meta.url).resolve('@openai/codex/package.json')), 'bin', 'codex.js')
+    const host = new CodexAgentHost()
+    const runtime = await host.modelProvider.prepare({
+      workspaceDirectory: workspace.workspaceDirectory,
+      privateDirectory: workspace.privateDirectory,
+      agentHome: workspace.agentHome,
+      executable,
+      playwrightConfigPath: workspace.playwrightConfigPath,
+      playwrightSecretsPath: workspace.playwrightSecretsPath,
+      controlConfigPath: workspace.controlConfigPath,
+      environment,
+      mcpEnvironment: workspace.mcpEnvironment,
+      provider: toAgentModelProviderDescriptor(modelProfile),
+    })
+    const launchOptions = {
+      workspaceDirectory: workspace.workspaceDirectory,
+      runtime,
+      executable,
+      playwrightConfigPath: workspace.playwrightConfigPath,
+      playwrightSecretsPath: workspace.playwrightSecretsPath,
+      controlConfigPath: workspace.controlConfigPath,
+      fullAgentAccess: false,
+    }
+    const session = await host.start(launchOptions)
+    const events: AgentEvent[] = []
+    let resumeId: string | null = null
+    try {
+      for await (const event of (await session.run([{
+        type: 'text', text: 'Call auto-test-control.test_contract exactly once, then confirm.',
+      }])).events) events.push(event)
+      resumeId = session.id
+    } finally {
+      await session.close?.()
+    }
+
+    expect(resumeId).toBeTruthy()
+    const resumed = await host.resume({ ...launchOptions, resumeId: resumeId! })
+    try {
+      for await (const event of (await resumed.run([{
+        type: 'text', text: 'Reply with a short confirmation without calling a tool.',
+      }])).events) events.push(event)
+    } finally {
+      await resumed.close?.()
+    }
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'tool_completed', server: 'auto-test-control', tool: 'test_contract', status: 'completed',
+    }))
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_message', text: 'contract confirmed' }))
+    expect(requests).toHaveLength(3)
+    expect((requests[0]?.tools as Array<Record<string, unknown>>).some((tool) => tool.type === 'namespace')).toBe(false)
+    const secondInput = requests[1]?.input as Array<Record<string, unknown>>
+    expect(secondInput.some((item) => item.type === 'function_call_output' && item.call_id === 'contract-call')).toBe(true)
+    expect(await readFile(workspace.mutationLedgerPath, 'utf8')).toBe('[]\n')
+  }, 30_000)
+})

--- a/tests/responses-tool-bridge.test.ts
+++ b/tests/responses-tool-bridge.test.ts
@@ -119,4 +119,32 @@ describe('Responses namespace compatibility bridge', () => {
       },
     })
   })
+
+  it('cancels the upstream stream when the Codex client disconnects', async () => {
+    let upstreamClosed!: () => void
+    const closed = new Promise<void>((resolve) => { upstreamClosed = resolve })
+    const upstream = createServer(async (request, response) => {
+      await jsonBody(request)
+      response.on('close', upstreamClosed)
+      response.writeHead(200, { 'content-type': 'text/event-stream' })
+      response.write(`data: ${JSON.stringify({ type: 'response.created', response: { id: 'response-1' } })}\n\n`)
+    })
+    servers.push(upstream)
+    const bridge = await startResponsesToolBridge(`${await listen(upstream)}/v1`)
+    bridges.push(bridge)
+    const controller = new AbortController()
+    const response = await fetch(`${bridge.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({ model: 'fixture', stream: true, input: [], tools: [] }),
+    })
+
+    controller.abort()
+    await expect(response.text()).rejects.toThrow()
+    await expect(Promise.race([
+      closed,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('upstream stream remained open')), 2_000)),
+    ])).resolves.toBeUndefined()
+  })
 })

--- a/tests/responses-tool-bridge.test.ts
+++ b/tests/responses-tool-bridge.test.ts
@@ -1,0 +1,122 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  flattenResponsesTools,
+  restoreResponsesToolCalls,
+  startResponsesToolBridge,
+  type ResponsesToolBridge,
+} from '../src/agent/responses-tool-bridge.js'
+
+const servers: Server[] = []
+const bridges: ResponsesToolBridge[] = []
+
+afterEach(async () => {
+  await Promise.all(bridges.splice(0).map((bridge) => bridge.close()))
+  await Promise.all(servers.splice(0).map(async (server) => {
+    if (!server.listening) return
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }))
+})
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}
+
+async function jsonBody(request: AsyncIterable<Uint8Array>): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(Buffer.from(chunk))
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+}
+
+describe('Responses namespace compatibility bridge', () => {
+  it('round-trips namespaced MCP calls through standard flat function tools', () => {
+    const request: Record<string, unknown> = {
+      tools: [
+        { type: 'function', name: 'shell_command', description: 'Run a command', strict: false, parameters: { type: 'object' } },
+        {
+          type: 'namespace',
+          name: 'mcp__auto_test_control',
+          description: 'Auto-Test control tools',
+          tools: [{ type: 'function', name: 'test_contract', description: 'Read the contract', strict: false, parameters: { type: 'object' } }],
+        },
+      ],
+      input: [{ type: 'function_call', call_id: 'prior-call', namespace: 'mcp__auto_test_control', name: 'test_contract', arguments: '{}' }],
+    }
+
+    const mapping = flattenResponsesTools(request)
+    const tools = request.tools as Array<Record<string, unknown>>
+    const flattened = tools.find((tool) => tool.name !== 'shell_command')!
+    expect(tools.some((tool) => tool.type === 'namespace')).toBe(false)
+    expect(flattened).toMatchObject({ type: 'function', name: 'mcp__auto_test_control__test_contract' })
+    expect(request.input).toEqual([expect.objectContaining({
+      type: 'function_call', name: flattened.name, call_id: 'prior-call',
+    })])
+    expect((request.input as Array<Record<string, unknown>>)[0]).not.toHaveProperty('namespace')
+
+    const providerEvent = {
+      type: 'response.output_item.done',
+      item: { type: 'function_call', call_id: 'next-call', name: flattened.name, arguments: '{}' },
+    }
+    expect(restoreResponsesToolCalls(providerEvent, mapping)).toEqual({
+      type: 'response.output_item.done',
+      item: {
+        type: 'function_call', call_id: 'next-call',
+        namespace: 'mcp__auto_test_control', name: 'test_contract', arguments: '{}',
+      },
+    })
+  })
+
+  it('rewrites a streamed provider call without changing call IDs or tool results', async () => {
+    let upstreamRequest: Record<string, unknown> | undefined
+    const upstream = createServer(async (request, response) => {
+      upstreamRequest = await jsonBody(request)
+      const tools = upstreamRequest.tools as Array<Record<string, unknown>>
+      const name = tools.find((tool) => typeof tool.name === 'string' && tool.name.includes('test_contract'))?.name
+      response.writeHead(200, { 'content-type': 'text/event-stream' })
+      for (const event of [
+        { type: 'response.created', response: { id: 'response-1' } },
+        { type: 'response.output_item.done', item: { type: 'function_call', call_id: 'call-1', name, arguments: '{}' } },
+        { type: 'response.completed', response: { id: 'response-1', usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } },
+      ]) response.write(`data: ${JSON.stringify(event)}\n\n`)
+      response.end()
+    })
+    servers.push(upstream)
+    const upstreamBaseUrl = `${await listen(upstream)}/v1`
+    const bridge = await startResponsesToolBridge(upstreamBaseUrl)
+    bridges.push(bridge)
+
+    const response = await fetch(`${bridge.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer fixture' },
+      body: JSON.stringify({
+        model: 'fixture', stream: true, input: [],
+        tools: [{
+          type: 'namespace', name: 'mcp__auto_test_control', description: 'Control',
+          tools: [{ type: 'function', name: 'test_contract', description: 'Contract', strict: false, parameters: { type: 'object' } }],
+        }],
+      }),
+    })
+    const events = (await response.text()).split('\n')
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => JSON.parse(line.slice('data: '.length)) as Record<string, unknown>)
+
+    expect(response.status).toBe(200)
+    expect((upstreamRequest?.tools as Array<Record<string, unknown>>)).toEqual([
+      expect.objectContaining({ type: 'function', name: 'mcp__auto_test_control__test_contract' }),
+    ])
+    expect(events[1]).toMatchObject({
+      type: 'response.output_item.done',
+      item: {
+        type: 'function_call', call_id: 'call-1',
+        namespace: 'mcp__auto_test_control', name: 'test_contract', arguments: '{}',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- translate Codex namespace MCP tools to standard Responses function tools through a loopback-only bridge for managed Providers
- restore Provider tool calls before Codex routes them to local MCP servers
- cancel the upstream stream when the owning Codex request disconnects and honor response backpressure
- preserve the existing AgentHost/Core contract, improve capability-preflight diagnostics, and update Windows guidance

## Verification
- npm run check (50 files, 414 tests, TypeScript build)
- real Codex CLI + Control MCP transport test through a flat-function Responses fixture
- Windows x64 private package 3325927 with a managed third-party Responses Provider: setup and doctor passed; real canary 1/1 passed; exactly one isolated Control MCP test_contract call completed; real browser operations executed; one write ledger entry accepted; pending=0; three referenced evidence artifacts and the result workbook were independently verified
- Linux Verify and Windows Verify passed for PR head 3325927

## Scope
This validates the Provider/MCP compatibility path and one Windows write canary. It does not claim that the full source workbook or every Provider/model combination passes.