### PR TITLE
docs: record the model-API-credential consensus and ignore key CSVs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ storage-state*.json
 auth-state*.json
 Auto-Test.private-key
 Auto-Test.private-provider.json
+# Provider API-key CSV files are private credentials, never commit them.
+*apiKey-*.csv
+*api-key-*.csv
 
 # Real test inputs are private by default. Synthetic templates may be committed.
 *.xlsx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,21 @@ Profiles live at `~/.config/auto-test/environment-profiles.json` (Linux/macOS) o
 `storageState`/`sessionStorage` per run; auth files must be `0600`. Write permission is governed
 only by the Profile, never by inferred per-case risk.
 
+## Model API credentials (consensus)
+
+- **Provider API keys are private credentials.** They never go into tracked files, commits, or public
+  docs. The project has one dedicated automation-test credential source; its CSV lives outside the
+  repo (or is git-ignored by `*apiKey-*.csv` / `*api-key-*.csv` if placed under the repo root) and is
+  only read into the build process via environment variables, never written into the command line or
+  shell history.
+- **Do not add a CSV under the repo root without it being ignored.** `build-private-windows-package.sh`
+  injects the key into the private ZIP; the ZIP itself is a sensitive credential artifact. Distribute
+  it point-to-point only, delete it locally after delivery, and never upload it to chat, cloud drives,
+  or public artifact stores.
+- **Model IDs are provider-specific.** A model id valid on one provider (e.g. Volcengine ARK) may not
+  exist on another (e.g. Aliyun Bailian); switching suppliers requires re-verifying the id and base URL
+  against that provider's Responses endpoint before packaging.
+
 ## Model profile (multi-provider switching)
 
 A separate `model-profiles.json` registry (same config dir as environment profiles; template at


### PR DESCRIPTION
## 背景

Auto-Test 现在有一个专用自动化测试模型供应商凭证 CSV，它放在仓库根目录。该文件携带**活 API Key**，而仓库是公开的——之前没有任何 gitignore 规则覆盖 `*apiKey-*.csv`，一旦 `git add -A` 就会把 Key 泄露到 GitHub。

## 改动

- `.gitignore`：新增 `*apiKey-*.csv` / `*api-key-*.csv`，让带 Key 的 CSV 永远无法被跟踪。
- `CLAUDE.md`：新增 `## Model API credentials (consensus)` 小节，记录约定：
  1. Provider API Key 是私有凭据，绝不进入 tracked 文件/提交/公开文档；
  2. 唯一构建入口是环境变量，不进命令行/shell 历史；
  3. 私有 ZIP 本身是敏感凭据载体，只点对点分发、交付后本地删除、绝不外传；
  4. 模型 ID 是供应商特定的，切换供应商必须重新在对方 Responses 端点验证。

## 验证

- `git check-ignore` 确认 `ai ali-apiKey-6789048.csv` 现在被忽略，`git add` 会拒绝。
- 纯文档 + gitignore 改动，不影响任何代码/测试/CI。