### PR TITLE
fix(cli): propagate --require-oracle-match into the process exit code

### DIFF
--- a/src/cli/compare-agent-runs.ts
+++ b/src/cli/compare-agent-runs.ts
@@ -70,8 +70,10 @@ export async function runAgentComparisonCli(args: string[]): Promise<number> {
 }
 
 if (process.argv[1] && resolve(process.argv[1]).endsWith('compare-agent-runs.ts')) {
-  void runAgentComparisonCli(process.argv.slice(2)).catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error))
-    process.exitCode = 1
-  })
+  void runAgentComparisonCli(process.argv.slice(2))
+    .then((exitCode) => { process.exitCode = exitCode })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error))
+      process.exitCode = 1
+    })
 }

--- a/tests/agent-competition.test.ts
+++ b/tests/agent-competition.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
@@ -350,5 +351,25 @@ describe('AgentHost competition contract', () => {
     expect(report.contractStatus).toBe('invalid')
     expect(report.contractProblems.some((problem) => problem.includes('不存在或越界证据'))).toBe(true)
     expect(report.contractProblems.some((problem) => problem.includes('缺少有效 workspaceIsolation 能力'))).toBe(true)
+  })
+
+  it('propagates the --require-oracle-match gate into a non-zero process exit code', async () => {
+    const root = await mkdtemp(resolve(tmpdir(), 'auto-test-competition-exit-'))
+    directories.push(root)
+    const baseline = await makeRun(root, 'baseline', result('passed'))
+    const candidate = await makeRun(root, 'candidate', result('blocked'))
+    const matching = await makeRun(root, 'matching', result('passed'))
+    const oraclePath = resolve(root, 'oracle.json')
+    await writeFile(oraclePath, JSON.stringify({
+      version: '1.0', workflowId: 'competition-fixture', sourceSha256: 'b'.repeat(64),
+      cases: [{ caseId: 'case-one', outcome: 'passed' }],
+    }))
+    const script = resolve('src', 'cli', 'compare-agent-runs.ts')
+    const mismatch = spawnSync(process.execPath, ['--import', 'tsx', script,
+      '--run', baseline, '--run', candidate, '--oracle', oraclePath, '--require-oracle-match', '--output', resolve(root, 'report.json')], { encoding: 'utf8' })
+    expect(mismatch.status).toBe(1)
+    const matched = spawnSync(process.execPath, ['--import', 'tsx', script,
+      '--run', baseline, '--run', matching, '--oracle', oraclePath, '--require-oracle-match', '--output', resolve(root, 'report-ok.json')], { encoding: 'utf8' })
+    expect(matched.status).toBe(0)
   })
 })


### PR DESCRIPTION
## 问题（真实验收才发现）

`agent:compare` 的入口用 `void runAgentComparisonCli(...).catch(...)` 只把**抛异常**时置 `process.exitCode = 1`，成功路径丢弃了返回值。于是 `--require-oracle-match` 即使有候选没命中 oracle，进程也退出 0——「必须能失败的 probe」在 CI 里根本不会失败。

单元测试只断言 `runAgentComparisonCli` 的**返回值**（0/1），从没覆盖入口这 6 行的退出码接线，所以漏了。

## 复现（修复前）

对真实 Codex/OMP 成对制品 + 一个 oracle 跑 `--require-oracle-match`，OMP `oracleMatchRate=0`，但退出码仍是 0。

## 修复

入口改为 `.then((exitCode) => { process.exitCode = exitCode })`，与 `agent-test.ts` 的入口一致。修复后：oracle 不匹配 → 退出 1；无 `--require-oracle-match` → 退出 0。

## 验证

- 新增子进程回归测试 `tests/agent-competition.test.ts`：真实驱动入口，断言 oracle 不匹配退出 1、匹配退出 0（用 `node --import tsx`，跨平台）。
- `npm run check` 全绿（456 测试 + typecheck + build）。
- 真实验收：`--require-oracle-match` 不匹配 → 退出码 1；不加 gate → 0。