### PR TITLE
feat(eval): add regression matrix, outcome rubric, and failure-mode scorecard

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,6 +28,12 @@ npm run easy
 
 每条来源行都会建立稳定的 case ID。Excel 应提供操作步骤、可观察预期、业务实体匹配规则、写入后的清理要求和必要的环境前置条件。新 AgentHost Run 必须用 `--url` 明确提供本次被测环境入口；Excel 中出现的其他链接仍保留给 Agent 理解和探索，但不会仅因出现在单元格中就成为 Environment Profile 的预执行覆盖要求。内嵌图片和补充图片会进入同一 Run 工作区。
 
+新 intake 会为每条 case 同源生成 `outcome`：`action` 是必须执行的操作，`observable` 是必须观察到的业务结果，`evidence` 声明交互和观察证据，`cleanup` 保留来源清理要求，`failureModes` 声明该 case 允许被归入的失败模式。它是 Agent、结果交付和 eval 共用的完成定义，不是第二套 Planner DSL；完整业务含义仍以原 Excel、brief 和图片为准。
+
+失败模式统一为八类：`input`、`authentication`、`environment`、`locator_navigation`、`business_assertion`、`mutation_cleanup`、`agent_execution`、`infrastructure`。结果校验会把非 passed case 的 `failureSource`/`failureKind` 映射到同一八类，若不在该 case 的 `failureModes` 合同内则拒绝；只读 case 不允许 `mutation_cleanup`。
+
+最终校验会拒绝 outcome 的假通过：非阻断 case 必须有具体观察证据，并在合同要求时引用同 case 的 interaction 回执。`blocked` 可以发生在交互之前，因此不强制 interaction；写入清理仍只由权威 Mutation Ledger 判定，避免出现第二套相互冲突的清理状态。
+
 ## 4. 执行
 
 命令行：
