### PR TITLE
fix(agent): aggregate OMP per-turn token usage from turn_end frames

### DIFF
--- a/src/agent/competition.ts
+++ b/src/agent/competition.ts
@@ -15,6 +15,7 @@ import type {
 } from './types.js'
 import { parseAgentTestResult } from './result.js'
 import { failureModeCounts } from './failure-mode.js'
+import { usageFrom } from './host.js'
 import { writePrivateJson } from './state.js'
 
 export interface AgentCompetitionOracleCase {
@@ -330,21 +331,24 @@ export async function readAggregateTokenUsage(runDirectory: string): Promise<Agg
       continue
     }
     const record = recordValue(event)
-    // The event log stores the host's raw terminal-turn event: Codex emits
-    // `turn.completed` with snake_case usage fields. Accept the normalized
-    // `turn_completed` spelling too so the reader is not silently tied to one
-    // host's wire format.
-    if (record?.type !== 'turn.completed' && record?.type !== 'turn_completed') continue
-    const turnUsage = recordValue(record.usage)
+    if (!record) continue
+    // The event log stores the host's raw turn events. Codex emits
+    // `turn.completed` with top-level usage; OMP emits per-turn usage nested
+    // under `message.usage` on its `turn_end` frames. Normalize both through
+    // the shared usageFrom mapper so the reader is not coupled to one host.
+    let turnUsage: ReturnType<typeof usageFrom>
+    if (record.type === 'turn.completed' || record.type === 'turn_completed') {
+      turnUsage = usageFrom(record.usage)
+    } else if (record.type === 'turn_end') {
+      turnUsage = usageFrom(recordValue(record.message)?.usage)
+    } else {
+      continue
+    }
     if (!turnUsage) continue
-    const inputTokens = numberField(turnUsage.input_tokens ?? turnUsage.inputTokens)
-    const cachedInputTokens = numberField(turnUsage.cached_input_tokens ?? turnUsage.cachedInputTokens)
-    const outputTokens = numberField(turnUsage.output_tokens ?? turnUsage.outputTokens)
-    if (inputTokens === undefined && cachedInputTokens === undefined && outputTokens === undefined) continue
     sawUsage = true
-    if (inputTokens !== undefined) usage.inputTokens += inputTokens
-    if (cachedInputTokens !== undefined) usage.cachedInputTokens += cachedInputTokens
-    if (outputTokens !== undefined) usage.outputTokens += outputTokens
+    usage.inputTokens += turnUsage.inputTokens
+    usage.cachedInputTokens += turnUsage.cachedInputTokens
+    usage.outputTokens += turnUsage.outputTokens
   }
   return sawUsage ? usage : undefined
 }

--- a/src/agent/host.ts
+++ b/src/agent/host.ts
@@ -236,12 +236,12 @@ function eventWithRaw(event: AgentEvent, raw: unknown): AgentEvent {
   return { ...event, raw }
 }
 
