### PR TITLE
fix: constrain Ark structured result fields

### DIFF
--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -191,6 +191,9 @@ Requirements:
 - Include concise user-facing blockers, product defects, and next actions without secrets. Use the test engineer's input language when practical.
 - Report the current Mutation Ledger and environment requirements exactly as returned by auto-test-control.environment_requirements; the harness independently checks their recorded identity, case linkage, evidence, and pending state.
 - The provider-facing strict schema uses an empty string for an optional scalar and an empty array for an optional array when that field does not apply. These are transport sentinels normalized by the Core; do not invent a failure classification, environment origin, receipt, or artifact path.
+- Use only these top-level keys: version, workflowId, sourceSha256, outcome, summary, startedAt, finishedAt, cases, mutations, environmentRequirements, blockers, productDefects, nextActions. Do not add caseIds, epoch, or mutationLedger.
+- Use only these keys in every case: caseId, title, outcome, summary, failureSource, failureKind, environmentRequirementIds, executionReceiptIds, fieldGateIds, evidence. Do not add case-level blockers, productDefects, or nextActions. Include every listed key; use the transport sentinels above when it does not apply.
+- Every evidence item must contain exactly kind, path, description. Use an empty path when no artifact path exists. Top-level blockers, productDefects, and nextActions are arrays of strings.
 
 ${executionEpochContext(executionEpoch)}
 

--- a/tests/codex-agent-prompt.test.ts
+++ b/tests/codex-agent-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { codexTestAgentPrompt } from '../src/agent/prompt.js'
+import { agentTestFinalPrompt, codexTestAgentPrompt } from '../src/agent/prompt.js'
+import { codexTestResultSchema } from '../src/agent/result.js'
 import type { WorkflowIntakeManifest } from '../src/workflow/types.js'
 
 function manifest(): WorkflowIntakeManifest {
@@ -73,5 +74,18 @@ describe('AgentHost test prompt safety rules', () => {
     expect(prompt).toContain('/run/case-results.epoch-0002.json')
     expect(prompt).toContain('Do not execute them, classify them, or create placeholder outcomes')
     expect(prompt).toContain('outcome contract derived from the same source row')
+  })
+
+  it('spells out the strict final-result keys for schema-loose providers', () => {
+    const prompt = agentTestFinalPrompt()
+    const topLevelKeys = Object.keys(codexTestResultSchema.properties).join(', ')
+    const caseKeys = Object.keys(codexTestResultSchema.properties.cases.items.properties).join(', ')
+    const evidenceKeys = Object.keys(codexTestResultSchema.properties.cases.items.properties.evidence.items.properties).join(', ')
+
+    expect(prompt).toContain(`Use only these top-level keys: ${topLevelKeys}.`)
+    expect(prompt).toContain('Do not add caseIds, epoch, or mutationLedger')
+    expect(prompt).toContain(`Use only these keys in every case: ${caseKeys}.`)
+    expect(prompt).toContain('Do not add case-level blockers, productDefects, or nextActions')
+    expect(prompt).toContain(`Every evidence item must contain exactly ${evidenceKeys}.`)
   })
 })


### PR DESCRIPTION
## Summary
- spell out the strict result key set in the AgentHost final prompt
- reject common extra fields emitted by schema-loose providers through explicit prompt guidance
- derive prompt contract assertions from the canonical result schema

## Verification
- npm run check
- 62 test files, 482 tests passed
- TypeScript build passed
- git diff --check