### PR TITLE
feat(eval): add a committed oracle and a thin eval-suite runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ Auto-Test.private-provider.json
 !templates/**/*.xlsx
 !tests/fixtures/**/*.xlsx
 
+# Eval oracles are business-specific ground truth (like real xlsx), private.
+# The format is documented in templates/eval-oracle.example.json.
+evals/
+
 # Editors and OS files
 .DS_Store
 .idea/

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -159,7 +159,7 @@ oracle 只记录已独立验证的 outcome 和必要失败分类，不从待评�
 
 固定回归任务集由 `src/eval/eval-suite.ts` 的 `canonicalEvalSuite()` 声明为版本化清单（canary、本地 fixture、Windows 验收、中断恢复），并保证八类失败模式每类至少被一个任务覆盖。AgentHost、Prompt、Model Profile 或 checkpoint 变更时，用这套固定任务集比较业务 outcome、证据完整性、Ledger 终态、失败来源、token/时间以及重试恢复次数；比较仍通过 `agent:compare` 完成，不引入新服务。
 
-`npm run eval:suite -- --run <baseline-run> --run <candidate-run> ...` 是这份任务集的薄聚合入口：它按 `canonicalEvalSuite()` 自动加载已提交 oracle 的任务，逐个跑 `agent:compare` 并汇总门禁结果。第一个 `--run` 是 baseline，其后是候选；任一 `requiresOracleMatch` 任务有候选未完整命中 oracle 即返回非零。目前只有绑定真实 canary 输入的 oracle（`evals/readonly-canary.oracle.json`）已接线，其余任务待补充 oracle/制品后加入。
+`npm run eval:suite -- --run <baseline-run> --run <candidate-run> ...` 是这份任务集的薄聚合入口：它按 `canonicalEvalSuite()` 逐个跑 `agent:compare` 并汇总门禁结果。第一个 `--run` 是 baseline，其后是候选；任一 `requiresOracleMatch` 任务有候选未完整命中 oracle 即返回非零。oracle 是业务专属 ground truth（和真实 xlsx 一样私有），放在 gitignored 的 `evals/` 下、按 `templates/eval-oracle.example.json` 的格式人工编写；未编写的任务会被 `eval:suite` 跳过而非报错。
 
 ## 7. 结果边界
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -159,6 +159,8 @@ oracle 只记录已独立验证的 outcome 和必要失败分类，不从待评�
 
 固定回归任务集由 `src/eval/eval-suite.ts` 的 `canonicalEvalSuite()` 声明为版本化清单（canary、本地 fixture、Windows 验收、中断恢复），并保证八类失败模式每类至少被一个任务覆盖。AgentHost、Prompt、Model Profile 或 checkpoint 变更时，用这套固定任务集比较业务 outcome、证据完整性、Ledger 终态、失败来源、token/时间以及重试恢复次数；比较仍通过 `agent:compare` 完成，不引入新服务。
 
+`npm run eval:suite -- --run <baseline-run> --run <candidate-run> ...` 是这份任务集的薄聚合入口：它按 `canonicalEvalSuite()` 自动加载已提交 oracle 的任务，逐个跑 `agent:compare` 并汇总门禁结果。第一个 `--run` 是 baseline，其后是候选；任一 `requiresOracleMatch` 任务有候选未完整命中 oracle 即返回非零。目前只有绑定真实 canary 输入的 oracle（`evals/readonly-canary.oracle.json`）已接线，其余任务待补充 oracle/制品后加入。
+
 ## 7. 结果边界
 
 - `passed`：每条 case 的操作、预期和最终状态均有具体证据；

--- a/evals/readonly-canary.oracle.json
+++ b/evals/readonly-canary.oracle.json
@@ -1,8 +1,0 @@
-{
-  "version": "1.0",
-  "workflowId": "lta后台测试用例-3f28b443",
-  "sourceSha256": "3f28b44320c0facd568a58a8bbe1cda4058c18ce3b753b24e016f93b7673f85e",
-  "cases": [
-    { "caseId": "test-001", "outcome": "passed" }
-  ]
-}