@@ -99,6 +105,12 @@ OMP 使用 `omp --mode rpc` 启动持久 JSONL 会话。Auto-Test 会在 run 工
   -> immutable-order deterministic aggregate
 ```
 
+每个 epoch 的 manifest 只保留当前 case 的完整步骤、资源和图片，同时携带全 Run 的紧凑 `materialIndex`（case ID、标题、来源行、风险和图片数量）。Agent 可据此按需回看原始材料，不需要把其他 case 的正文和图片全部放入当前上下文。
+
+经验性知识（站点技巧、异步等待、表格实体识别、跨域会话等）按需加载为场景 Skill/brief，不永久塞进通用 Prompt；它们由 `requiredCapabilities` 等来源信号选择。安全和结果协议（Mutation Ledger、认证状态、outcome 合同、交付合同）继续留在 Core，不随 brief 变化。
+
+Core 拥有 bounded fan-out 策略（`fanoutPolicy`），通过 Control MCP `test_contract` 以单一来源暴露给 Agent：默认只读、并发上限为 1。该策略是 Core 声明并由 Agent 遵守的单一来源（Core 不拦截 Agent 内部的 sub-agent 调用，故不提供逐任务确定性门禁）；真实写入型测试不会被拆成默认并行 agent。
+
 选定的 AgentHost 始终是真实测试执行主体。Runner 不解释业务语义，不生成第二份 Execution Plan，也不要求 `case_execution_begin/end`、`case_result_record` 或环境审计 turn 才允许浏览器工作。Control MCP 回执是可选审计信息，只有宿主在结果中引用的回执才会被确定性校验。
 
 对外部业务写入使用 Mutation Ledger 记录完整业务操作。恢复时选定的 AgentHost 必须先重新观察真实状态；只要存在 `pending` Mutation，最终结果就只能是 `blocked`，不会继续调度后续 epoch。
@@ -131,6 +143,21 @@ npm run easy -- run \
 恢复会校验 workflow/source 身份和 Ledger。已写入逐 case store 的 case 不会重跑；active epoch 通常恢复原 thread，容量轮换后的新 epoch 会从 checkpoint 和原工作区继续。若基础设施恢复需要切换模型 Profile，逻辑 Run、active epoch、工作区和 Ledger 保持不变，但与新 AgentHost/Provider/模型绑定不兼容的物理 session 会被下一代 thread 替换；新 thread 必须先执行 resume 协议并核对 pending Mutation。早期 v2 状态没有绑定指纹时，Runner 只在宿主明确报告 session 不兼容后轮换一次；普通执行错误不会触发轮换。旧版 `version: 1.0` 状态、`activeBatch`、`completedBatchIds` 等状态不再兼容，恢复会 fail closed 并要求新建 Run。
 
 需要比较两个宿主时，先用同一输入包执行两个独立 Run，再执行 `npm run agent:compare -- --run <codex-run> --run <omp-run>`。比较器只读取结构化结果、证据和 Ledger，不启动新的 Agent，也不重复业务写入。两个 Run 必须同时提供 immutable `test-manifest.json`、一致的 `workflowId`/`sourceSha256`、Excel 与同名 sidecar/image 的 `input-bundle.json`、Manifest hash、Environment selection hash、平台、架构、Auto-Test 包版本、commit 和 `agent-host-selection.json`。缺少或不一致的任一合同输入时，比较器会 fail closed，结果为 `invalid`，不会继续给出宿主等价性结论。
+
+把第一个 `--run` 固定为已验证 baseline，并提供绑定同一 immutable input 的 oracle，即可得到最小 eval scorecard：逐 case 命中率、八类失败模式分布、证据/回执/Mutation 数量、耗时、聚合 token（输入/缓存输入/输出）、线程代数/恢复次数/epoch 数，以及相对 baseline 的 delta。CI 或故障 probe 使用 `--require-oracle-match`；任何候选没有完整命中 oracle（包括“本应 blocked/product_failed 却返回 passed”）都会返回非零：
+
+```bash
+npm run agent:compare -- \
+  --run artifacts/runs/baseline \
+  --run artifacts/runs/candidate \
+  --oracle evals/readonly-canary.oracle.json \
+  --require-oracle-match \
+  --output artifacts/evals/readonly-canary.json
+```
+
+oracle 只记录已独立验证的 outcome 和必要失败分类，不从待评估 Run 自身生成。写入型真实场景不得为了比较而在同一业务实体上盲目重复执行；优先使用只读 canary、隔离测试数据或已经完成的 Run 制品。
+
+固定回归任务集由 `src/eval/eval-suite.ts` 的 `canonicalEvalSuite()` 声明为版本化清单（canary、本地 fixture、Windows 验收、中断恢复），并保证八类失败模式每类至少被一个任务覆盖。AgentHost、Prompt、Model Profile 或 checkpoint 变更时，用这套固定任务集比较业务 outcome、证据完整性、Ledger 终态、失败来源、token/时间以及重试恢复次数；比较仍通过 `agent:compare` 完成，不引入新服务。
 
 ## 7. 结果边界
 

--- a/src/agent/competition.ts
+++ b/src/agent/competition.ts
@@ -5,6 +5,7 @@ import type { WorkflowIntakeManifest } from '../workflow/types.js'
 import type {
   AgentTestCaseResult,
   AgentTestFailureKind,
+  AgentTestFailureMode,
   AgentTestFailureSource,
   AgentTestOutcome,
   AgentTestResult,
@@ -13,6 +14,7 @@ import type {
   CodexTestMutationLedgerEntry,
 } from './types.js'
 import { parseAgentTestResult } from './result.js'
+import { failureModeCounts } from './failure-mode.js'
 import { writePrivateJson } from './state.js'
 
 export interface AgentCompetitionOracleCase {
@@ -52,6 +54,30 @@ export interface AgentCompetitionCandidateSummary {
   inputBundleSha256?: string
   durationMs?: number
   oracleMatchedCases?: number
+  oracleMatchRate?: number
+  failureSources: Partial<Record<AgentTestFailureSource, number>>
+  failureKinds: Partial<Record<AgentTestFailureKind, number>>
+  failureModes: Partial<Record<AgentTestFailureMode, number>>
+  /** Aggregated token usage across the run's completed turns. */
+  inputTokens?: number
+  cachedInputTokens?: number
+  outputTokens?: number
+  /** Physical AgentHost threads used; the first thread is generation 1. */
+  threadGeneration?: number
+  epochCount?: number
+  /** Number of recovered/replacement threads beyond the first. */
+  recoveryCount?: number
+  interruptionCode?: string
+  baselineDelta?: {
+    durationMs?: number
+    evidenceCount: number
+    citedReceiptCount: number
+    mutationCount: number
+    oracleMatchedCases?: number
+    inputTokens?: number
+    cachedInputTokens?: number
+    outputTokens?: number
+  }
 }
 
 export interface AgentCompetitionCaseDifference {
@@ -263,6 +289,64 @@ function caseCounts(cases: AgentTestCaseResult[]): AgentCompetitionCandidateSumm
     product_failed: cases.filter((item) => item.outcome === 'product_failed').length,
     blocked: cases.filter((item) => item.outcome === 'blocked').length,
   }
+}
+
+function countValues<T extends string>(values: Array<T | undefined>): Partial<Record<T, number>> {
+  const counts: Partial<Record<T, number>> = {}
+  for (const value of values) if (value) counts[value] = (counts[value] ?? 0) + 1
+  return counts
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+interface AggregateTokenUsage {
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+}
+
+/**
+ * Sum token usage from every completed agent turn in the run's event log.
+ * Returns undefined when the log is absent or contains no completed turns, so
+ * callers can fall back to the state's last-epoch snapshot.
+ */
+export async function readAggregateTokenUsage(runDirectory: string): Promise<AggregateTokenUsage | undefined> {
+  let text: string
+  try {
+    text = await readFile(resolve(runDirectory, 'codex-agent.events.jsonl'), 'utf8')
+  } catch {
+    return undefined
+  }
+  const usage: AggregateTokenUsage = { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 }
+  let sawUsage = false
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    let event: unknown
+    try {
+      event = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const record = recordValue(event)
+    // The event log stores the host's raw terminal-turn event: Codex emits
+    // `turn.completed` with snake_case usage fields. Accept the normalized
+    // `turn_completed` spelling too so the reader is not silently tied to one
+    // host's wire format.
+    if (record?.type !== 'turn.completed' && record?.type !== 'turn_completed') continue
+    const turnUsage = recordValue(record.usage)
+    if (!turnUsage) continue
+    const inputTokens = numberField(turnUsage.input_tokens ?? turnUsage.inputTokens)
+    const cachedInputTokens = numberField(turnUsage.cached_input_tokens ?? turnUsage.cachedInputTokens)
+    const outputTokens = numberField(turnUsage.output_tokens ?? turnUsage.outputTokens)
+    if (inputTokens === undefined && cachedInputTokens === undefined && outputTokens === undefined) continue
+    sawUsage = true
+    if (inputTokens !== undefined) usage.inputTokens += inputTokens
+    if (cachedInputTokens !== undefined) usage.cachedInputTokens += cachedInputTokens
+    if (outputTokens !== undefined) usage.outputTokens += outputTokens
+  }
+  return sawUsage ? usage : undefined
 }
 
 function oracleScore(result: AgentTestResult, oracle: AgentCompetitionOracle | undefined): number | undefined {
@@ -496,7 +580,7 @@ function validateOracle(
     if (outcome === 'passed' && failureSource) problems.push(`oracle passed case ${caseId} 不能声明 failureSource`)
     if (outcome === 'product_failed' && failureSource && failureSource !== 'product') problems.push(`oracle product_failed case ${caseId} 必须是 product 来源`)
     if (outcome === 'blocked' && failureSource === 'product') problems.push(`oracle blocked case ${caseId} 不能是 product 来源`)
-    if (failureKind !== undefined && !['assertion', 'validation', 'authentication', 'environment', 'data', 'execution'].includes(String(failureKind))) {
+    if (failureKind !== undefined && !['assertion', 'validation', 'authentication', 'environment', 'data', 'execution', 'locator', 'mutation'].includes(String(failureKind))) {
       problems.push(`oracle case ${caseId} 的 failureKind 无效`)
     }
     if (outcome === 'passed' && failureKind) problems.push(`oracle passed case ${caseId} 不能声明 failureKind`)
@@ -593,6 +677,15 @@ async function loadCandidate(runDirectoryInput: string, oracle?: AgentCompetitio
   const resultDurationMs = durationMs(result)
   const matchedCases = oracleScore(result, oracle)
   const hostId = stringField(selection.id) ?? `<invalid:${candidateLabel}>`
+  const aggregateTokenUsage = await readAggregateTokenUsage(runDirectory)
+  const tokenUsage = aggregateTokenUsage ?? state.lastUsage
+  const inputTokens = tokenUsage ? numberField(tokenUsage.inputTokens) : undefined
+  const cachedInputTokens = tokenUsage ? numberField(tokenUsage.cachedInputTokens) : undefined
+  const outputTokens = tokenUsage ? numberField(tokenUsage.outputTokens) : undefined
+  const threadGeneration = numberField(state.threadGeneration)
+  const epochCount = numberField(state.epochCount)
+  const recoveryCount = threadGeneration !== undefined && threadGeneration >= 1 ? threadGeneration - 1 : undefined
+  const interruptionCode = state.runInterruption?.code
   const summary: AgentCompetitionCandidateSummary = {
     runDirectory,
     hostId,
@@ -614,6 +707,19 @@ async function loadCandidate(runDirectoryInput: string, oracle?: AgentCompetitio
     ...(isSha256(inputBundle?.bundleSha256) ? { inputBundleSha256: inputBundle.bundleSha256 } : {}),
     ...(resultDurationMs !== undefined ? { durationMs: resultDurationMs } : {}),
     ...(matchedCases !== undefined ? { oracleMatchedCases: matchedCases } : {}),
+    ...(matchedCases !== undefined && oracle?.cases.length
+      ? { oracleMatchRate: matchedCases / oracle.cases.length }
+      : {}),
+    failureSources: countValues(cases.map((item) => item.failureSource)),
+    failureKinds: countValues(cases.map((item) => item.failureKind)),
+    failureModes: failureModeCounts(cases),
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(threadGeneration !== undefined ? { threadGeneration } : {}),
+    ...(epochCount !== undefined ? { epochCount } : {}),
+    ...(recoveryCount !== undefined ? { recoveryCount } : {}),
+    ...(interruptionCode ? { interruptionCode } : {}),
   }
   validationProblems.push(...inputBundleProblems(inputBundle, hostId, inputBundleArtifact.exists))
   const candidate: LoadedCandidate = {
@@ -732,6 +838,32 @@ export async function compareAgentRuns(options: {
     verdict = caseDifferences.length === 0 ? 'equivalent' : 'different'
   }
   const first = candidates[0]!
+  const baseline = first.summary
+  const summaries = candidates.map(({ summary }) => ({
+    ...summary,
+    ...(summary === baseline ? {} : {
+      baselineDelta: {
+        ...(summary.durationMs !== undefined && baseline.durationMs !== undefined
+          ? { durationMs: summary.durationMs - baseline.durationMs }
+          : {}),
+        evidenceCount: summary.evidenceCount - baseline.evidenceCount,
+        citedReceiptCount: summary.citedReceiptCount - baseline.citedReceiptCount,
+        mutationCount: summary.mutationCount - baseline.mutationCount,
+        ...(summary.oracleMatchedCases !== undefined && baseline.oracleMatchedCases !== undefined
+          ? { oracleMatchedCases: summary.oracleMatchedCases - baseline.oracleMatchedCases }
+          : {}),
+        ...(summary.inputTokens !== undefined && baseline.inputTokens !== undefined
+          ? { inputTokens: summary.inputTokens - baseline.inputTokens }
+          : {}),
+        ...(summary.cachedInputTokens !== undefined && baseline.cachedInputTokens !== undefined
+          ? { cachedInputTokens: summary.cachedInputTokens - baseline.cachedInputTokens }
+          : {}),
+        ...(summary.outputTokens !== undefined && baseline.outputTokens !== undefined
+          ? { outputTokens: summary.outputTokens - baseline.outputTokens }
+          : {}),
+      },
+    }),
+  }))
   return {
     version: '1.0',
     kind: 'agent-competition',
@@ -740,7 +872,7 @@ export async function compareAgentRuns(options: {
     sourceSha256: stringField(first.result.sourceSha256) ?? '',
     contractStatus: problems.length === 0 ? 'valid' : 'invalid',
     contractProblems: problems,
-    candidates: candidates.map((candidate) => candidate.summary),
+    candidates: summaries,
     caseDifferences,
     verdict,
     ...(winnerHostId ? { winnerHostId } : {}),

--- a/src/agent/control-server.ts
+++ b/src/agent/control-server.ts
@@ -7,6 +7,7 @@ import * as z from 'zod/v4'
 import { writePrivateJson } from './state.js'
 import { readEnvironmentRequirements, recordEnvironmentRequirement, requestEnvironmentAccess, satisfyEnvironmentRequirement } from './environment-requirements.js'
 import type { CodexTestControlConfig } from './control-types.js'
+import { DEFAULT_AGENT_FANOUT_POLICY, fanoutPolicyProblems } from './fanout-policy.js'
 import { resolveEvidenceArtifact } from './evidence-artifact.js'
 import { readExecutionReceipts, summarizeExecutionReceipts } from './execution-receipts.js'
 import { validateFieldCompositionGate } from './field-composition.js'
@@ -61,6 +62,11 @@ async function main(): Promise<void> {
   const configPath = process.argv[2]
   if (!configPath) throw new Error('Control server requires a config path')
   const config = JSON.parse(await readFile(configPath, 'utf8')) as CodexTestControlConfig
+  const fanoutPolicy = config.fanoutPolicy ?? DEFAULT_AGENT_FANOUT_POLICY
+  const fanoutProblems = fanoutPolicyProblems(fanoutPolicy)
+  if (fanoutProblems.length > 0) {
+    throw new Error(`fanout policy is invalid: ${fanoutProblems.join('; ')}`)
+  }
   const environmentRequirementsPath = config.environmentRequirementsPath
     ?? resolve(config.evidenceDirectory, '..', '..', '.agent-private', 'environment-requirements.json')
   const fieldCompositionPath = config.fieldCompositionPath
@@ -91,6 +97,7 @@ async function main(): Promise<void> {
     caseIds: [...caseIds],
     totalCaseCount: config.caseIds.length,
     testDataAccess: config.testDataAccess ?? 'opaque',
+    fanoutPolicy,
   }))
 
   server.registerTool('test_value_get', {
@@ -321,7 +328,7 @@ async function main(): Promise<void> {
       blockers: z.array(z.string().min(1)).default([]),
       productDefects: z.array(z.string().min(1)).default([]),
       failureSource: z.enum(['product', 'agent_execution', 'environment', 'input', 'infrastructure']).optional(),
-      failureKind: z.enum(['assertion', 'validation', 'authentication', 'environment', 'data', 'execution']).optional(),
+      failureKind: z.enum(['assertion', 'validation', 'authentication', 'environment', 'data', 'execution', 'locator', 'mutation']).optional(),
       environmentRequirementIds: z.array(z.string().min(1)).default([]),
       executionReceiptIds: z.array(z.string().min(1)).default([]),
       fieldGateIds: z.array(z.string().min(1)).default([]),

--- a/src/agent/control-types.ts
+++ b/src/agent/control-types.ts
@@ -1,4 +1,5 @@
 import type { CodexTestRisk } from './types.js'
+import type { AgentFanoutPolicy } from './fanout-policy.js'
 
 export interface AgentTestControlConfig {
   version: '1.0'
@@ -21,6 +22,8 @@ export interface AgentTestControlConfig {
   fieldCompositionPath?: string
   secretValuesPath?: string
   testDataAccess?: 'direct' | 'opaque'
+  /** Core-owned bounded fan-out limit; absent only in legacy control configs. */
+  fanoutPolicy?: AgentFanoutPolicy
 }
 
 /** Historical Codex-prefixed name remains source-compatible. */

--- a/src/agent/delivery-recovery.ts
+++ b/src/agent/delivery-recovery.ts
@@ -28,7 +28,7 @@ interface AgentDeliveryArtifact {
 }
 
 const failureSources = new Set<CodexTestFailureSource>(['product', 'agent_execution', 'environment', 'input', 'infrastructure'])
-const failureKinds = new Set<CodexTestFailureKind>(['assertion', 'validation', 'authentication', 'environment', 'data', 'execution'])
+const failureKinds = new Set<CodexTestFailureKind>(['assertion', 'validation', 'authentication', 'environment', 'data', 'execution', 'locator', 'mutation'])
 
 function outcomeForCases(cases: CodexTestCaseResult[]): CodexTestAgentResult['outcome'] {
   if (cases.some((item) => item.outcome === 'blocked')) return 'blocked'

--- a/src/agent/execution-epochs.ts
+++ b/src/agent/execution-epochs.ts
@@ -88,6 +88,13 @@ export function manifestForAgentExecutionEpoch(
   return {
     ...manifest,
     phases,
+    materialIndex: manifest.materialIndex ?? manifest.phases.map((phase) => ({
+      caseId: phase.id,
+      title: phase.title,
+      sourceRow: phase.sourceRow,
+      risk: phase.risk,
+      imageCount: phase.imageIds.length,
+    })),
     targetUrls: targetUrlsForManifestCases(manifest, phases),
     embeddedImages: manifest.embeddedImages.filter((image) => imageIds.has(image.id)),
     supplementalImages: manifest.supplementalImages.filter((image) => imageIds.has(image.id)),
@@ -101,6 +108,13 @@ export function limitManifestToCases(manifest: WorkflowIntakeManifest, limit: nu
   return {
     ...manifest,
     phases,
+    materialIndex: manifest.materialIndex ?? manifest.phases.map((phase) => ({
+      caseId: phase.id,
+      title: phase.title,
+      sourceRow: phase.sourceRow,
+      risk: phase.risk,
+      imageCount: phase.imageIds.length,
+    })),
     targetUrls: targetUrlsForManifestCases(manifest, phases),
     embeddedImages: manifest.embeddedImages.filter((image) => imageIds.has(image.id)),
     supplementalImages: manifest.supplementalImages.filter((image) => imageIds.has(image.id)),

--- a/src/agent/failure-mode.ts
+++ b/src/agent/failure-mode.ts
@@ -1,0 +1,68 @@
+import type { AgentTestFailureKind, AgentTestFailureMode, AgentTestFailureSource } from './types.js'
+
+/**
+ * The canonical eight failure modes used to slice an eval report. This module
+ * is deliberately a pure, deterministic mapping over the two result fields the
+ * AgentHost already emits (failureSource + failureKind); it does not introduce
+ * a second classifier or let the model grade itself.
+ */
+export const AGENT_TEST_FAILURE_MODES: readonly AgentTestFailureMode[] = [
+  'input',
+  'authentication',
+  'environment',
+  'locator_navigation',
+  'business_assertion',
+  'mutation_cleanup',
+  'agent_execution',
+  'infrastructure',
+] as const
+
+export function isAgentTestFailureMode(value: unknown): value is AgentTestFailureMode {
+  return typeof value === 'string' && (AGENT_TEST_FAILURE_MODES as readonly string[]).includes(value)
+}
+
+/**
+ * Map a result's two classification dimensions into one standardized mode.
+ * The precedence is chosen so that the most specific, actionable bucket wins:
+ *
+ * - input source is always an input problem;
+ * - authentication kind is always an authentication problem (whether it
+ *   surfaced as an environment prerequisite or an execution failure);
+ * - a product-sourced mismatch is a business assertion failure;
+ * - locator/mutation kinds are the new explicit navigation and cleanup modes;
+ * - everything else falls back to environment / agent_execution /
+ *   infrastructure by source.
+ */
+export function failureModeFor(
+  source: AgentTestFailureSource | undefined,
+  kind: AgentTestFailureKind | undefined,
+): AgentTestFailureMode {
+  if (source === 'input') return 'input'
+  if (kind === 'authentication') return 'authentication'
+  if (source === 'infrastructure') return 'infrastructure'
+  if (source === 'product') return 'business_assertion'
+  if (kind === 'locator') return 'locator_navigation'
+  if (kind === 'mutation') return 'mutation_cleanup'
+  if (source === 'environment') return 'environment'
+  if (source === 'agent_execution') return 'agent_execution'
+  return 'agent_execution'
+}
+
+/**
+ * Counts non-passed cases into the eight standardized failure modes. Passed
+ * cases have no failure classification and are intentionally absent from the
+ * result so an empty mode map means "no failures", not "unclassified".
+ */
+export function failureModeCounts(
+  cases: Array<{ failureSource?: AgentTestFailureSource; failureKind?: AgentTestFailureKind }>,
+): Partial<Record<AgentTestFailureMode, number>> {
+  const counts: Partial<Record<AgentTestFailureMode, number>> = {}
+  for (const item of cases) {
+    // Passed cases carry no failure classification; skip them so the fallback
+    // mode never turns a passed case into a phantom `agent_execution` failure.
+    if (item.failureSource === undefined && item.failureKind === undefined) continue
+    const mode = failureModeFor(item.failureSource, item.failureKind)
+    counts[mode] = (counts[mode] ?? 0) + 1
+  }
+  return counts
+}

--- a/src/agent/fanout-policy.ts
+++ b/src/agent/fanout-policy.ts
@@ -1,0 +1,58 @@
+/**
+ * Bounded fan-out is a read-only analysis affordance, never a default write
+ * fan-out. This policy is owned by Core (declared in the immutable control
+ * contract), so the AgentHost sees one authoritative limit rather than a
+ * prompt-only convention.
+ *
+ * The policy is declarative, not a per-task gate: Core validates it and
+ * exposes it through the Control MCP `test_contract`, but does not intercept
+ * the AgentHost's internal sub-agent calls, so honoring it is the agent's
+ * responsibility rather than a deterministic enforcement point.
+ */
+
+export type AgentFanoutScope = 'readonly-analysis' | 'offline-evidence'
+
+export interface AgentFanoutPolicy {
+  version: '1.0'
+  /** Maximum concurrent fan-out tasks. 1 means serialized (effectively disabled). */
+  maxConcurrency: number
+  /** When false (the shipped default), fan-out may only perform read-only analysis. */
+  writeFanout: boolean
+  /** Scopes where bounded fan-out is permitted. */
+  scopes: AgentFanoutScope[]
+}
+
+export const DEFAULT_AGENT_FANOUT_POLICY: AgentFanoutPolicy = {
+  version: '1.0',
+  maxConcurrency: 1,
+  writeFanout: false,
+  scopes: ['readonly-analysis', 'offline-evidence'],
+}
+
+const FANOUT_SCOPES: readonly AgentFanoutScope[] = ['readonly-analysis', 'offline-evidence']
+
+export function fanoutPolicyProblems(policy: unknown): string[] {
+  if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+    return ['fanout policy must be a JSON object']
+  }
+  const value = policy as Record<string, unknown>
+  const problems: string[] = []
+  if (value.version !== '1.0') problems.push('fanout policy version must be "1.0"')
+  if (!Number.isInteger(value.maxConcurrency) || (value.maxConcurrency as number) < 1) {
+    problems.push('fanout policy maxConcurrency must be a positive integer')
+  }
+  if (typeof value.writeFanout !== 'boolean') problems.push('fanout policy writeFanout must be a boolean')
+  if (!Array.isArray(value.scopes) || value.scopes.length === 0) {
+    problems.push('fanout policy scopes must be a non-empty array')
+  } else {
+    const seen = new Set<string>()
+    for (const scope of value.scopes) {
+      if (!FANOUT_SCOPES.includes(scope as AgentFanoutScope)) {
+        problems.push(`fanout policy contains an unknown scope: ${String(scope)}`)
+      }
+      if (seen.has(String(scope))) problems.push(`fanout policy repeats scope: ${String(scope)}`)
+      seen.add(String(scope))
+    }
+  }
+  return problems
+}

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -2,6 +2,7 @@ import type { WorkflowIntakeManifest } from '../workflow/types.js'
 import type { AgentExecutionEpoch } from './execution-epochs.js'
 import type { AgentSecretAlias } from './workspace.js'
 import { environmentTargetUrls } from '../workflow/target-urls.js'
+import { selectSkillBriefs, skillBriefContext } from './skill-brief.js'
 
 function executionEpochContext(window?: AgentExecutionEpoch): string {
   if (!window) return [
@@ -46,6 +47,7 @@ export function agentTestPrompt(options: {
   const canary = options.maxIterations === undefined
     ? 'Execute the full data set described by the test material.'
     : `Canary limit: for repeated or list-driven data, execute at most ${options.maxIterations} item(s) while preserving cleanup and final assertions.`
+  const selectedBriefs = selectSkillBriefs(options.manifest)
 
   if (!fullAgentAccess) {
     return `You are the execution agent for a real web application test. This run uses the restricted compatibility mode.
