### PR TITLE
fix(launcher): probe with minimal reasoning effort to avoid timeout

### DIFF
--- a/scripts/launch-windows.ps1
+++ b/scripts/launch-windows.ps1
@@ -570,6 +570,12 @@ function Start-CodexProbeProcess([string] $Executable) {
     '--skip-git-repo-check',
     '--color',
     'never',
+    # The probe only checks that the model API echoes the marker, so override
+    # the configured reasoning effort to "minimal". Reasoning models such as
+    # deepseek-v4-flash otherwise spend the full probe timeout thinking about a
+    # trivial prompt and the health check times out.
+    '-c',
+    'model_reasoning_effort="minimal"',
     '-C',
     $RepositoryRoot
   )


### PR DESCRIPTION
## Summary

The Windows launcher's model-API health check runs `codex exec "Reply with exactly AUTO_TEST_API_READY."` using the configured reasoning effort, which is `high` for the default deepseek profile. Reasoning models such as **deepseek-v4-flash** spend the whole probe timeout thinking about the trivial prompt, so the probe exceeded 120s and the launcher aborted setup with `模型 API 探针在 120 秒内未完成`.

Reported during Windows setup with `deepseek-v4-flash-ga-260731` via ARK: the previous package (PR #45 substring fix) sometimes completed the probe (but failed the strict marker line) and sometimes timed out at 120s, because `high` reasoning effort on a reasoning model is slow and variable for a trivial prompt.

## Change (`scripts/launch-windows.ps1`)

Override `model_reasoning_effort` to `minimal` for the probe via `-c model_reasoning_effort="minimal"`. The probe only needs the model to echo the marker, so minimal reasoning keeps it fast while remaining a meaningful health check.

Verified locally that `codex exec` accepts `-c 'model_reasoning_effort="minimal"'` (output showed `reasoning effort: minimal`).

## Verification

- `npm run check`: typecheck clean, **416 tests pass**, build clean.
- `windows-verify` CI runs the launcher probe path (with a stub codex) as the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)