--- a/evals/readonly-canary.oracle.json
+++ b/evals/readonly-canary.oracle.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "workflowId": "lta后台测试用例-3f28b443",
+  "sourceSha256": "3f28b44320c0facd568a58a8bbe1cda4058c18ce3b753b24e016f93b7673f85e",
+  "cases": [
+    { "caseId": "test-001", "outcome": "passed" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "easy": "tsx src/cli/easy.ts",
     "agent:test": "tsx src/cli/agent-test.ts",
     "agent:compare": "tsx src/cli/compare-agent-runs.ts",
+    "eval:suite": "tsx src/cli/run-eval-suite.ts",
     "import": "tsx src/cli/import-xlsx.ts",
     "intake:workflow": "tsx src/cli/intake-workflow.ts",
     "pipeline:workflow": "tsx src/cli/workflow-pipeline.ts",

--- a/src/cli/run-eval-suite.ts
+++ b/src/cli/run-eval-suite.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { resolve } from 'node:path'
+import { runEvalSuite } from '../eval/run-eval-suite.js'
+
+function valuesAfter(args: string[], name: string): string[] {
+  const values: string[] = []
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] !== name) continue
+    const value = args[index + 1]
+    if (!value || value.startsWith('--')) throw new Error(`${name} 必须提供取值`)
+    values.push(resolve(value))
+  }
+  return values
+}
+
+function help(): string {
+  return [
+    '用法:',
+    '  npm run eval:suite -- --run <baseline-run> --run <candidate-run> ...',
+    '',
+    '按 canonicalEvalSuite() 的固定任务集，对第一个 --run（baseline）与其后的候选 run 跑 oracle 门禁比较。',
+    '只有 inputContract.kind === "oracle" 且已提交 oracle 文件的任务会被执行，其余任务跳过。',
+    '任一 requiresOracleMatch 任务有候选未完整命中 oracle 时返回非零。',
+  ].join('\n')
+}
+
+export async function runEvalSuiteCli(args: string[]): Promise<number> {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(help())
+    return 0
+  }
+  const runDirectories = valuesAfter(args, '--run')
+  if (runDirectories.length < 2) throw new Error('至少提供两个 --run 目录（第一个作为 baseline）')
+  const baselineDirectory = runDirectories[0]!
+  const candidateDirectories = runDirectories.slice(1)
+  const run = await runEvalSuite({ baselineDirectory, candidateDirectories })
+
+  for (const problem of run.suiteProblems) console.log(`套件问题：${problem}`)
+  if (run.tasks.length === 0) {
+    console.log('没有可运行的 oracle 任务（其余任务尚未接线到可运行 oracle）')
+    return run.failed ? 1 : 0
+  }
+  for (const task of run.tasks) {
+    console.log(`任务 ${task.taskId}：${task.verdict}（合同 ${task.contractStatus}）`)
+    for (const candidate of task.candidates) {
+      const rate = candidate.oracleMatchRate !== undefined ? `${Math.round(candidate.oracleMatchRate * 100)}%` : '-'
+      console.log(`  - ${candidate.hostId}：${candidate.outcome}，oracle ${candidate.oracleMatchedCases ?? '-'}，命中率 ${rate}`)
+    }
+    if (task.requiresOracleMatch && task.gateFailed) console.log(`  门禁失败：${task.taskId} 需要完整命中 oracle`)
+  }
+  return run.failed ? 1 : 0
+}
+
+if (process.argv[1] && resolve(process.argv[1]).endsWith('run-eval-suite.ts')) {
+  void runEvalSuiteCli(process.argv.slice(2))
+    .then((exitCode) => { process.exitCode = exitCode })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error))
+      process.exitCode = 1
+    })
+}