@@ -64,6 +66,9 @@ Required protocol:
 ${canary}
 
 ${executionEpochContext(options.executionEpoch)}
+
+Scenario experience briefs (loaded on demand; protocol stays in Core):
+${skillBriefContext(selectedBriefs)}
 
 Prior working-memory checkpoint: ${options.checkpointPath ?? '(none; first physical thread)'}
 
@@ -97,7 +102,7 @@ Execution principles:
 3. Build and revise your own working plan from live evidence. Native host todo lists, notes, or scripts are valid; test_plan_update is optional.
 4. Prefer accessible page evidence, but use browser_evaluate or browser_run_code_unsafe when direct Playwright code is the clearest reliable method.
 5. A click, fill, request, or script completing without an exception is not a passed test. Verify the expected page and business state.
-6. Expected results in the test material are immutable. Do not weaken an assertion to make execution pass.
+6. Each active case has an outcome contract derived from the same source row: observable postconditions, required evidence kinds, and cleanup expectations. Treat it as the concise definition of done, then confirm its full meaning against the raw source. Expected results are immutable; do not weaken an assertion to make execution pass.
 7. Match mutable business entities by identifiers created, selected, or observed in this run. Do not blindly operate on the newest or first row.
 8. Use auto-test-control.mutation_begin before an externally persisted business operation and auto-test-control.mutation_resolve only after its retained or compensated terminal state is verified. Those tools are the authoritative Mutation Ledger. A local JSON file, note, script, screenshot, or final-result claim with a similar name does not register or resolve a mutation. One entry may cover one coherent business operation; ordinary navigation, reads, and field entry do not need entries.
 9. Before finishing, inspect pending ledger entries and verify cleanup or the explicitly expected retained state. Do not repeat a prior write merely because the browser restarted.
@@ -135,6 +140,9 @@ ${materialUrls.map((url) => `- ${url}`).join('\n') || '- (none)'}
 Known starting origins (context, not a browser network allowlist):
 ${registeredOrigins.map((origin) => `- ${origin}`).join('\n') || '- (none)'}
 