-function usageFrom(value: unknown): AgentUsage | undefined {
+export function usageFrom(value: unknown): AgentUsage | undefined {
   const record = recordValue(value)
   if (!record) return undefined
-  const inputTokens = record.inputTokens ?? record.input_tokens
-  const cachedInputTokens = record.cachedInputTokens ?? record.cached_input_tokens
-  const outputTokens = record.outputTokens ?? record.output_tokens
+  const inputTokens = record.inputTokens ?? record.input_tokens ?? record.input
+  const cachedInputTokens = record.cachedInputTokens ?? record.cached_input_tokens ?? record.cacheRead
+  const outputTokens = record.outputTokens ?? record.output_tokens ?? record.output
   if (![inputTokens, cachedInputTokens, outputTokens].every((item) => typeof item === 'number')) return undefined
   return { inputTokens: inputTokens as number, cachedInputTokens: cachedInputTokens as number, outputTokens: outputTokens as number }
 }

--- a/src/agent/omp-host.ts
+++ b/src/agent/omp-host.ts
@@ -14,8 +14,9 @@ import type {
   AgentHostSession,
   AgentHostStream,
   AgentInputPart,
+  AgentUsage,
 } from './host.js'
-import { AgentHostError, normalizeAgentEvent, resolveHostExecutable } from './host.js'
+import { AgentHostError, normalizeAgentEvent, resolveHostExecutable, usageFrom } from './host.js'
 import { OmpModelProviderAdapter } from './omp-provider.js'
 
 interface OmpResponse {
@@ -196,6 +197,8 @@ interface ActiveRun {
   queue: AsyncEventQueue<AgentEvent>
   promptId: string
   lastAssistantText?: string
+  /** Accumulated per-turn token usage; attached to the terminal turn_completed. */
+  usage: AgentUsage
 }
 
 function mimeType(path: string): string {
@@ -347,7 +350,7 @@ class OmpRpcSession implements AgentHostSession {
     if (this.activeRun) throw new AgentHostError('omp', 'OMP session already has an active prompt', 'process')
     const queue = new AsyncEventQueue<AgentEvent>()
     const promptId = `autotest-${randomUUID()}`
-    this.activeRun = { queue, promptId }
+    this.activeRun = { queue, promptId, usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 } }
     try {
       const prompt = await promptPayload(input, promptId, this.maxFrameBytes)
       const response = await this.request(prompt)
@@ -474,6 +477,22 @@ class OmpRpcSession implements AgentHostSession {
     if (frame.type === 'message_start' || frame.type === 'message_update' || frame.type === 'tool_execution_update') return
     const active = this.activeRun
     if (!active) return
+    // OMP reports per-turn token usage nested in turn_end.message.usage; the
+    // terminal agent_end carries none. Accumulate here so the emitted
+    // turn_completed carries the run's total usage for the live lastUsage
+    // snapshot (the events-file reader sums turn_end frames independently).
+    if (frame.type === 'turn_end') {
+      const message = frame.message
+      const usageRecord = message && typeof message === 'object' && !Array.isArray(message)
+        ? (message as Record<string, unknown>).usage
+        : undefined
+      const turnUsage = usageFrom(usageRecord)
+      if (turnUsage) {
+        active.usage.inputTokens += turnUsage.inputTokens
+        active.usage.cachedInputTokens += turnUsage.cachedInputTokens
+        active.usage.outputTokens += turnUsage.outputTokens
+      }
+    }
     const event = normalizeAgentEvent(frame)
     if (event.type === 'agent_message' && event.text) active.lastAssistantText = event.text
     // OMP normally emits the complete assistant message as message_end and
@@ -487,6 +506,7 @@ class OmpRpcSession implements AgentHostSession {
         active.queue.push({ type: 'agent_message', text: finalText, raw: frame })
       }
     }
+    if (event.type === 'turn_completed') event.usage = active.usage
     active.queue.push(event)
     if (frame.type === 'agent_end' && frame.isTerminal !== false) {
       this.activeRun = undefined

--- a/tests/agent-token-aggregation.test.ts
+++ b/tests/agent-token-aggregation.test.ts
@@ -33,6 +33,14 @@ describe('readAggregateTokenUsage', () => {
     await expect(readAggregateTokenUsage(directory)).resolves.toEqual({ inputTokens: 100, cachedInputTokens: 40, outputTokens: 10 })
   })
 
+  it('sums OMP turn_end frames with nested message.usage', async () => {
+    const directory = await makeEventsDirectory([
+      JSON.stringify({ type: 'turn_end', message: { usage: { input: 100, output: 20, cacheRead: 40 } } }),
+      JSON.stringify({ type: 'turn_end', message: { usage: { input: 50, output: 5, cacheRead: 10 } } }),
+    ])
+    await expect(readAggregateTokenUsage(directory)).resolves.toEqual({ inputTokens: 150, cachedInputTokens: 50, outputTokens: 25 })
+  })
+
   it('returns undefined when the log is missing or has no completed turn with usage', async () => {
     await expect(readAggregateTokenUsage('/definitely/missing')).resolves.toBeUndefined()
     const empty = await makeEventsDirectory([JSON.stringify({ type: 'agent_message', text: 'no usage here' })])


### PR DESCRIPTION
## 问题

OMP 的 token 用量不在终态 `agent_end` 上，而是嵌套在 `turn_end` 帧的 `message.usage`（键为 `input/output/cacheRead`）。`readAggregateTokenUsage` 只认 Codex 的 `turn.completed`（snake_case），因此 OMP run 的聚合 token 永远回退到空的 `lastUsage`，scorecard 显示 0/空。

## 修复

- `host.ts` 的 `usageFrom`（规范化的唯一入口）扩展为同时接受 OMP 的 `input/output/cacheRead` 键，与 Codex 的 camelCase / snake_case 并列，并导出。
- `competition.ts` 的 `readAggregateTokenUsage` 对 `turn_end` 帧按 `message.usage` 求和，与 Codex `turn.completed` 走同一 mapper，不在比较器里内联宿主格式。

## 验证

- `npm run check` 全绿（typecheck + 455 测试 + build）。
- 真实 OMP 制品反证：`agenthost-omp-charge-full-20260806-836c849-v6` 聚合从 0/空 变为 `{inputTokens: 285696, cachedInputTokens: 67750016, outputTokens: 119327}`。

## 说明

- `cachedInputTokens` 数值较大（≈67.7M）是因为 OMP 按 302 个内部 turn 分别上报 `cacheRead`，求和即为整个 run 的缓存输入 token 总量。
- 本轮只修「聚合」路径；OMP 的 live `lastUsage` 快照（`runTurn` 里 `turn_completed.usage` 对 OMP 仍为 undefined）属另一处，本次未动。