### PR TITLE
fix(agent): keep test execution on primary thread

### DIFF
--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -66,6 +66,8 @@ npm run agent:test -- \
 
 Provider 选择在 AgentHost 边界完成。Core 只传递 `AgentModelProviderDescriptor`（`providerId`、`model`、`baseUrl`、统一 `api`、输入模态、推理/容量能力和环境变量引用），再调用选中 Host 的 `modelProvider.prepare()`；适配器负责原生文件、selector、启动参数和隔离环境。Codex 当前声明只支持 `openai-responses`，并映射为 `wire_api = "responses"`。受管 Profile 的 `models.json` 以当前安装版 Codex CLI 的 bundled model catalog 为模板，保留该版本原生 agent instructions 和必需 schema，再只覆盖 Profile 声明的模型、推理、搜索、输入模态和容量能力；模板不可读取或生成文件不能由真实 CLI 解析时会在模型请求前 fail closed。这样既避免第三方模型落入错误的 fallback metadata，也不会用框架自制的弱提示替换 Codex 原生执行框架。Codex Web Search 只有在 Profile 明确声明 `supportsSearchTool: true` 时启用。OMP 声明支持 OMP catalog 的协议集合，并把同一 descriptor 写成 `models.yml`。因此 `openai-completions` 等 Profile 可以被 OMP 消费，但会在 Codex 适配器准备阶段明确拒绝，而不是让 Runner 解析 Codex 字段。第三方 Host 只需实现相同接口；已有合成 Host 契约测试证明它不需要在 Runner 增加 ID 分支。自定义模型应声明真实上下文窗口、输出上限和输入模态，避免错误调度或把不支持的图片发送给 Provider；仅 native 配置且没有目录元数据时，Codex 才可能保留 fallback metadata 警告。
 
+Auto-Test 的 Codex 测试线程固定由单一主代理执行，不启用 Codex 多代理工具。页面写入、Mutation Ledger 和回放 episode 因此始终由同一线程排序；只读材料分析仍可由主代理使用工作区脚本完成。
+
 仓库提供两个无密钥内置 Profile：
 
 | Profile | Model | Base URL | `envKey` | 备注 |

--- a/src/agent/codex-host.ts
+++ b/src/agent/codex-host.ts
@@ -150,7 +150,7 @@ export function startCodexSdkThread(
         shell_tool: options.fullAgentAccess,
         apps: false,
         plugins: false,
-        multi_agent: options.fullAgentAccess,
+        multi_agent: false,
         remote_plugin: false,
         hooks: false,
         memories: false,

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -94,7 +94,6 @@ Work with the same autonomy you would have in an interactive agent session:
 - Use shell commands and create temporary scripts or notes inside the run workspace whenever that is more effective than individual browser calls.
 - Use the complete Playwright MCP, including page evaluation, network inspection, vision tools, and Playwright code execution when useful.
 - Use network access and web search when they materially help diagnose the application or understand a dependency.
-- You may use host-provided subagents for parallel read-only analysis of materials or evidence; keep stateful browser writes coordinated by the primary thread.
 - Do not edit the Auto-Test repository or application source code. Any generated helper belongs inside this run workspace.
 
 Execution principles:

--- a/tests/agent-host.test.ts
+++ b/tests/agent-host.test.ts
@@ -289,6 +289,7 @@ process.stdin.on('end', () => {
     expect(sandboxIndex).toBeGreaterThanOrEqual(0)
     expect(args[sandboxIndex + 1]).toBe('danger-full-access')
     expect(args).toContain('features.plugins=false')
+    expect(args).toContain('features.multi_agent=false')
   })
 
   it('classifies host errors so only operational transport classes are retryable', () => {

--- a/tests/codex-agent-prompt.test.ts
+++ b/tests/codex-agent-prompt.test.ts
@@ -34,6 +34,7 @@ describe('AgentHost test prompt safety rules', () => {
 
     expect(prompt).toContain('primary test engineer')
     expect(prompt).toContain('shell commands')
+    expect(prompt).not.toContain('subagents')
     expect(prompt).toContain('browser_run_code_unsafe')
     expect(prompt).toContain('/run/input/original/fixture.xlsx')
     expect(prompt).toContain('/run/input/run-values.json')


### PR DESCRIPTION
## Summary
- disable Codex multi-agent tools for Auto-Test execution threads
- remove the prompt instruction that encouraged subagent delegation
- document the single-primary-thread execution contract

## Why
Stateful browser execution, Mutation Ledger operations, and replay episodes must remain ordered. A model could enter an empty subagent wait without creating a worker, leaving a resumable run stuck indefinitely.

## Verification
- `npm run check`
- focused AgentHost and prompt tests (23 tests)
- local OpenCodeReview delegation: 2/2 reviewable source files covered, no findings

## Docs
Updated `docs/agent-hosts.md`. No CLI, packaging, authentication, or Windows-specific behavior changed.