--- a/src/cli/run-eval-suite.ts
+++ b/src/cli/run-eval-suite.ts
@@ -36,6 +36,7 @@ export async function runEvalSuiteCli(args: string[]): Promise<number> {
   const run = await runEvalSuite({ baselineDirectory, candidateDirectories })
 
   for (const problem of run.suiteProblems) console.log(`套件问题：${problem}`)
+  if (run.skipped.length > 0) console.log(`跳过（oracle 未接线或未编写）：${run.skipped.join('、')}`)
   if (run.tasks.length === 0) {
     console.log('没有可运行的 oracle 任务（其余任务尚未接线到可运行 oracle）')
     return run.failed ? 1 : 0

--- a/src/eval/run-eval-suite.ts
+++ b/src/eval/run-eval-suite.ts
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { compareAgentRuns, type AgentCompetitionOracle } from '../agent/competition.js'
+import type { AgentTestOutcome } from '../agent/types.js'
+import { canonicalEvalSuite, evalSuiteProblems } from './eval-suite.js'
+
+export interface EvalSuiteCandidateResult {
+  hostId: string
+  outcome: AgentTestOutcome
+  oracleMatchedCases?: number
+  oracleMatchRate?: number
+}
+
+export interface EvalSuiteTaskResult {
+  taskId: string
+  oraclePath?: string
+  requiresOracleMatch: boolean
+  verdict: string
+  contractStatus: string
+  candidates: EvalSuiteCandidateResult[]
+  /** True when this task requires a full oracle match and some candidate misses it. */
+  gateFailed: boolean
+}
+
+export interface EvalSuiteRun {
+  suiteProblems: string[]
+  tasks: EvalSuiteTaskResult[]
+  /** True when any required oracle gate failed. */
+  failed: boolean
+}
+
+/**
+ * Run the fixed eval suite's oracle-bound tasks against one baseline and its
+ * candidate runs. This is a thin aggregator over `compareAgentRuns`, not a new
+ * service: each task just declares which committed oracle gates its comparison.
+ * Tasks whose input contract is not yet wired to a runnable oracle are skipped.
+ */
+export async function runEvalSuite(options: {
+  baselineDirectory: string
+  candidateDirectories: string[]
+}): Promise<EvalSuiteRun> {
+  const suite = canonicalEvalSuite()
+  const suiteProblems = evalSuiteProblems(suite)
+  if (suiteProblems.length > 0) return { suiteProblems, tasks: [], failed: true }
+
+  const runDirectories = [options.baselineDirectory, ...options.candidateDirectories]
+  const tasks: EvalSuiteTaskResult[] = []
+  for (const task of suite.tasks) {
+    if (task.inputContract.kind !== 'oracle') continue
+    const oracle = JSON.parse(await readFile(resolve(task.inputContract.path), 'utf8')) as AgentCompetitionOracle
+    const report = await compareAgentRuns({ runDirectories, oracle })
+    const candidates: EvalSuiteCandidateResult[] = report.candidates.map((candidate) => ({
+      hostId: candidate.hostId,
+      outcome: candidate.outcome,
+      ...(candidate.oracleMatchedCases !== undefined ? { oracleMatchedCases: candidate.oracleMatchedCases } : {}),
+      ...(candidate.oracleMatchRate !== undefined ? { oracleMatchRate: candidate.oracleMatchRate } : {}),
+    }))
+    const gateFailed = task.requiresOracleMatch && candidates.some((candidate) => candidate.oracleMatchRate !== 1)
+    tasks.push({
+      taskId: task.id,
+      oraclePath: task.inputContract.path,
+      requiresOracleMatch: task.requiresOracleMatch,
+      verdict: report.verdict,
+      contractStatus: report.contractStatus,
+      candidates,
+      gateFailed,
+    })
+  }
+  return { suiteProblems: [], tasks, failed: tasks.some((task) => task.gateFailed) }
+}

--- a/src/eval/run-eval-suite.ts
+++ b/src/eval/run-eval-suite.ts
@@ -25,6 +25,8 @@ export interface EvalSuiteTaskResult {
 export interface EvalSuiteRun {
   suiteProblems: string[]
   tasks: EvalSuiteTaskResult[]
+  /** Task ids that were skipped because their oracle is not authored or wired yet. */
+  skipped: string[]
   /** True when any required oracle gate failed. */
   failed: boolean
 }
@@ -32,22 +34,37 @@ export interface EvalSuiteRun {
 /**
  * Run the fixed eval suite's oracle-bound tasks against one baseline and its
  * candidate runs. This is a thin aggregator over `compareAgentRuns`, not a new
- * service: each task just declares which committed oracle gates its comparison.
- * Tasks whose input contract is not yet wired to a runnable oracle are skipped.
+ * service: each task declares which committed/private oracle gates its
+ * comparison. A task whose oracle file is missing is skipped, not failed —
+ * oracles are business-specific ground truth authored locally (see
+ * templates/eval-oracle.example.json), not checked in.
  */
 export async function runEvalSuite(options: {
   baselineDirectory: string
   candidateDirectories: string[]
+  /** Override a task's oracle path; tests inject a synthetic oracle here. */
+  oracleOverrides?: Partial<Record<string, string>>
 }): Promise<EvalSuiteRun> {
   const suite = canonicalEvalSuite()
   const suiteProblems = evalSuiteProblems(suite)
-  if (suiteProblems.length > 0) return { suiteProblems, tasks: [], failed: true }
+  if (suiteProblems.length > 0) return { suiteProblems, tasks: [], skipped: [], failed: true }
 
   const runDirectories = [options.baselineDirectory, ...options.candidateDirectories]
   const tasks: EvalSuiteTaskResult[] = []
+  const skipped: string[] = []
   for (const task of suite.tasks) {
-    if (task.inputContract.kind !== 'oracle') continue
-    const oracle = JSON.parse(await readFile(resolve(task.inputContract.path), 'utf8')) as AgentCompetitionOracle
+    if (task.inputContract.kind !== 'oracle') {
+      skipped.push(task.id)
+      continue
+    }
+    const oraclePath = options.oracleOverrides?.[task.id] ?? task.inputContract.path
+    let oracle: AgentCompetitionOracle
+    try {
+      oracle = JSON.parse(await readFile(resolve(oraclePath), 'utf8')) as AgentCompetitionOracle
+    } catch {
+      skipped.push(task.id)
+      continue
+    }
     const report = await compareAgentRuns({ runDirectories, oracle })
     const candidates: EvalSuiteCandidateResult[] = report.candidates.map((candidate) => ({
       hostId: candidate.hostId,
@@ -58,7 +75,7 @@ export async function runEvalSuite(options: {
     const gateFailed = task.requiresOracleMatch && candidates.some((candidate) => candidate.oracleMatchRate !== 1)
     tasks.push({
       taskId: task.id,
-      oraclePath: task.inputContract.path,
+      oraclePath,
       requiresOracleMatch: task.requiresOracleMatch,
       verdict: report.verdict,
       contractStatus: report.contractStatus,
@@ -66,5 +83,5 @@ export async function runEvalSuite(options: {
       gateFailed,
     })
   }
-  return { suiteProblems: [], tasks, failed: tasks.some((task) => task.gateFailed) }
+  return { suiteProblems: [], tasks, skipped, failed: tasks.some((task) => task.gateFailed) }
 }

--- a/templates/eval-oracle.example.json
+++ b/templates/eval-oracle.example.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "workflowId": "synthetic-readonly-canary-v1",
+  "sourceSha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "cases": [
+    { "caseId": "case-1", "outcome": "passed" }
+  ]
+}

--- a/tests/run-eval-suite.test.ts
+++ b/tests/run-eval-suite.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runEvalSuite } from '../src/eval/run-eval-suite.js'
+import { compareAgentRuns } from '../src/agent/competition.js'
+
+vi.mock('../src/agent/competition.js', () => ({
+  compareAgentRuns: vi.fn(),
+}))
+
+function candidate(hostId: string, outcome: 'passed' | 'blocked', oracleMatchRate: number): Record<string, unknown> {
+  return {
+    runDirectory: `/${hostId}`, hostId, platform: 'x', arch: 'x', terminal: true, outcome,
+    caseCounts: { passed: outcome === 'passed' ? 1 : 0, product_failed: 0, blocked: outcome === 'blocked' ? 1 : 0 },
+    evidenceCount: 1, citedReceiptCount: 0, mutationCount: 0, pendingMutationCount: 0,
+    oracleMatchedCases: oracleMatchRate === 1 ? 1 : 0, oracleMatchRate,
+    failureSources: {}, failureKinds: {}, failureModes: {},
+  }
+}
+
+function report(rates: number[]): unknown {
+  return {
+    version: '1.0', kind: 'agent-competition', generatedAt: '2026-08-13T00:00:00.000Z',
+    workflowId: 'lta后台测试用例-3f28b443', sourceSha256: '3f28b44320c0facd568a58a8bbe1cda4058c18ce3b753b24e016f93b7673f85e',
+    contractStatus: 'valid', contractProblems: [],
+    verdict: rates.some((rate) => rate !== 1) ? 'oracle_winner' : 'equivalent', winnerHostId: 'baseline', caseDifferences: [],
+    candidates: rates.map((rate, index) => candidate(index === 0 ? 'baseline' : 'candidate', rate === 1 ? 'passed' : 'blocked', rate)),
+  }
+}
+
+describe('runEvalSuite', () => {
+  beforeEach(() => vi.mocked(compareAgentRuns).mockReset())
+
+  it('runs the oracle-bound task and fails the gate when a candidate misses the oracle', async () => {
+    vi.mocked(compareAgentRuns).mockResolvedValue(report([1, 0]) as never)
+    const run = await runEvalSuite({ baselineDirectory: '/baseline', candidateDirectories: ['/candidate'] })
+    expect(run.suiteProblems).toEqual([])
+    expect(run.tasks.map((task) => task.taskId)).toEqual(['readonly-canary'])
+    expect(run.tasks[0]!.gateFailed).toBe(true)
+    expect(run.failed).toBe(true)
+  })
+
+  it('passes when every candidate fully matches the oracle', async () => {
+    vi.mocked(compareAgentRuns).mockResolvedValue(report([1, 1]) as never)
+    const run = await runEvalSuite({ baselineDirectory: '/baseline', candidateDirectories: ['/candidate'] })
+    expect(run.tasks[0]!.gateFailed).toBe(false)
+    expect(run.failed).toBe(false)
+  })
+})

--- a/tests/run-eval-suite.test.ts
+++ b/tests/run-eval-suite.test.ts
@@ -1,10 +1,30 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runEvalSuite } from '../src/eval/run-eval-suite.js'
 import { compareAgentRuns } from '../src/agent/competition.js'
 
 vi.mock('../src/agent/competition.js', () => ({
   compareAgentRuns: vi.fn(),
 }))
+
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+async function makeOracle(): Promise<string> {
+  const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-eval-oracle-'))
+  directories.push(directory)
+  const path = resolve(directory, 'oracle.json')
+  await writeFile(path, JSON.stringify({
+    version: '1.0', workflowId: 'synthetic', sourceSha256: 'a'.repeat(64),
+    cases: [{ caseId: 'case-1', outcome: 'passed' }],
+  }))
+  return path
+}
 
 function candidate(hostId: string, outcome: 'passed' | 'blocked', oracleMatchRate: number): Record<string, unknown> {
   return {
@@ -19,7 +39,7 @@ function candidate(hostId: string, outcome: 'passed' | 'blocked', oracleMatchRat
 function report(rates: number[]): unknown {
   return {
     version: '1.0', kind: 'agent-competition', generatedAt: '2026-08-13T00:00:00.000Z',
-    workflowId: 'lta后台测试用例-3f28b443', sourceSha256: '3f28b44320c0facd568a58a8bbe1cda4058c18ce3b753b24e016f93b7673f85e',
+    workflowId: 'synthetic', sourceSha256: 'a'.repeat(64),
     contractStatus: 'valid', contractProblems: [],
     verdict: rates.some((rate) => rate !== 1) ? 'oracle_winner' : 'equivalent', winnerHostId: 'baseline', caseDifferences: [],
     candidates: rates.map((rate, index) => candidate(index === 0 ? 'baseline' : 'candidate', rate === 1 ? 'passed' : 'blocked', rate)),
@@ -31,7 +51,11 @@ describe('runEvalSuite', () => {
 
   it('runs the oracle-bound task and fails the gate when a candidate misses the oracle', async () => {
     vi.mocked(compareAgentRuns).mockResolvedValue(report([1, 0]) as never)
-    const run = await runEvalSuite({ baselineDirectory: '/baseline', candidateDirectories: ['/candidate'] })
+    const oraclePath = await makeOracle()
+    const run = await runEvalSuite({
+      baselineDirectory: '/baseline', candidateDirectories: ['/candidate'],
+      oracleOverrides: { 'readonly-canary': oraclePath },
+    })
     expect(run.suiteProblems).toEqual([])
     expect(run.tasks.map((task) => task.taskId)).toEqual(['readonly-canary'])
     expect(run.tasks[0]!.gateFailed).toBe(true)
@@ -40,8 +64,19 @@ describe('runEvalSuite', () => {
 
   it('passes when every candidate fully matches the oracle', async () => {
     vi.mocked(compareAgentRuns).mockResolvedValue(report([1, 1]) as never)
-    const run = await runEvalSuite({ baselineDirectory: '/baseline', candidateDirectories: ['/candidate'] })
+    const oraclePath = await makeOracle()
+    const run = await runEvalSuite({
+      baselineDirectory: '/baseline', candidateDirectories: ['/candidate'],
+      oracleOverrides: { 'readonly-canary': oraclePath },
+    })
     expect(run.tasks[0]!.gateFailed).toBe(false)
+    expect(run.failed).toBe(false)
+  })
+
+  it('skips a task whose oracle is not authored instead of failing', async () => {
+    const run = await runEvalSuite({ baselineDirectory: '/baseline', candidateDirectories: ['/candidate'] })
+    expect(run.tasks).toEqual([])
+    expect(run.skipped).toContain('readonly-canary')
     expect(run.failed).toBe(false)
   })
 })


### PR DESCRIPTION
## 背景

上一轮真实验收发现：回归矩阵的「比较 + 打分」机器已经能跑、也当场抓到一个退出码 bug 修掉了，但离「可直接验收的 eval」还差两样——没有 oracle 文件、没有跑 suite 的入口。本 PR 补齐这两样。

## 改动

- **`evals/readonly-canary.oracle.json`**：第一个已提交 oracle，绑定真实 canary 输入合同（`outcome: passed`）。它是独立编写的 ground truth，不是从待评估 run 生成的。
- **`src/eval/run-eval-suite.ts` + `src/cli/run-eval-suite.ts`**：`canonicalEvalSuite()` 的薄聚合入口。加载 suite → 对每个 `inputContract.kind === 'oracle'` 的任务跑 `compareAgentRuns` → 汇总。任一 `requiresOracleMatch` 任务有候选未完整命中 oracle 即返回非零。未接线到可运行 oracle 的任务跳过。
- `npm run eval:suite` 脚本 + quick-start 说明。

## 验证

- 真实验收（真实 Codex/OMP lta-one 成对制品）：
  ```
  任务 readonly-canary：oracle_winner（合同 valid）
    - codex：passed，oracle 1，命中率 100%
    - omp：blocked，oracle 0，命中率 0%
    门禁失败：readonly-canary 需要完整命中 oracle
  （退出码 1）
  ```
- `npm run check` 全绿（458 测试 + typecheck + build）。

## 需要你 review 的两点

1. **隐私/业务名**：`evals/readonly-canary.oracle.json` 提交了真实 `workflowId`（含「lta后台测试用例」）和私有 xlsx 的 `sourceSha256` 哈希。它是 eval 数据而非通用代码，但若你希望这类真值只存本地、不进公开仓库，我可以把它移到 gitignore（改由模板 + 本地覆盖）。
2. **只读语义**：这份 oracle 实际绑的是登录 canary（`test-001`），不是严格只读；suite 里 `readonly-canary` 任务名与之一致但语义略偏，等有真正只读 canary 的真值后可替换/改名。