### PR TITLE
fix(launcher): accept probe marker as substring for reasoning models

### DIFF
--- a/scripts/launch-windows.ps1
+++ b/scripts/launch-windows.ps1
@@ -708,7 +708,11 @@ function Test-CodexProvider {
         $hint = Get-CodexProbeFailureHint $probe $probeExitCode
         throw "模型 API 探针失败。$hint"
       }
-      if ($probe -notmatch '(?m)^\s*AUTO_TEST_API_READY\s*$') {
+      # Substring match (not a strict whole-line match): reasoning models such
+      # as deepseek-v4-flash tend to wrap the requested marker in thinking or
+      # extra text, so requiring a line that is exactly AUTO_TEST_API_READY
+      # rejects a healthy API. The marker is distinctive enough for a probe.
+      if ($probe -notmatch 'AUTO_TEST_API_READY') {
         throw '模型 API 已响应但健康检查结果异常。'
       }
       Write-Host '[OK] 模型 API 调用验证通过'


### PR DESCRIPTION
## Summary

The Windows launcher's model-API health check ran `codex exec "Reply with exactly AUTO_TEST_API_READY."` and required the output to match a **strict whole-line** regex `^\s*AUTO_TEST_API_READY\s*$`. Reasoning models such as **deepseek-v4-flash** wrap the requested marker in thinking or extra text, so a healthy API was rejected with `模型 API 已响应但健康检查结果异常`, the launcher rolled back the provider config, and exited 1.

Reported during Windows setup with `deepseek-v4-flash-ga-260731` via ARK: the model responded (exit 0, API/Key fine) but the strict line match failed.

## Change (`scripts/launch-windows.ps1`)

Switch the probe marker check from `(?m)^\s*AUTO_TEST_API_READY\s*$` to a substring match `AUTO_TEST_API_READY`. The marker is distinctive enough for a health probe; accepting it anywhere in stdout/stderr tolerates reasoning-model output formatting. The existing exit-code guard still rejects genuinely failed probes.

## Verification

- `npm run check`: typecheck clean, **414 tests pass**, build clean.
- The `windows-launcher` test asserting the probe does not use the old single-quoted exec form is preserved.
- `windows-verify` CI runs the launcher bootstrap (including the probe path) as the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)