### PR TITLE
refactor: extract model-provider contract to core + add architecture contract

### DIFF
--- a/architecture.yml
+++ b/architecture.yml
@@ -1,0 +1,36 @@
+# Auto-Test architecture contract - agents must not violate it; check.py gates the end.
+# Derived from the real dependency flow (2026-08-21): core is pure and cli has zero
+# inbound edges are already true; rules fix the flow direction and forbid reversals/cycles.
+
+layers:
+  entry: [src.cli]                          # entry points, outbound-only
+  agent: [src.agent]                        # agent orchestration
+  workflow: [src.workflow]                  # workflow engine (orchestration core)
+  io: [src.input, src.ir, src.report, src.runtime, src.compiler]   # input/compile/output
+  repair: [src.repair, src.exploration]     # repair & exploration
+  support: [src.usability, src.validation, src.eval, src.importer]
+  foundation: [src.core]                    # pure foundation (types/diagnostics)
+
+rules:
+  # foundation must stay pure: no dependency on any internal layer
+  - from: foundation
+    cannot_depend_on: [entry, agent, workflow, io, repair, support]
+
+  # entry is the top layer; internal modules must not depend back on it
+  - from: agent
+    cannot_depend_on: [entry]
+  - from: workflow
+    cannot_depend_on: [entry]
+  - from: io
+    cannot_depend_on: [entry, agent, workflow]
+  - from: repair
+    cannot_depend_on: [entry]
+  - from: support
+    cannot_depend_on: [entry]
+
+  # dominant direction is agent -> workflow; workflow depending back on agent is a cycle
+  - from: workflow
+    cannot_depend_on: [agent]
+
+# ignore tests / scripts / configs (module-name globs; globs starting with * need quotes)
+exclude: [tests.*, scripts.*, examples.*, '*.config']

--- a/src/agent/host.ts
+++ b/src/agent/host.ts
@@ -1,6 +1,12 @@
 import { constants as fsConstants } from 'node:fs'
 import { access } from 'node:fs/promises'
 import { delimiter, extname, isAbsolute, resolve } from 'node:path'
+import {
+  type AgentModelApi,
+  type AgentModelInputModality,
+  type AgentModelProviderDescriptor,
+  type AgentModelReasoningEffort,
+} from '../core/model-provider.js'
 
 /**
  * The only execution surface the Auto-Test core expects from an agent.
@@ -10,44 +16,16 @@ import { delimiter, extname, isAbsolute, resolve } from 'node:path'
  * normalized events below and never imports a vendor SDK.
  */
 export type AgentHostId = 'codex' | 'omp' | (string & {})
-export const AGENT_MODEL_APIS = [
-  'openai-completions',
-  'openai-responses',
-  'openai-codex-responses',
-  'azure-openai-responses',
-  'anthropic-messages',
-  'bedrock-converse-stream',
-  'google-generative-ai',
-  'google-gemini-cli',
-  'google-vertex',
-] as const
-export type AgentModelApi = typeof AGENT_MODEL_APIS[number]
-export type AgentModelReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
-export type AgentModelInputModality = 'text' | 'image'
-
-export type AgentModelCredential =
-  | { type: 'environment'; name: string }
-  | { type: 'none' }
-
-/** Host-neutral model endpoint selected once for an Auto-Test run. */
-export interface AgentModelProviderDescriptor {
-  profileId: string
-  providerId: string
-  model: string
-  baseUrl: string
-  api: AgentModelApi
-  credential: AgentModelCredential
-  displayName?: string
-  reasoningEffort?: AgentModelReasoningEffort
-  reasoningEfforts?: AgentModelReasoningEffort[]
-  inputModalities?: AgentModelInputModality[]
-  supportsParallelToolCalls?: boolean
-  supportsSearchTool?: boolean
-  serviceTier?: string
-  supportsWebsockets?: boolean
-  contextWindowTokens?: number
-  maxOutputTokens?: number
-}
+// Model capability contract now lives in core/model-provider.ts (a provider
+// contract, not agent-specific); re-exported here for agent-layer consumers.
+export {
+  AGENT_MODEL_APIS,
+  type AgentModelApi,
+  type AgentModelCredential,
+  type AgentModelInputModality,
+  type AgentModelProviderDescriptor,
+  type AgentModelReasoningEffort,
+} from '../core/model-provider.js'
 
 export type AgentInputPart =
   | { type: 'text'; text: string }

