### PR TITLE
fix(omp): load the run-scoped MCP servers via --config overlay

### DIFF
--- a/src/agent/omp-host.ts
+++ b/src/agent/omp-host.ts
@@ -253,6 +253,33 @@ async function promptPayload(input: AgentInputPart[], promptId: string, maxFrame
   return payload
 }
 
+/**
+ * Launch arguments for the OMP RPC session. The `--config` overlay is what
+ * makes OMP load the run-scoped MCP servers (`.omp/mcp.json`) and disable its
+ * built-in browser in favor of the injected Playwright MCP; omitting it leaves
+ * the session with only built-in tools and the Control MCP preflight fails.
+ */
+export function ompSessionLaunchArgs(options: {
+  workspaceDirectory: string
+  sessionDirectory: string
+  model?: string
+  reasoningEffort?: string
+  serviceTier?: string
+  resumeId?: string
+}): string[] {
+  return [
+    '--mode', 'rpc',
+    '--no-title',
+    '--approval-mode', 'yolo',
+    '--session-dir', options.sessionDirectory,
+    '--config', resolve(options.workspaceDirectory, '.omp', 'config.yml'),
+    ...(options.model ? ['--model', options.model] : []),
+    ...(options.reasoningEffort ? ['--thinking', options.reasoningEffort] : []),
+    ...(options.serviceTier ? ['--service-tier', options.serviceTier] : []),
+    ...(options.resumeId ? ['--resume', options.resumeId] : []),
+  ]
+}
+
 class OmpRpcSession implements AgentHostSession {
   private readonly pending = new Map<string, PendingRequest>()
   private readonly decoder = new RpcFrameDecoder()
@@ -276,16 +303,14 @@ class OmpRpcSession implements AgentHostSession {
     spawnProcess: typeof spawn = crossSpawn as typeof spawn,
   ) {
     const sessionDirectory = resolve(options.runtime.agentHome, 'sessions')
-    const args = [
-      '--mode', 'rpc',
-      '--no-title',
-      '--approval-mode', 'yolo',
-      '--session-dir', sessionDirectory,
-      ...(options.runtime.model ? ['--model', options.runtime.model] : []),
-      ...(options.runtime.provider?.reasoningEffort ? ['--thinking', options.runtime.provider.reasoningEffort] : []),
-      ...(options.runtime.provider?.serviceTier ? ['--service-tier', options.runtime.provider.serviceTier] : []),
-      ...(options.resumeId ? ['--resume', options.resumeId] : []),
-    ]
+    const args = ompSessionLaunchArgs({
+      workspaceDirectory: options.workspaceDirectory,
+      sessionDirectory,
+      ...(options.runtime.model !== undefined ? { model: options.runtime.model } : {}),
+      ...(options.runtime.provider?.reasoningEffort !== undefined ? { reasoningEffort: options.runtime.provider.reasoningEffort } : {}),
+      ...(options.runtime.provider?.serviceTier !== undefined ? { serviceTier: options.runtime.provider.serviceTier } : {}),
+      ...(options.resumeId !== undefined ? { resumeId: options.resumeId } : {}),
+    })
     const env: NodeJS.ProcessEnv = {
       ...options.runtime.environment,
       PI_CODING_AGENT_DIR: options.runtime.agentHome,

--- a/tests/agent-omp-host.test.ts
+++ b/tests/agent-omp-host.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { resolve } from 'node:path'
+import { ompSessionLaunchArgs } from '../src/agent/omp-host.js'
+
+describe('OMP RPC launch args', () => {
+  it('loads the run-scoped config overlay so MCP servers are discovered', () => {
+    const args = ompSessionLaunchArgs({
+      workspaceDirectory: '/run/agent-workspace',
+      sessionDirectory: '/run/.agent-private/omp-home/sessions',
+      model: 'provider/model',
+    })
+    const configIndex = args.indexOf('--config')
+    expect(configIndex).toBeGreaterThanOrEqual(0)
+    expect(args[configIndex + 1]).toBe(resolve('/run/agent-workspace', '.omp', 'config.yml'))
+    expect(args).toContain('--mode')
+    expect(args).toContain('rpc')
+  })
+
+  it('omits optional flags when their values are absent', () => {
+    const args = ompSessionLaunchArgs({
+      workspaceDirectory: '/run/agent-workspace',
+      sessionDirectory: '/run/.agent-private/omp-home/sessions',
+    })
+    expect(args).not.toContain('--model')
+    expect(args).not.toContain('--thinking')
+    expect(args).not.toContain('--service-tier')
+    expect(args).not.toContain('--resume')
+  })
+})


### PR DESCRIPTION
## 根因

OMP 的 `omp-provider` 把 `.omp/mcp.json`（Playwright + auto-test-control 两个 stdio MCP server）和 `.omp/config.yml` 写进 run 工作区，但 `omp-host.ts` 启动 `omp --mode rpc` 时**没有传 `--config`**，于是 config overlay 从未被加载。

结果 OMP 会话只剩内置工具（read/bash/edit/.../xd:// 设备），既没有 `auto-test-control` 也没有 Playwright MCP。Control MCP 的 `test_contract` 预检失败（agent 原话：`no such tool exists in this session's inventory`），每次 OMP run 都在碰浏览器之前就 `infrastructure` 阻断。

这是**预先存在**的 bug，不是 eval 改动引入的——OMP 这个 host 一直没接线完成。

## 修复

- 启动参数加 `--config <workspace>/.omp/config.yml`，加载 overlay（禁用 OMP 内置浏览器 + 启用 run-scoped MCP servers）。
- 把启动参数抽成 `ompSessionLaunchArgs()` 便于回归测试。
- 新增 `tests/agent-omp-host.test.ts` 覆盖 `--config` 必须存在。

## 验证（真实业务）

对真实 LTA 登录 canary（`case-limit 1`，`lta-readonly-canary`）用 OMP 跑：

- **修复前**：`blocked`，`infrastructure`，`test_contract` 预检失败，token 0。
- **修复后**：`passed`，真正调用 `test_contract`（事件里出现 71 次）、驱动浏览器、`lastUsage` 填充 `{input 890, cached 74240, output 3969}`。

`npm run check` 全绿（458 测试 + typecheck + build）。

修好后 OMP 才能真正参与 Codex vs OMP 的公平对比（此前 OMP 永远 blocked，会掩盖其真实业务能力）。