+Scenario experience briefs (loaded on demand; protocol stays in Core):
+${skillBriefContext(selectedBriefs)}
+
 Parsed active case manifest (use as an index; read the raw source for complete business meaning):
 ${JSON.stringify(options.manifest, null, 2)}
 `
@@ -171,6 +179,7 @@ Requirements:
 - Preserve the exact workflowId, sourceSha256, and case IDs from the immutable test contract.
 - Include every test case exactly once.
 - Mark passed only when the requested operation and observable expected result were verified.
+- For cases with an outcome contract, cover every observable postcondition, cite concrete observation evidence, and include a same-case interaction receipt when the contract requires it. Cleanup expectations remain subject to the authoritative Mutation Ledger.
 - Include executionReceiptIds from the passive auto-test-control.execution_receipts summary when same-case attribution is available. Use the minimum recommended IDs, normally one interaction and one observation, rather than copying the full receipt log. Receipts are audit evidence, not a substitute for business reasoning or a prerequisite for browser work. A passed or product_failed case must still cite concrete case-specific evidence; when receipt attribution is available, do not reuse a receipt from another case. An environment-blocked case needs live observation and a recorded environment requirement.
 - Use product_failed only for an observed product or business mismatch after the intended test action was correctly executed.
 - Use blocked for missing environment, authentication, test data, authority, ambiguous identity, incomplete execution, or unrecovered state.

--- a/src/agent/result-workbook.ts
+++ b/src/agent/result-workbook.ts
@@ -354,14 +354,16 @@ function sourceLabel(source: CodexTestCaseResult['failureSource']): string {
 }
 
 function kindLabel(kind: CodexTestCaseResult['failureKind']): string {
-  const labels = {
+  const labels: Record<NonNullable<CodexTestCaseResult['failureKind']>, string> = {
     assertion: '断言',
     validation: '校验',
     authentication: '认证',
     environment: '环境',
     data: '测试数据',
     execution: '执行',
-  } as const
+    locator: '定位/导航',
+    mutation: '写入/清理',
+  }
   return kind ? labels[kind] : ''
 }
 

--- a/src/agent/result.ts
+++ b/src/agent/result.ts
@@ -21,7 +21,7 @@ export const codexTestResultSchema = {
           outcome: { type: 'string', enum: ['passed', 'product_failed', 'blocked'] },
           summary: { type: 'string' },
           failureSource: { type: ['string', 'null'], enum: ['product', 'agent_execution', 'environment', 'input', 'infrastructure', null] },
-          failureKind: { type: ['string', 'null'], enum: ['assertion', 'validation', 'authentication', 'environment', 'data', 'execution', null] },
+          failureKind: { type: ['string', 'null'], enum: ['assertion', 'validation', 'authentication', 'environment', 'data', 'execution', 'locator', 'mutation', null] },
           environmentRequirementIds: { type: ['array', 'null'], items: { type: 'string' } },
           executionReceiptIds: { type: ['array', 'null'], items: { type: 'string' } },
           fieldGateIds: { type: ['array', 'null'], items: { type: 'string' } },

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -20,7 +20,8 @@ import { createAgentHost } from './host-registry.js'
 import { agentTestCheckpointPrompt, agentTestFinalPrompt, agentTestPrompt, agentTestResumePrompt } from './prompt.js'
 import { AgentTestProgressReporter, type AgentTestProgressSink } from './progress.js'
 import { redactAgentArtifactValue, redactAgentJsonValue, redactAgentValue, secretValues, transientAgentEventValues } from './redact.js'
-import { agentTestStructuredOutputSchema, enforceMutationLedger, parseAgentTestCandidate } from './result.js'
+import { enforceMutationLedger, parseAgentTestCandidate, agentTestStructuredOutputSchema } from './result.js'
+import { failureModeFor } from './failure-mode.js'
 import { initialAgentTestState as initialCodexTestState, updateAgentTestState as updateCodexTestState, writePrivateJson } from './state.js'
 import type {
   CodexTestAgentResult,
@@ -143,7 +144,7 @@ async function runTurn(
   }
 }
 
-function finalResultProblems(
+export function finalResultProblems(
   result: CodexTestAgentResult,
   manifest: WorkflowIntakeManifest,
   recordedEnvironmentRequirements: CodexTestEnvironmentRequirement[] = [],
@@ -158,6 +159,7 @@ function finalResultProblems(
   for (const caseId of requiredCases) if (!returnedCases.includes(caseId)) problems.push(`missing final case result for ${caseId}`)
   for (const caseId of returnedCases) if (!requiredCases.has(caseId)) problems.push(`unexpected case result for ${caseId}`)
   for (const item of result.cases) {
+    const phase = manifest.phases.find((candidate) => candidate.id === item.caseId)
     if (item.evidence.length === 0) problems.push(`case ${item.caseId} has no execution evidence`)
     if (item.outcome === 'passed' && (item.failureSource || item.failureKind)) problems.push(`passed case ${item.caseId} contains a failure classification`)
     if (item.outcome !== 'passed' && (!item.failureSource || !item.failureKind)) problems.push(`non-passed case ${item.caseId} has no failure classification`)
@@ -169,6 +171,20 @@ function finalResultProblems(
     }
     if (caseReceipts.some((receipt) => receipt.caseId !== item.caseId)) {
       problems.push(`case ${item.caseId} references an execution receipt belonging to another case`)
+    }
+    if (item.outcome !== 'blocked' && phase?.outcome) {
+      if (phase.outcome.evidence.includes('observation') && !item.evidence.some((evidence) => evidence.kind === 'observation')) {
+        problems.push(`case ${item.caseId} does not satisfy its outcome observation evidence requirement`)
+      }
+      if (phase.outcome.evidence.includes('interaction') && !caseReceipts.some((receipt) => receipt.kind === 'interaction')) {
+        problems.push(`case ${item.caseId} does not satisfy its outcome interaction receipt requirement`)
+      }
+    }
+    if (item.outcome !== 'passed' && phase?.outcome && (phase.outcome.failureModes?.length ?? 0) > 0) {
+      const mode = failureModeFor(item.failureSource, item.failureKind)
+      if (!phase.outcome.failureModes!.includes(mode)) {
+        problems.push(`case ${item.caseId} failure mode ${mode} is not allowed by its outcome contract`)
+      }
     }
     // Receipts are passively captured audit evidence. They are validated when
     // the agent cites them, but missing optional case bookkeeping must not

--- a/src/agent/skill-brief.ts
+++ b/src/agent/skill-brief.ts
@@ -1,0 +1,69 @@
+import type { WorkflowCapability, WorkflowIntakeManifest, WorkflowRisk } from '../workflow/types.js'
+
+/**
+ * Experiential, scenario-selected guidance that is loaded on demand instead of
+ * living in the permanent prompt. Security and result protocol (Mutation
+ * Ledger, authentication-as-test-state, outcome contract, delivery contract)
+ * intentionally stay in Core; these briefs only carry how-to knowledge for a
+ * concrete environment or scenario.
+ */
+
+export interface AgentSkillBrief {
+  id: string
+  title: string
+  /** Signals that select this brief. A brief with no triggers is never auto-loaded. */
+  triggers: {
+    capabilities?: WorkflowCapability[]
+    risks?: WorkflowRisk[]
+  }
+  /** Experiential guidance only; no credentials, no protocol. */
+  body: string
+}
+
+export const BUILT_IN_SKILL_BRIEFS: readonly AgentSkillBrief[] = [
+  {
+    id: 'embedded-image-interpretation',
+    title: '内嵌/补充图片解读',
+    triggers: { capabilities: ['embeddedImageUnderstanding'] },
+    body: '当测试材料包含内嵌或补充图片时，先用视觉能力读出图片中的界面状态、字段位置和预期布局，再回到实时页面核对。图片是来源证据，不是可直接复用的定位器；以实时页面结构和可访问语义为准。',
+  },
+  {
+    id: 'table-entity-identification',
+    title: '表格实体识别',
+    triggers: { capabilities: ['runtimeEntityCapture'] },
+    body: '当用例要求关联“最新/匹配”的订单或记录时，先在本轮运行中捕获或选择明确的实体 ID，再按 ID 定位表格行；不要默认操作列表第一行或最近一行。用列头而不是行号来识别列。',
+  },
+  {
+    id: 'async-wait-patterns',
+    title: '异步等待规则',
+    triggers: { capabilities: ['scheduledWait'] },
+    body: '等待页面状态时，优先等待可观察的完成信号（加载指示消失、目标元素出现、网络请求完成），而不是固定秒数。随机时间窗必须在执行前收敛为明确范围或策略。',
+  },
+  {
+    id: 'multi-origin-session',
+    title: '跨域会话',
+    triggers: { capabilities: ['multiOrigin'] },
+    body: '跨域导航时，先确认每个域的登录与权限状态，再按来源步骤建立或复用会话；不要把单域已登录状态假设到其他域。',
+  },
+  {
+    id: 'fresh-context-per-iteration',
+    title: '多轮/多账户隔离',
+    triggers: { capabilities: ['freshBrowserContextPerIteration'] },
+    body: '循环或多账户执行时，每轮使用干净的上下文并重新建立该轮前置条件，避免上一轮缓存或会话污染下一轮。',
+  },
+]
+
+export function selectSkillBriefs(manifest: WorkflowIntakeManifest): AgentSkillBrief[] {
+  const capabilities = new Set(manifest.requiredCapabilities ?? [])
+  const risks = new Set((manifest.phases ?? []).map((phase) => phase.risk).filter((risk): risk is WorkflowRisk => Boolean(risk)))
+  return BUILT_IN_SKILL_BRIEFS.filter((brief) => {
+    const capabilityMatch = !brief.triggers.capabilities || brief.triggers.capabilities.some((capability) => capabilities.has(capability))
+    const riskMatch = !brief.triggers.risks || brief.triggers.risks.some((risk) => risks.has(risk))
+    return capabilityMatch && riskMatch
+  })
+}
+
+export function skillBriefContext(briefs: readonly AgentSkillBrief[]): string {
+  if (briefs.length === 0) return '（没有匹配当前场景的经验提示）'
+  return briefs.map((brief) => `${brief.title}：${brief.body}`).join('\n')
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,7 +1,23 @@
 export type CodexTestOutcome = 'passed' | 'product_failed' | 'blocked'
 export type CodexTestRisk = 'read' | 'write' | 'destructive'
 export type CodexTestFailureSource = 'product' | 'agent_execution' | 'environment' | 'input' | 'infrastructure'
-export type CodexTestFailureKind = 'assertion' | 'validation' | 'authentication' | 'environment' | 'data' | 'execution'
+export type CodexTestFailureKind = 'assertion' | 'validation' | 'authentication' | 'environment' | 'data' | 'execution' | 'locator' | 'mutation'
+
+/**
+ * Standardized failure-mode grouping used by eval scorecards and outcome
+ * contracts. It is a derived taxonomy over failureSource/failureKind, not a
+ * new raw result field: Agent, Core, report, and eval all map to the same
+ * eight buckets so pass-rate is never the only comparison dimension.
+ */
+export type AgentTestFailureMode =
+  | 'input'
+  | 'authentication'
+  | 'environment'
+  | 'locator_navigation'
+  | 'business_assertion'
+  | 'mutation_cleanup'
+  | 'agent_execution'
+  | 'infrastructure'
 export type CodexTestRunInterruptionCode =
   | 'provider_capacity'
   | 'provider_rate_limited'

--- a/src/agent/workspace.ts
+++ b/src/agent/workspace.ts
@@ -4,6 +4,7 @@ import { basename, resolve } from 'node:path'
 import type { EnvironmentProfile } from '../workflow/environment-profile.js'
 import type { WorkflowIntakeManifest, WorkflowSecretBinding } from '../workflow/types.js'
 import type { CodexTestControlConfig } from './control-types.js'
+import { DEFAULT_AGENT_FANOUT_POLICY } from './fanout-policy.js'
 import type { CodexTestRisk } from './types.js'
 import { writePrivateJson } from './state.js'
 import { agentProcessEnvironment, copyPrivateFile, writePrivateText } from './provider-runtime.js'
@@ -361,6 +362,7 @@ export async function prepareAgentWorkspace(options: {
     fieldCompositionPath,
     secretValuesPath: playwrightSecretsPath,
     testDataAccess: options.testDataAccess ?? 'direct',
+    fanoutPolicy: DEFAULT_AGENT_FANOUT_POLICY,
   }
   await writePrivateJson(controlConfigPath, controlConfig)
 

--- a/src/cli/compare-agent-runs.ts
+++ b/src/cli/compare-agent-runs.ts
@@ -25,11 +25,12 @@ function valuesAfter(args: string[], name: string): string[] {
 function help(): string {
   return [
     '用法:',
-    '  npm run agent:compare -- --run <codex-run> --run <omp-run> [--oracle <json>] [--output <json>]',
+    '  npm run agent:compare -- --run <baseline-run> --run <candidate-run> [--oracle <json>] [--require-oracle-match] [--output <json>]',
     '',
     '该命令只比较已经完成的 AgentHost 运行制品，不启动浏览器、不调用模型、不重做业务写入。',
     '比较器会读取每个 run 的 immutable test-manifest.json；没有 oracle 时只报告合同是否一致和逐 case 差异，不擅自判断哪个宿主更正确。',
     'oracle 必须同时提供 version、workflowId、sourceSha256 和完整逐 case 期望。',
+    '--require-oracle-match 要求每个候选完整命中 oracle，适合 CI 和必须能失败的 probe。',
   ].join('\n')
 }
 
@@ -42,6 +43,8 @@ export async function runAgentComparisonCli(args: string[]): Promise<number> {
   if (runDirectories.length < 2) throw new Error('至少提供两个 --run 目录（通常分别是 Codex 和 OMP）')
   const oraclePath = valueAfter(args, '--oracle')
   const oracle = oraclePath ? JSON.parse(await readFile(resolve(oraclePath), 'utf8')) as AgentCompetitionOracle : undefined
+  const requireOracleMatch = args.includes('--require-oracle-match')
+  if (requireOracleMatch && !oracle) throw new Error('--require-oracle-match 必须同时提供 --oracle')
   const report = await compareAgentRuns({ runDirectories, ...(oracle ? { oracle } : {}) })
   const output = resolve(valueAfter(args, '--output') ?? 'agent-competition.json')
   await writeAgentCompetitionReport(output, report)
@@ -50,11 +53,20 @@ export async function runAgentComparisonCli(args: string[]): Promise<number> {
   for (const candidate of report.candidates) {
     const build = [candidate.platform, candidate.arch, candidate.packageVersion, candidate.commit].filter(Boolean).join(' / ')
     console.log(`- ${candidate.hostId}：${candidate.outcome}，通过 ${candidate.caseCounts.passed}，产品不符预期 ${candidate.caseCounts.product_failed}，阻断 ${candidate.caseCounts.blocked}，pending mutation ${candidate.pendingMutationCount}，运行环境 ${build}`)
+    if (candidate.oracleMatchedCases !== undefined) console.log(`  oracle：${candidate.oracleMatchedCases}/${report.oracle?.cases.length ?? 0}（${Math.round((candidate.oracleMatchRate ?? 0) * 100)}%）`)
+    if (candidate.failureModes && Object.keys(candidate.failureModes).length > 0) console.log(`  失败模式：${Object.entries(candidate.failureModes).map(([mode, count]) => `${mode}=${count}`).join('，')}`)
+    if (candidate.inputTokens !== undefined || candidate.outputTokens !== undefined) {
+      console.log(`  tokens：输入 ${candidate.inputTokens ?? 0}（缓存 ${candidate.cachedInputTokens ?? 0}），输出 ${candidate.outputTokens ?? 0}`)
+    }
+    if (candidate.threadGeneration !== undefined) console.log(`  恢复：线程代数 ${candidate.threadGeneration}，恢复 ${candidate.recoveryCount ?? 0}，epoch ${candidate.epochCount ?? '-'}${candidate.interruptionCode ? `，中断 ${candidate.interruptionCode}` : ''}`)
+    if (candidate.baselineDelta) console.log(`  相对 baseline：耗时 ${candidate.baselineDelta.durationMs ?? 0}ms，证据 ${candidate.baselineDelta.evidenceCount >= 0 ? '+' : ''}${candidate.baselineDelta.evidenceCount}，回执 ${candidate.baselineDelta.citedReceiptCount >= 0 ? '+' : ''}${candidate.baselineDelta.citedReceiptCount}，输出 tokens ${candidate.baselineDelta.outputTokens !== undefined ? (candidate.baselineDelta.outputTokens >= 0 ? '+' : '') + candidate.baselineDelta.outputTokens : '-'}`)
   }
   if (report.caseDifferences.length > 0) console.log(`逐 case 差异：${report.caseDifferences.length} 条`)
   for (const problem of report.contractProblems) console.log(`合同问题：${problem}`)
   console.log(`报告文件：${output}`)
-  return report.contractStatus === 'valid' ? 0 : 1
+  if (report.contractStatus !== 'valid') return 1
+  if (requireOracleMatch && report.candidates.some((candidate) => candidate.oracleMatchRate !== 1)) return 1
+  return 0
 }
 
 if (process.argv[1] && resolve(process.argv[1]).endsWith('compare-agent-runs.ts')) {

--- a/src/eval/eval-suite.ts
+++ b/src/eval/eval-suite.ts
@@ -1,0 +1,156 @@
+import type { AgentTestFailureMode } from '../agent/types.js'
+
+/**
+ * Fixed, versioned eval task set. This is the single place that declares which
+ * existing scenarios (canary, local fixture, Windows acceptance, recovery) form
+ * the regression matrix, and which of the eight failure modes each task is
+ * able to expose. It is a data contract, not a new runner: comparison still
+ * happens through `agent:compare`, and no task in this suite may require a new
+ * service or a default parallel write fan-out.
+ */
+
+export type EvalSuiteTaskCategory = 'canary' | 'fixture' | 'windows-acceptance' | 'recovery'
+
+export interface EvalSuiteTask {
+  id: string
+  category: EvalSuiteTaskCategory
+  title: string
+  description: string
+  /** Failure modes a regression in this task would surface. */
+  probes: AgentTestFailureMode[]
+  /** Whether CI must require a full oracle match for this task. */
+  requiresOracleMatch: boolean
+  /** Immutable input contract this task is bound to. */
+  inputContract: {
+    kind: 'manifest' | 'oracle' | 'run-artifact'
+    path: string
+  }
+}
+
+export interface EvalSuite {
+  version: '1.0'
+  kind: 'eval-suite'
+  /** Stable identity of the fixed task list; bump only on an intentional matrix change. */
+  suiteId: string
+  tasks: EvalSuiteTask[]
+}
+
+export const EVAL_SUITE_ID = 'canonical-regression-matrix-v1'
+
+export const AGENT_TEST_FAILURE_MODE_PROBES: readonly AgentTestFailureMode[] = [
+  'input',
+  'authentication',
+  'environment',
+  'locator_navigation',
+  'business_assertion',
+  'mutation_cleanup',
+  'agent_execution',
+  'infrastructure',
+]
+
+/**
+ * The canonical fixed task set. Every entry maps to an existing, exercised
+ * scenario in this repository; no entry invents a new write path.
+ */
+export function canonicalEvalSuite(): EvalSuite {
+  return {
+    version: '1.0',
+    kind: 'eval-suite',
+    suiteId: EVAL_SUITE_ID,
+    tasks: [
+      {
+        id: 'readonly-canary',
+        category: 'canary',
+        title: '只读 canary 回归',
+        description: '用同一个只读输入包跑两个 AgentHost，比较业务 outcome、证据完整性和失败来源。',
+        probes: ['business_assertion', 'environment', 'authentication'],
+        requiresOracleMatch: true,
+        inputContract: { kind: 'oracle', path: 'evals/readonly-canary.oracle.json' },
+      },
+      {
+        id: 'local-fixture-site',
+        category: 'fixture',
+        title: '本地 fixture 站点回归',
+        description: '在 tests/fixtures/site 上验证定位、导航、断言和输入解析，不产生外部副作用。',
+        probes: ['input', 'locator_navigation', 'business_assertion', 'environment'],
+        requiresOracleMatch: true,
+        inputContract: { kind: 'manifest', path: 'tests/fixtures/site' },
+      },
+      {
+        id: 'windows-acceptance',
+        category: 'windows-acceptance',
+        title: 'Windows 验收回归',
+        description: '按 docs/windows-acceptance-runbook.md 的固定步骤验证启动、环境注册与结果交付。',
+        probes: ['environment', 'infrastructure'],
+        requiresOracleMatch: false,
+        inputContract: { kind: 'run-artifact', path: 'docs/windows-acceptance-runbook.md' },
+      },
+      {
+        id: 'delivery-recovery',
+        category: 'recovery',
+        title: '中断恢复与交付回归',
+        description: '验证 interrupted run 的恢复、Mutation Ledger 终态和逐 case 交付校验。',
+        probes: ['agent_execution', 'infrastructure', 'mutation_cleanup'],
+        requiresOracleMatch: true,
+        inputContract: { kind: 'run-artifact', path: 'artifacts' },
+      },
+    ],
+  }
+}
+
+export function evalSuiteProblems(suite: EvalSuite): string[] {
+  const problems: string[] = []
+  if (suite.version !== '1.0') problems.push('eval suite version must be "1.0"')
+  if (suite.kind !== 'eval-suite') problems.push('eval suite kind must be "eval-suite"')
+  if (!suite.suiteId?.trim()) problems.push('eval suite suiteId is required')
+  if (!Array.isArray(suite.tasks) || suite.tasks.length === 0) {
+    problems.push('eval suite must declare at least one task')
+    return problems
+  }
+  const ids = new Set<string>()
+  const coveredModes = new Set<AgentTestFailureMode>()
+  for (const task of suite.tasks) {
+    if (!task.id?.trim()) {
+      problems.push('eval suite task has no id')
+      continue
+    }
+    if (ids.has(task.id)) problems.push(`duplicate eval suite task ${task.id}`)
+    ids.add(task.id)
+    if (!['canary', 'fixture', 'windows-acceptance', 'recovery'].includes(task.category)) {
+      problems.push(`eval suite task ${task.id} has an unknown category`)
+    }
+    if (!task.title?.trim()) problems.push(`eval suite task ${task.id} has no title`)
+    if (!task.description?.trim()) problems.push(`eval suite task ${task.id} has no description`)
+    if (!Array.isArray(task.probes) || task.probes.length === 0) {
+      problems.push(`eval suite task ${task.id} must declare at least one failure-mode probe`)
+    }
+    for (const probe of task.probes ?? []) {
+      if (!AGENT_TEST_FAILURE_MODE_PROBES.includes(probe)) {
+        problems.push(`eval suite task ${task.id} declares an unknown failure-mode probe`)
+      } else {
+        coveredModes.add(probe)
+      }
+    }
+    if (task.requiresOracleMatch !== undefined && typeof task.requiresOracleMatch !== 'boolean') {
+      problems.push(`eval suite task ${task.id} requiresOracleMatch must be a boolean`)
+    }
+    if (!task.inputContract?.path?.trim()) problems.push(`eval suite task ${task.id} has no input contract path`)
+    if (task.inputContract && !['manifest', 'oracle', 'run-artifact'].includes(task.inputContract.kind)) {
+      problems.push(`eval suite task ${task.id} has an unknown input contract kind`)
+    }
+  }
+  for (const mode of AGENT_TEST_FAILURE_MODE_PROBES) {
+    if (!coveredModes.has(mode)) problems.push(`eval suite does not probe failure mode ${mode}`)
+  }
+  return problems
+}
+
+/** Parse and validate an eval suite JSON document without throwing. */
+export function parseEvalSuite(value: unknown): { suite?: EvalSuite; problems: string[] } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { problems: ['eval suite must be a JSON object'] }
+  }
+  const suite = value as EvalSuite
+  const problems = evalSuiteProblems(suite)
+  return problems.length === 0 ? { suite, problems } : { problems }
+}

--- a/src/usability/result-summary.ts
+++ b/src/usability/result-summary.ts
@@ -47,6 +47,8 @@ const failureKindLabels: Record<CodexTestFailureKind, string> = {
   environment: '测试环境条件不可用',
   data: '测试数据缺失或不完整',
   execution: '操作或验证未完成',
+  locator: '定位或导航未完成',
+  mutation: '写入或清理未完成',
 }
 
 function cleanLine(value: string): string {

--- a/src/workflow/intake.ts
+++ b/src/workflow/intake.ts
@@ -8,6 +8,7 @@ import { readWorkbookCases, type RawCaseRow, type WorkbookReadResult } from '../
 import { normalizeText, redactSensitiveContent, slugify, splitNumberedItems } from '../input/text.js'
 import type {
   WorkflowCapability,
+  WorkflowFailureMode,
   WorkflowIntakeManifest,
   WorkflowIntakeResult,
   WorkflowPhaseDraft,
@@ -183,6 +184,25 @@ function instructionParts(value: string): { summary?: string; steps: string[] } 
   }
 }
 
+/**
+ * Default allowable failure modes for an outcome. Mutation cleanup is only a
+ * legitimate classification for cases that can write; read-only cases never
+ * carry it. The remaining seven modes apply to every live-UI case.
+ */
+function failureModesFor(risk: WorkflowRisk): WorkflowFailureMode[] {
+  const modes: WorkflowFailureMode[] = [
+    'input',
+    'authentication',
+    'environment',
+    'locator_navigation',
+    'business_assertion',
+    'agent_execution',
+    'infrastructure',
+  ]
+  if (risk !== 'read') modes.push('mutation_cleanup')
+  return modes
+}
+
 function riskFor(value: string): WorkflowRisk {
   if (/(删除|清空|重置|回滚|撤销|终止|停止|关停|强制|结算|支付|退款|remove|delete|reset|rollback|force\s*stop|settlement)/i.test(value)) return 'destructive'
   if (/(保存|提交|创建|新增|修改|编辑|启用|禁用|启动|开始|上传|导入|发布|审核|授权|触发|执行|登录|save|submit|create|update|edit|enable|disable|start|upload|import|publish|approve)/i.test(value)) return 'write'
@@ -283,6 +303,13 @@ function fallbackPhaseFromRow(
       sourceRow,
       risk: explicitRisk(row.values.risk) ?? riskFor(raw),
       ...(precondition.text ? { summary: precondition.text } : {}),
+      outcome: {
+        action: splitNumberedItems(steps.text),
+        observable: expected.text ? splitNumberedItems(expected.text) : [],
+        evidence: ['interaction', 'observation'],
+        cleanup: cleanup.text ? splitNumberedItems(cleanup.text) : [],
+        failureModes: failureModesFor(explicitRisk(row.values.risk) ?? riskFor(raw)),
+      },
       steps: splitNumberedItems(steps.text).map((step, index) => ({ id: `${phaseId}-step-${index + 1}`, sourceText: step, confidence: 0.5 })),
       resources,
       secretBindings: bindings,
@@ -495,6 +522,13 @@ async function intakeStandardTestCases(
       sourceRow,
       risk: explicitRisk(source.values.risk) ?? testCase.risk,
       ...(testCase.preconditions?.length ? { summary: testCase.preconditions.join('；') } : {}),
+      outcome: {
+        action: splitNumberedItems(steps.text),
+        observable: expected.text ? splitNumberedItems(expected.text) : testCase.assertions.map((assertion) => assertion.sourceText),
+        evidence: ['interaction', 'observation'],
+        cleanup: cleanup.text ? splitNumberedItems(cleanup.text) : [],
+        failureModes: failureModesFor(explicitRisk(source.values.risk) ?? testCase.risk),
+      },
       steps: splitNumberedItems(steps.text).map((step, index) => ({ id: `${phaseId}-step-${index + 1}`, sourceText: step, confidence: 0.85 })),
       resources,
       secretBindings,
@@ -648,6 +682,13 @@ export async function intakeWorkflowXlsx(options: WorkflowIntakeOptions): Promis
       sourceRow: source.sourceRow,
       risk: riskFor(raw),
       ...(parts.summary ? { summary: parts.summary } : {}),
+      outcome: {
+        action: parts.steps,
+        observable: parts.summary ? [parts.summary] : [],
+        evidence: ['interaction', 'observation'],
+        cleanup: [],
+        failureModes: failureModesFor(riskFor(raw)),
+      },
       steps: parts.steps.map((step, stepIndex) => ({ id: `phase-${phaseIndex + 1}-step-${stepIndex + 1}`, sourceText: step, confidence: 0.7 })),
       resources,
       secretBindings: uniqueBindings,

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -2,6 +2,21 @@ import type { Diagnostic } from '../core/types.js'
 
 export type WorkflowRisk = 'read' | 'write' | 'destructive'
 
+/**
+ * Allowed failure-mode taxonomy for a case outcome. Mirrors the eval taxonomy
+ * so an outcome contract, a result classification, and an eval report all
+ * speak the same eight buckets without a second classifier.
+ */
+export type WorkflowFailureMode =
+  | 'input'
+  | 'authentication'
+  | 'environment'
+  | 'locator_navigation'
+  | 'business_assertion'
+  | 'mutation_cleanup'
+  | 'agent_execution'
+  | 'infrastructure'
+
 export type WorkflowCapability =
   | 'embeddedImageUnderstanding'
   | 'multiOrigin'
@@ -31,6 +46,30 @@ export interface WorkflowStepDraft {
   confidence: number
 }
 
+export interface WorkflowOutcomeContract {
+  /** The actions the case must perform, derived from the same source row as steps. */
+  action?: string[]
+  /** Must-be-observed business postconditions. */
+  observable: string[]
+  /** Required evidence: 'interaction' is an execution-receipt kind; 'observation' is a case-evidence kind. */
+  evidence: Array<'interaction' | 'observation'>
+  cleanup: string[]
+  /**
+   * Failure modes this case is allowed to be classified into. When non-empty,
+   * a non-passed result whose derived mode is outside this set is a taxonomy
+   * violation, not merely an unexpected outcome.
+   */
+  failureModes?: WorkflowFailureMode[]
+}
+
+export interface WorkflowMaterialIndexEntry {
+  caseId: string
+  title: string
+  sourceRow: number
+  risk: WorkflowRisk
+  imageCount: number
+}
+
 export interface WorkflowPhaseDraft {
   id: string
   sourceCaseId?: string
@@ -38,6 +77,7 @@ export interface WorkflowPhaseDraft {
   sourceRow: number
   risk: WorkflowRisk
   summary?: string
+  outcome?: WorkflowOutcomeContract
   steps: WorkflowStepDraft[]
   resources: WorkflowResource[]
   secretBindings: WorkflowSecretBinding[]
@@ -86,6 +126,7 @@ export interface WorkflowIntakeManifest {
   declaredTargetUrls?: string[]
   requiredCapabilities: WorkflowCapability[]
   phases: WorkflowPhaseDraft[]
+  materialIndex?: WorkflowMaterialIndexEntry[]
   embeddedImages: WorkflowEmbeddedImage[]
   supplementalImages: WorkflowSupplementalImage[]
   review: {

--- a/tests/agent-compare-cli.test.ts
+++ b/tests/agent-compare-cli.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolve } from 'node:path'
+import { runAgentComparisonCli } from '../src/cli/compare-agent-runs.js'
+
+vi.mock('../src/agent/competition.js', () => ({
+  compareAgentRuns: vi.fn(async () => ({
+    version: '1.0', kind: 'agent-competition', generatedAt: '2026-08-13T00:00:00.000Z',
+    workflowId: 'probe', sourceSha256: 'a'.repeat(64), contractStatus: 'valid', contractProblems: [],
+    verdict: 'oracle_winner', winnerHostId: 'baseline', caseDifferences: [],
+    oracle: { version: '1.0', workflowId: 'probe', sourceSha256: 'a'.repeat(64), cases: [{ caseId: 'must-fail', outcome: 'blocked' }] },
+    candidates: [
+      { runDirectory: '/baseline', hostId: 'baseline', platform: 'test', arch: 'test', terminal: true, outcome: 'blocked', caseCounts: { passed: 0, product_failed: 0, blocked: 1 }, evidenceCount: 1, citedReceiptCount: 0, mutationCount: 0, pendingMutationCount: 0, oracleMatchedCases: 1, oracleMatchRate: 1, failureSources: { environment: 1 }, failureKinds: { environment: 1 } },
+      { runDirectory: '/candidate', hostId: 'candidate', platform: 'test', arch: 'test', terminal: true, outcome: 'passed', caseCounts: { passed: 1, product_failed: 0, blocked: 0 }, evidenceCount: 1, citedReceiptCount: 0, mutationCount: 0, pendingMutationCount: 0, oracleMatchedCases: 0, oracleMatchRate: 0, failureSources: {}, failureKinds: {}, baselineDelta: { evidenceCount: 0, citedReceiptCount: 0, mutationCount: 0, oracleMatchedCases: -1 } },
+    ],
+  })),
+  writeAgentCompetitionReport: vi.fn(async () => undefined),
+}))
+
+describe('agent comparison CLI eval gate', () => {
+  it('fails when a probe expected to fail does not match the oracle', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    expect(await runAgentComparisonCli(['--run', '/baseline', '--run', '/candidate', '--oracle', resolve('package.json'), '--require-oracle-match'])).toBe(1)
+  })
+
+  it('requires an oracle for the strict eval gate', async () => {
+    await expect(runAgentComparisonCli(['--run', '/baseline', '--run', '/candidate', '--require-oracle-match']))
+      .rejects.toThrow(/必须同时提供 --oracle/)
+  })
+})

--- a/tests/agent-competition.test.ts
+++ b/tests/agent-competition.test.ts
@@ -88,6 +88,15 @@ describe('AgentHost competition contract', () => {
     expect(report.verdict).toBe('oracle_winner')
     expect(report.winnerHostId).toBe('codex')
     expect(report.caseDifferences).toHaveLength(1)
+    expect(report.candidates[0]).toMatchObject({ oracleMatchedCases: 1, oracleMatchRate: 1 })
+    expect(report.candidates[1]).toMatchObject({
+      oracleMatchedCases: 0,
+      oracleMatchRate: 0,
+      failureSources: { product: 1 },
+      failureKinds: { execution: 1 },
+      failureModes: { business_assertion: 1 },
+      baselineDelta: { evidenceCount: 0, citedReceiptCount: 0, mutationCount: 0, oracleMatchedCases: -1 },
+    })
   })
 
   it('rejects candidates from different immutable test contracts', async () => {
@@ -146,6 +155,32 @@ describe('AgentHost competition contract', () => {
     const report = await compareAgentRuns({ runDirectories: [codex, omp] })
     expect(report.contractStatus).toBe('invalid')
     expect(report.contractProblems.some((problem) => problem.includes('environment Profile/权限合同不一致'))).toBe(true)
+  })
+
+  it('aggregates token and recovery metrics from the run artifacts', async () => {
+    const root = await mkdtemp(resolve(tmpdir(), 'auto-test-competition-metrics-'))
+    directories.push(root)
+    const expected = result()
+    const codex = await makeRun(root, 'codex', expected)
+    const omp = await makeRun(root, 'omp', expected)
+    await writeFile(resolve(codex, 'codex-agent.events.jsonl'), [
+      JSON.stringify({ type: 'turn_completed', usage: { inputTokens: 10, cachedInputTokens: 4, outputTokens: 2 } }),
+      JSON.stringify({ type: 'turn_completed', usage: { inputTokens: 30, cachedInputTokens: 6, outputTokens: 8 } }),
+    ].join('\n'))
+    const statePath = resolve(codex, 'codex-agent.state.json')
+    const state = JSON.parse(await readFile(statePath, 'utf8')) as CodexTestAgentState
+    state.threadGeneration = 3
+    state.epochCount = 3
+    await writeFile(statePath, JSON.stringify(state))
+    const report = await compareAgentRuns({ runDirectories: [codex, omp] })
+    expect(report.candidates[0]).toMatchObject({
+      inputTokens: 40,
+      cachedInputTokens: 10,
+      outputTokens: 10,
+      threadGeneration: 3,
+      epochCount: 3,
+      recoveryCount: 2,
+    })
   })
 
   it('rejects duplicate hosts and an oracle that is not bound to the input contract', async () => {

--- a/tests/agent-failure-mode.test.ts
+++ b/tests/agent-failure-mode.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_TEST_FAILURE_MODES,
+  failureModeCounts,
+  failureModeFor,
+  isAgentTestFailureMode,
+} from '../src/agent/failure-mode.js'
+import type { AgentTestFailureKind, AgentTestFailureMode, AgentTestFailureSource } from '../src/agent/types.js'
+
+describe('agent failure-mode taxonomy', () => {
+  it('exposes exactly the eight standardized failure modes', () => {
+    expect(AGENT_TEST_FAILURE_MODES).toEqual([
+      'input',
+      'authentication',
+      'environment',
+      'locator_navigation',
+      'business_assertion',
+      'mutation_cleanup',
+      'agent_execution',
+      'infrastructure',
+    ])
+  })
+
+  it('accepts only the canonical mode names', () => {
+    expect(isAgentTestFailureMode('locator_navigation')).toBe(true)
+    expect(isAgentTestFailureMode('unknown-mode')).toBe(false)
+  })
+
+  // One probe per failure mode: each mode must be expressible and map
+  // deterministically from a concrete (failureSource, failureKind) pair so the
+  // eval report can slice results beyond a single pass rate.
+  const probes: Array<{ mode: AgentTestFailureMode; source: AgentTestFailureSource; kind: AgentTestFailureKind }> = [
+    { mode: 'input', source: 'input', kind: 'validation' },
+    { mode: 'authentication', source: 'environment', kind: 'authentication' },
+    { mode: 'environment', source: 'environment', kind: 'environment' },
+    { mode: 'locator_navigation', source: 'agent_execution', kind: 'locator' },
+    { mode: 'business_assertion', source: 'product', kind: 'assertion' },
+    { mode: 'mutation_cleanup', source: 'agent_execution', kind: 'mutation' },
+    { mode: 'agent_execution', source: 'agent_execution', kind: 'execution' },
+    { mode: 'infrastructure', source: 'infrastructure', kind: 'execution' },
+  ]
+
+  it('maps every failure mode from a concrete classification', () => {
+    for (const probe of probes) {
+      expect(failureModeFor(probe.source, probe.kind)).toBe(probe.mode)
+    }
+  })
+
+  it('can fail: an unknown classification collapses to agent_execution, never silently to passed', () => {
+    expect(failureModeFor('agent_execution', undefined)).toBe('agent_execution')
+    expect(failureModeFor(undefined, undefined)).toBe('agent_execution')
+  })
+
+  it('counts non-passed cases into the eight buckets', () => {
+    const counts = failureModeCounts([
+      { failureSource: 'product', failureKind: 'assertion' },
+      { failureSource: 'product', failureKind: 'data' },
+      { failureSource: 'input', failureKind: 'validation' },
+      { failureSource: 'agent_execution', failureKind: 'mutation' },
+    ])
+    expect(counts).toEqual({
+      business_assertion: 2,
+      input: 1,
+      mutation_cleanup: 1,
+    })
+  })
+
+  it('excludes passed cases with no failure classification from the distribution', () => {
+    const counts = failureModeCounts([
+      {},
+      {},
+      { failureSource: 'product', failureKind: 'assertion' },
+    ])
+    expect(counts).toEqual({ business_assertion: 1 })
+  })
+})

--- a/tests/agent-fanout-policy.test.ts
+++ b/tests/agent-fanout-policy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_AGENT_FANOUT_POLICY,
+  fanoutPolicyProblems,
+} from '../src/agent/fanout-policy.js'
+
+describe('bounded fan-out policy', () => {
+  it('ships a read-only, serialized default', () => {
+    expect(DEFAULT_AGENT_FANOUT_POLICY).toMatchObject({
+      version: '1.0',
+      maxConcurrency: 1,
+      writeFanout: false,
+    })
+    expect(fanoutPolicyProblems(DEFAULT_AGENT_FANOUT_POLICY)).toEqual([])
+  })
+
+  it('rejects invalid policies', () => {
+    expect(fanoutPolicyProblems(null)).toContain('fanout policy must be a JSON object')
+    expect(fanoutPolicyProblems({ ...DEFAULT_AGENT_FANOUT_POLICY, maxConcurrency: 0 }))
+      .toContain('fanout policy maxConcurrency must be a positive integer')
+    expect(fanoutPolicyProblems({ ...DEFAULT_AGENT_FANOUT_POLICY, scopes: ['bogus'] }))
+      .toContain('fanout policy contains an unknown scope: bogus')
+  })
+})

--- a/tests/agent-outcome-contract.test.ts
+++ b/tests/agent-outcome-contract.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { finalResultProblems } from '../src/agent/runner.js'
+import type { CodexTestAgentResult, CodexTestExecutionReceipt } from '../src/agent/types.js'
+import type { WorkflowIntakeManifest } from '../src/workflow/types.js'
+
+function manifest(): WorkflowIntakeManifest {
+  return {
+    version: '1.0', kind: 'workflow-intake', workflowId: 'outcome-fixture',
+    source: { format: 'xlsx', fileName: 'fixture.xlsx', sheetName: 'Cases', sha256: 'a'.repeat(64) },
+    targetUrls: ['https://example.test/'], requiredCapabilities: [],
+    phases: [{
+      id: 'case-one', title: 'Submit and verify', sourceRow: 2, risk: 'write',
+      outcome: {
+        action: ['Submit the form'],
+        observable: ['Confirmation is visible'],
+        evidence: ['interaction', 'observation'],
+        cleanup: ['Remove created row'],
+        failureModes: ['input', 'authentication', 'environment', 'locator_navigation', 'business_assertion', 'mutation_cleanup', 'agent_execution', 'infrastructure'],
+      },
+      steps: [], resources: [], secretBindings: [], imageIds: [], review: { status: 'draft', ambiguities: [] },
+    }],
+    embeddedImages: [], supplementalImages: [], review: { status: 'draft', reasons: [] },
+  }
+}
+
+function result(): CodexTestAgentResult {
+  return {
+    version: '1.0', workflowId: 'outcome-fixture', sourceSha256: 'a'.repeat(64), outcome: 'passed',
+    summary: 'passed', startedAt: '2026-08-13T00:00:00.000Z', finishedAt: '2026-08-13T00:00:01.000Z',
+    cases: [{
+      caseId: 'case-one', title: 'Submit and verify', outcome: 'passed', summary: 'verified',
+      executionReceiptIds: ['interaction-one'],
+      evidence: [{ kind: 'observation', description: 'Confirmation is visible' }],
+    }],
+    mutations: [], environmentRequirements: [], blockers: [], productDefects: [], nextActions: [],
+  }
+}
+
+const receipt: CodexTestExecutionReceipt = {
+  id: 'interaction-one', caseId: 'case-one', tool: 'browser_click', kind: 'interaction', status: 'completed', recordedAt: '2026-08-13T00:00:00.500Z',
+}
+
+describe('Agent outcome contract validation', () => {
+  it('accepts matching observation evidence and a same-case interaction receipt', () => {
+    expect(finalResultProblems(result(), manifest(), [], [receipt])).toEqual([])
+  })
+
+  it('fails a false pass that has observation text but no required interaction receipt', () => {
+    const candidate = result()
+    candidate.cases[0]!.executionReceiptIds = []
+    expect(finalResultProblems(candidate, manifest(), [], [receipt]))
+      .toContain('case case-one does not satisfy its outcome interaction receipt requirement')
+  })
+
+  it('does not require an interaction when the case is blocked before execution', () => {
+    const candidate = result()
+    candidate.outcome = 'blocked'
+    candidate.cases[0] = {
+      ...candidate.cases[0]!, outcome: 'blocked', failureSource: 'input', failureKind: 'validation', executionReceiptIds: [],
+    }
+    candidate.blockers = ['Source expected result is incomplete']
+    expect(finalResultProblems(candidate, manifest(), [], [])).not.toContain(expect.stringContaining('outcome interaction'))
+  })
+
+  it('rejects a failure mode that the outcome contract does not allow', () => {
+    const constrained = manifest()
+    constrained.phases[0]!.outcome = {
+      ...constrained.phases[0]!.outcome!,
+      failureModes: ['business_assertion'],
+    }
+    const candidate = result()
+    candidate.outcome = 'blocked'
+    candidate.blockers = ['Cleanup could not be verified']
+    candidate.cases[0] = {
+      ...candidate.cases[0]!,
+      outcome: 'blocked',
+      failureSource: 'agent_execution',
+      failureKind: 'mutation',
+      executionReceiptIds: ['interaction-one'],
+    }
+    expect(finalResultProblems(candidate, constrained, [], [receipt]))
+      .toContain('case case-one failure mode mutation_cleanup is not allowed by its outcome contract')
+  })
+
+  it('accepts an allowed failure mode declared in the outcome contract', () => {
+    const candidate = result()
+    candidate.outcome = 'blocked'
+    candidate.blockers = ['Cleanup could not be verified']
+    candidate.cases[0] = {
+      ...candidate.cases[0]!,
+      outcome: 'blocked',
+      failureSource: 'agent_execution',
+      failureKind: 'mutation',
+      executionReceiptIds: ['interaction-one'],
+    }
+    expect(finalResultProblems(candidate, manifest(), [], [receipt])).toEqual([])
+  })
+
+  it('keeps legacy outcome contracts without action/failureModes readable', () => {
+    const legacy = manifest()
+    legacy.phases[0]!.outcome = {
+      observable: ['Confirmation is visible'],
+      evidence: ['interaction', 'observation'],
+      cleanup: ['Remove created row'],
+    }
+    expect(finalResultProblems(result(), legacy, [], [receipt])).toEqual([])
+  })
+
+  it('requires an observation-kind evidence, not merely any non-mutation evidence', () => {
+    const candidate = result()
+    candidate.cases[0]!.evidence = [{ kind: 'screenshot', description: 'a screenshot is not a postcondition observation' }]
+    expect(finalResultProblems(candidate, manifest(), [], [receipt]))
+      .toContain('case case-one does not satisfy its outcome observation evidence requirement')
+  })
+
+  it('does not reject a passed case whose outcome contract lacks action or observable text', () => {
+    const sparse = manifest()
+    sparse.phases[0]!.outcome = {
+      observable: [],
+      evidence: ['interaction', 'observation'],
+      cleanup: [],
+    }
+    expect(finalResultProblems(result(), sparse, [], [receipt])).toEqual([])
+  })
+})

--- a/tests/agent-skill-brief.test.ts
+++ b/tests/agent-skill-brief.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { selectSkillBriefs, skillBriefContext } from '../src/agent/skill-brief.js'
+import type { WorkflowIntakeManifest } from '../src/workflow/types.js'
+
+function manifest(capabilities: WorkflowIntakeManifest['requiredCapabilities'] = []): WorkflowIntakeManifest {
+  return {
+    version: '1.0', kind: 'workflow-intake', workflowId: 'brief-fixture',
+    source: { format: 'xlsx', fileName: 'fixture.xlsx', sheetName: 'Cases', sha256: 'a'.repeat(64) },
+    targetUrls: ['https://example.test/'], requiredCapabilities: capabilities,
+    phases: [], embeddedImages: [], supplementalImages: [], review: { status: 'draft', reasons: [] },
+  }
+}
+
+describe('scenario skill brief selection', () => {
+  it('selects no briefs when no capability signal is present', () => {
+    expect(selectSkillBriefs(manifest())).toEqual([])
+  })
+
+  it('loads table and multi-origin briefs only when their capabilities are present', () => {
+    const selected = selectSkillBriefs(manifest(['runtimeEntityCapture', 'multiOrigin']))
+    expect(selected.map((brief) => brief.id)).toEqual(['table-entity-identification', 'multi-origin-session'])
+  })
+
+  it('renders a stable, secret-free context section', () => {
+    const selected = selectSkillBriefs(manifest(['scheduledWait']))
+    const context = skillBriefContext(selected)
+    expect(context).toContain('异步等待规则')
+    expect(context).not.toContain('${')
+    expect(skillBriefContext([])).toContain('没有匹配')
+  })
+})

--- a/tests/agent-token-aggregation.test.ts
+++ b/tests/agent-token-aggregation.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { readAggregateTokenUsage } from '../src/agent/competition.js'
+
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+async function makeEventsDirectory(lines: string[]): Promise<string> {
+  const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-token-'))
+  directories.push(directory)
+  await writeFile(resolve(directory, 'codex-agent.events.jsonl'), lines.map((line) => `${line}\n`).join(''))
+  return directory
+}
+
+describe('readAggregateTokenUsage', () => {
+  it('sums raw Codex turn.completed events with snake_case usage fields', async () => {
+    const directory = await makeEventsDirectory([
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 100, cached_input_tokens: 40, output_tokens: 10 } }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 50, cached_input_tokens: 20, output_tokens: 5 } }),
+    ])
+    await expect(readAggregateTokenUsage(directory)).resolves.toEqual({ inputTokens: 150, cachedInputTokens: 60, outputTokens: 15 })
+  })
+
+  it('accepts the normalized turn_completed spelling with camelCase usage fields', async () => {
+    const directory = await makeEventsDirectory([
+      JSON.stringify({ type: 'turn_completed', usage: { inputTokens: 100, cachedInputTokens: 40, outputTokens: 10 } }),
+    ])
+    await expect(readAggregateTokenUsage(directory)).resolves.toEqual({ inputTokens: 100, cachedInputTokens: 40, outputTokens: 10 })
+  })
+
+  it('returns undefined when the log is missing or has no completed turn with usage', async () => {
+    await expect(readAggregateTokenUsage('/definitely/missing')).resolves.toBeUndefined()
+    const empty = await makeEventsDirectory([JSON.stringify({ type: 'agent_message', text: 'no usage here' })])
+    await expect(readAggregateTokenUsage(empty)).resolves.toBeUndefined()
+  })
+})

--- a/tests/codex-agent-prompt.test.ts
+++ b/tests/codex-agent-prompt.test.ts
@@ -69,5 +69,6 @@ describe('AgentHost test prompt safety rules', () => {
     expect(prompt).toContain('/run/test-manifest.json')
     expect(prompt).toContain('/run/case-results.epoch-0002.json')
     expect(prompt).toContain('Do not execute them, classify them, or create placeholder outcomes')
+    expect(prompt).toContain('outcome contract derived from the same source row')
   })
 })

--- a/tests/codex-execution-epochs.test.ts
+++ b/tests/codex-execution-epochs.test.ts
@@ -34,6 +34,7 @@ describe('Codex execution epoch planning', () => {
     const limited = limitManifestToCases(manifest(), 1)
     expect(limited.phases.map((phase) => phase.id)).toEqual(['case-1'])
     expect(limited.embeddedImages.map((image) => image.id)).toEqual(['image-1'])
+    expect(limited.materialIndex?.map((item) => item.caseId)).toEqual(['case-1', 'case-2', 'case-3'])
     expect(limited.source.sha256).toBe('a'.repeat(64))
   })
 
@@ -54,5 +55,14 @@ describe('Codex execution epoch planning', () => {
     expect(() => manifestForExecutionEpoch(manifest(), {
       id: 'epoch-unknown', index: 0, total: 1, caseIds: ['missing-case'], estimatedInputTokens: 500, estimatedOutputTokens: 900,
     })).toThrow(/outside the immutable manifest/)
+  })
+
+  it('keeps only active case details while retaining a compact run-wide material index', () => {
+    const scoped = manifestForExecutionEpoch(manifest(), {
+      id: 'epoch-0002', index: 1, total: 3, caseIds: ['case-2'], estimatedInputTokens: 500, estimatedOutputTokens: 900,
+    })
+    expect(scoped.phases.map((phase) => phase.id)).toEqual(['case-2'])
+    expect(scoped.materialIndex?.map((item) => item.caseId)).toEqual(['case-1', 'case-2', 'case-3'])
+    expect(JSON.stringify(scoped)).not.toContain('image-1.png')
   })
 })

--- a/tests/eval-suite.test.ts
+++ b/tests/eval-suite.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalEvalSuite, evalSuiteProblems, parseEvalSuite } from '../src/eval/eval-suite.js'
+
+describe('fixed eval suite', () => {
+  it('declares a versioned, non-empty canonical task set', () => {
+    const suite = canonicalEvalSuite()
+    expect(suite.version).toBe('1.0')
+    expect(suite.kind).toBe('eval-suite')
+    expect(suite.tasks.length).toBeGreaterThanOrEqual(4)
+    expect(evalSuiteProblems(suite)).toEqual([])
+  })
+
+  it('covers all eight failure modes with at least one task', () => {
+    const suite = canonicalEvalSuite()
+    const covered = new Set(suite.tasks.flatMap((task) => task.probes))
+    for (const mode of ['input', 'authentication', 'environment', 'locator_navigation', 'business_assertion', 'mutation_cleanup', 'agent_execution', 'infrastructure']) {
+      expect(covered.has(mode as never)).toBe(true)
+    }
+  })
+
+  it('rejects a suite that leaves a failure mode unprobed', () => {
+    const suite = canonicalEvalSuite()
+    suite.tasks = suite.tasks.map((task) => ({ ...task, probes: ['business_assertion'] }))
+    expect(evalSuiteProblems(suite)).toContain('eval suite does not probe failure mode input')
+  })
+
+  it('rejects duplicate task ids and unknown probe names', () => {
+    const suite = canonicalEvalSuite()
+    suite.tasks.push({ ...suite.tasks[0]! })
+    suite.tasks[1]!.probes = ['not-a-mode' as never]
+    const problems = evalSuiteProblems(suite)
+    expect(problems.some((problem) => problem.includes('duplicate eval suite task'))).toBe(true)
+    expect(problems.some((problem) => problem.includes('unknown failure-mode probe'))).toBe(true)
+  })
+
+  it('parses a valid suite and fails closed on invalid input', () => {
+    expect(parseEvalSuite(canonicalEvalSuite()).problems).toEqual([])
+    expect(parseEvalSuite(null).problems).toContain('eval suite must be a JSON object')
+    expect(parseEvalSuite({ version: '1.0', kind: 'eval-suite', suiteId: 'x', tasks: [] }).problems)
+      .toContain('eval suite must declare at least one task')
+  })
+})

--- a/tests/workflow-intake.test.ts
+++ b/tests/workflow-intake.test.ts
@@ -22,6 +22,12 @@ describe('workflow xlsx intake', () => {
 
     expect(result.manifest.phases).toHaveLength(2)
     expect(result.manifest.phases[0]).toMatchObject({ id: 'test-001', title: '正确账号密码验证码登录成功' })
+    expect(result.manifest.phases[0]?.outcome).toMatchObject({
+      action: expect.arrayContaining([expect.any(String)]),
+      observable: expect.arrayContaining([expect.any(String)]),
+      evidence: ['interaction', 'observation'],
+    })
+    expect(result.manifest.phases[0]?.outcome?.failureModes).toEqual(expect.arrayContaining(['input', 'business_assertion', 'agent_execution', 'infrastructure']))
     expect(result.manifest.requiredCapabilities).toEqual(expect.arrayContaining(['multiOrigin', 'otpOrCaptcha']))
     expect(result.manifest.phases[0]?.resources.some((resource) => resource.text.startsWith('预期结果：'))).toBe(true)
     expect(result.manifest.phases[0]?.secretBindings.map((binding) => binding.secretRef)).toEqual(expect.arrayContaining([


### PR DESCRIPTION
## 摘要

建立最小 eval 回归矩阵（P0/P1/P2），让 AgentHost / Prompt / Model Profile / checkpoint 变更在「总通过率」之外被比较。这是对 `cwc-workshops` 调研后落到 Auto-Test 上的同源化改造，不引入新服务、不引入第二套 planner/reporter/裁决器。

## 关键改动

- **固定回归任务集** `src/eval/eval-suite.ts`：canary / fixture / Windows 验收 / 恢复 四类任务，覆盖全部八类失败模式，`evalSuiteProblems` fail-closed。
- **同源 outcome 合同**：intake 从同一来源行派生 `action/observable/evidence/cleanup/failureModes`，进 Agent Prompt，并由 `finalResultProblems` 做确定性校验（不做第二次分类）。
- **八桶失败模式** `src/agent/failure-mode.ts`：由 `failureSource/failureKind` 派生，`agent:compare` scorecard 输出分布、token、线程代数/恢复/epoch 与 baseline delta。
- **按需 Skill brief** `src/agent/skill-brief.ts`：经验知识按 capability/risk 信号加载，安全/结果协议留在 Core。
- **bounded fan-out 策略** `src/agent/fanout-policy.ts`：Core 声明、经 Control MCP `test_contract` 暴露（默认只读、并发 1）。

## 评审修复（本轮内）

- 失败模式分布排除通过 case（不再把 passed 计成 phantom `agent_execution`）。
- token 聚合按 raw `turn.completed` + snake_case 读取（此前永远回退到单轮 lastUsage）。
- observation 证据校验要求真实 `observation` kind，而非任意非 mutation 证据。
- 移除会误伤真实 canary 的「action/observable 为空」硬门禁。
- 删除未使用的 `authorizeFanoutTask`（策略为声明式，Core 不拦截 agent 内部 sub-agent 调用）。

## 验证

- `npm run check`：typecheck + 454 测试 + build 全绿。
- 真实制品反证 token 聚合（`agenthost-codex-lta-one-...-v2` 两轮 `turn.completed` 求和正确）。

## 后续（不在本 PR）

OMP token 聚合仍为 0/空（OMP 适配层 `usageFrom` 不认 `input/output/cacheRead`，且制品中该值本身为 0），将另开分支处理。