--- a/src/core/model-provider.ts
+++ b/src/core/model-provider.ts
@@ -1,0 +1,43 @@
+/**
+ * Host-neutral model provider contract, shared by agent adapters, the workflow
+ * layer (model profiles) and the compiler. Lives in core so lower layers never
+ * have to reach into `agent/` for provider capability metadata.
+ */
+export const AGENT_MODEL_APIS = [
+  'openai-completions',
+  'openai-responses',
+  'openai-codex-responses',
+  'azure-openai-responses',
+  'anthropic-messages',
+  'bedrock-converse-stream',
+  'google-generative-ai',
+  'google-gemini-cli',
+  'google-vertex',
+] as const
+export type AgentModelApi = typeof AGENT_MODEL_APIS[number]
+export type AgentModelReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+export type AgentModelInputModality = 'text' | 'image'
+
+export type AgentModelCredential =
+  | { type: 'environment'; name: string }
+  | { type: 'none' }
+
+/** Host-neutral model endpoint selected once for an Auto-Test run. */
+export interface AgentModelProviderDescriptor {
+  profileId: string
+  providerId: string
+  model: string
+  baseUrl: string
+  api: AgentModelApi
+  credential: AgentModelCredential
+  displayName?: string
+  reasoningEffort?: AgentModelReasoningEffort
+  reasoningEfforts?: AgentModelReasoningEffort[]
+  inputModalities?: AgentModelInputModality[]
+  supportsParallelToolCalls?: boolean
+  supportsSearchTool?: boolean
+  serviceTier?: string
+  supportsWebsockets?: boolean
+  contextWindowTokens?: number
+  maxOutputTokens?: number
+}

--- a/src/workflow/model-profile.ts
+++ b/src/workflow/model-profile.ts
@@ -1,13 +1,13 @@
 import { homedir } from 'node:os'
 import { posix, resolve, win32 } from 'node:path'
 import { readFile } from 'node:fs/promises'
-import { AGENT_MODEL_APIS } from '../agent/host.js'
+import { AGENT_MODEL_APIS } from '../core/model-provider.js'
 import type {
   AgentModelApi,
   AgentModelInputModality,
   AgentModelProviderDescriptor,
   AgentModelReasoningEffort,
-} from '../agent/host.js'
+} from '../core/model-provider.js'
 
 /** @deprecated Registry readers still accept wireApi, but normalized profiles use api. */
 export type CodexWireApi = 'responses' | 'chat'


### PR DESCRIPTION
## Summary

Two-part change that encodes the project's dependency flow in a contract and makes the code comply with it:

**1. `refactor` — break a real `workflow → agent` dependency cycle.**
`src/workflow/model-profile.ts` imported `AGENT_MODEL_APIS` + the model types from `src/agent/host.ts`. The dominant direction is `agent → workflow` (18 edges); that one reverse edge closed a loop.
- New `src/core/model-provider.ts` — host-neutral model provider contract (a provider-capability contract, not agent-specific).
- `src/agent/host.ts` — re-exports the moved symbols so agent-layer consumers (omp-provider, provider-runtime, codex-provider) keep working.
- `src/workflow/model-profile.ts` — imports the contract from `core`.

**2. `chore` — add `architecture.yml`, the dependency-flow contract.**
Checked by the `architecture-viewer/check.py` tool. Layers derived from the real flow: `core` is pure (34 inbound / 0 outbound), `cli` has zero inbound edges. Rules fix the flow direction and forbid the cycle this refactor removes.

## Why

The contract gives a deterministic, reviewable answer to "which module may depend on which, and how dependencies flow." `check.py` gates it: agents keep the contract green and fix violations by inverting dependencies / extracting interfaces / splitting modules — which is exactly what the refactor does.

## Verification

- `npm run check` (local): typecheck ✓ · 486 vitest tests ✓ · `tsc` build ✓
- Contract checker after change: `workflow → agent` resolved. One known finding remains — `src/compiler.mcp-replay → src.agent.host` (needs the agent-event contract extracted to core) — out of scope, tracked separately.

## Notes

- Behavior-preserving: pure move of a `const` + types + re-export.
- `architecture.yml` is new at repo root; `exclude` covers `tests.*`, `scripts.*`, `examples.*`, `*.config`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
