### PR TITLE
refactor: extract agent event contract to core, resolve last contract violation

### DIFF
--- a/src/agent/host.ts
+++ b/src/agent/host.ts
@@ -27,51 +27,29 @@ export {
   type AgentModelReasoningEffort,
 } from '../core/model-provider.js'
 
-export type AgentInputPart =
-  | { type: 'text'; text: string }
-  | { type: 'local_image'; path: string }
 
-export interface AgentUsage {
-  inputTokens: number
-  cachedInputTokens: number
-  outputTokens: number
-}
+// Agent event contract lives in core/agent-events.ts; imported here for the
+// host surface and re-exported for agent-layer consumers.
+import {
+  agentHostErrorKindForMessage,
+  type AgentEvent,
+  type AgentHostErrorKind,
+  type AgentInputPart,
+} from '../core/agent-events.js'
+export {
+  type AgentEventType,
+  type AgentEvent,
+  type AgentHostErrorKind,
+  type AgentInputPart,
+  type AgentUsage,
+  agentHostErrorMessageForMatching,
+  agentHostErrorKindForMessage,
+  isAgentEvent,
+  isAgentSessionIncompatibleMessage,
+  normalizeAgentEvent,
+  usageFrom,
+} from '../core/agent-events.js'
 
-export type AgentEventType =
-  | 'thread_started'
-  | 'turn_started'
-  | 'turn_completed'
-  | 'turn_failed'
-  | 'session_incompatible'
-  | 'error'
-  | 'agent_message'
-  | 'tool_started'
-  | 'tool_completed'
-  | 'command_started'
-  | 'command_completed'
-  | 'file_change_started'
-  | 'file_change_completed'
-  | 'reasoning_started'
-  | 'todo_started'
-  | 'other'
-
-export interface AgentEvent {
-  type: AgentEventType
-  raw?: unknown | undefined
-  threadId?: string | undefined
-  message?: string | undefined
-  text?: string | undefined
-  usage?: AgentUsage | undefined
-  id?: string | undefined
-  server?: string | undefined
-  tool?: string | undefined
-  callId?: string | undefined
-  status?: 'completed' | 'failed' | undefined
-  arguments?: unknown | undefined
-  result?: unknown | undefined
-  /** Host-neutral classification for provider/runtime failures. */
-  errorKind?: AgentHostErrorKind | undefined
-}
 
 export interface AgentHostCapabilities {
   streaming: boolean
@@ -180,15 +158,6 @@ export interface AgentHostProbeResult {
   reason?: string
 }
 
-export type AgentHostErrorKind =
-  | 'transport'
-  | 'process'
-  | 'quota'
-  | 'session_incompatible'
-  | 'capability'
-  | 'configuration'
-  | 'protocol'
-  | 'unknown'
 
 export interface AgentHost {
   readonly id: AgentHostId
@@ -200,88 +169,6 @@ export interface AgentHost {
   resume(options: AgentHostLaunchOptions & { resumeId: string }): Promise<AgentHostSession>
 }
 
-export function isAgentEvent(value: unknown): value is AgentEvent {
-  return Boolean(value && typeof value === 'object' && 'type' in value && typeof (value as { type?: unknown }).type === 'string')
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
-}
-
-function recordValue(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined
-}
-
-function eventWithRaw(event: AgentEvent, raw: unknown): AgentEvent {
-  return { ...event, raw }
-}
-
-export function usageFrom(value: unknown): AgentUsage | undefined {
-  const record = recordValue(value)
-  if (!record) return undefined
-  const inputTokens = record.inputTokens ?? record.input_tokens ?? record.input
-  const cachedInputTokens = record.cachedInputTokens ?? record.cached_input_tokens ?? record.cacheRead
-  const outputTokens = record.outputTokens ?? record.output_tokens ?? record.output
-  if (![inputTokens, cachedInputTokens, outputTokens].every((item) => typeof item === 'number')) return undefined
-  return { inputTokens: inputTokens as number, cachedInputTokens: cachedInputTokens as number, outputTokens: outputTokens as number }
-}
-
-const advisoryHostMessagePatterns = [
-  /^Model metadata for `[^`]+` not found\. Defaulting to fallback metadata\b/i,
-  /^Heads up: Long threads and multiple compactions can cause the model to be less accurate\./i,
-  /^Skill descriptions were shortened to fit the skills context budget\./i,
-]
-
-const incompatibleSessionMessagePatterns = [
-  /^This (?:session|thread) was (?:recorded|created|started) with (?:model|provider) .+ but is resuming with .+[.]?$/i,
-  /\bCannot resume (?:session|thread)\b.*\b(?:different|incompatible)\b.*\b(?:model|provider)\b/i,
-  /\b(?:session|thread)\b.*\b(?:model|provider)\b.*\b(?:mismatch|incompatible)\b/i,
-]
-
-const quotaOrCapacityMessagePatterns = [
-  /\ballocated quota exceeded\b/i,
-  /\b(?:quota|usage|credit)(?: limit)?\s+(?:exceeded|depleted|insufficient|exhausted)\b/i,
-  /\binsufficient quota\b/i,
-  /\b(?:rate limit|too many requests)\b/i,
-  /\b(?:tpm|rpm)(?: rate)? limit\b/i,
-  /\btoken[- ]limit\b/i,
-  /\b(?:maximum )?(?:context length|context window)\b/i,
-  /\btoo many tokens\b/i,
-  /\boutput limit\b/i,
-  /\bat capacity\b/i,
-  /\b(?:resource )?exhausted\b/i,
-  /\boverloaded\b/i,
-  /\b429\b/i,
-]
-
-/** These Codex advisories do not stop the following turn from running. */
-function isAdvisoryHostMessage(message: string): boolean {
-  return advisoryHostMessagePatterns.some((pattern) => pattern.test(message))
-}
-
-/** Host adapters use this only for physical-session compatibility failures. */
-export function isAgentSessionIncompatibleMessage(message: string): boolean {
-  return incompatibleSessionMessagePatterns.some((pattern) => pattern.test(message))
-}
-
-/** Normalize common provider error spellings before applying host-neutral rules. */
-export function agentHostErrorMessageForMatching(message: string): string {
-  return message
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .toLowerCase()
-}
-
-/**
- * Normalize provider capacity/usage failures at the host boundary. Codex and
- * OMP may use different wire errors, but the Core must make the same
- * fail-fast decision for both.
- */
-export function agentHostErrorKindForMessage(message: string): AgentHostErrorKind | undefined {
-  const normalized = agentHostErrorMessageForMatching(message)
-  return quotaOrCapacityMessagePatterns.some((pattern) => pattern.test(normalized)) ? 'quota' : undefined
-}
 
 export function normalizeAgentHostError(hostId: AgentHostId, error: unknown): unknown {
   const message = error instanceof Error ? error.message : String(error)
@@ -294,203 +181,6 @@ export function normalizeAgentHostError(hostId: AgentHostId, error: unknown): un
       : error
   }
   return kind ? new AgentHostError(hostId, message, kind) : error
-}
-
-function normalizedFailureEvent(message: string, raw: unknown, id?: string): AgentEvent {
-  if (isAdvisoryHostMessage(message)) return eventWithRaw({ type: 'other', ...(id ? { id } : {}), message }, raw)
-  if (isAgentSessionIncompatibleMessage(message)) {
-    return eventWithRaw({ type: 'session_incompatible', ...(id ? { id } : {}), message }, raw)
-  }
-  const errorKind = agentHostErrorKindForMessage(message)
-  return eventWithRaw({ type: 'error', ...(id ? { id } : {}), message, ...(errorKind ? { errorKind } : {}) }, raw)
-}
-
-function normalizeItemEvent(raw: Record<string, unknown>, item: Record<string, unknown>): AgentEvent {
-  const itemType = stringValue(item.type)
-  const itemId = stringValue(item.id)
-  const status = item.status === 'failed' || item.isError === true ? 'failed' : 'completed'
-  if (itemType === 'mcp_tool_call') {
-    return {
-      type: raw.type === 'item.started' ? 'tool_started' : 'tool_completed',
-      id: itemId,
-      callId: itemId,
-      server: stringValue(item.server),
-      tool: stringValue(item.tool) ?? 'mcp_tool',
-      status,
-      arguments: item.arguments,
-      result: item.result,
-      raw,
-    }
-  }
-  if (itemType === 'command_execution') {
-    return {
-      type: raw.type === 'item.started' ? 'command_started' : 'command_completed',
-      id: itemId,
-      callId: itemId,
-      tool: 'command_execution',
-      status,
-      raw,
-    }
-  }
-  if (itemType === 'file_change') {
-    return {
-      type: raw.type === 'item.started' ? 'file_change_started' : 'file_change_completed',
-      id: itemId,
-      callId: itemId,
-      tool: 'file_change',
-      status,
-      raw,
-    }
-  }
-  if (itemType === 'reasoning') return eventWithRaw({ type: 'reasoning_started', id: itemId }, raw)
-  if (itemType === 'todo_list') return eventWithRaw({ type: 'todo_started', id: itemId }, raw)
-  if (itemType === 'web_search') return eventWithRaw({ type: 'tool_completed', id: itemId, tool: 'web_search', status }, raw)
-  if (itemType === 'agent_message') return eventWithRaw({ type: 'agent_message', id: itemId, text: stringValue(item.text) ?? '' }, raw)
-  if (itemType === 'error') {
-    const message = stringValue(item.message) ?? 'agent item failed'
-    return normalizedFailureEvent(message, raw, itemId)
-  }
-  return eventWithRaw({ type: 'other', id: itemId }, raw)
-}
-
-function normalizeOmpMessage(raw: Record<string, unknown>): AgentEvent | undefined {
-  const message = recordValue(raw.message)
-  if (!message) return undefined
-  const role = stringValue(message.role)
-  if (role !== 'assistant') return undefined
-  const content = message.content
-  if (typeof content === 'string') return content ? eventWithRaw({ type: 'agent_message', text: content }, raw) : undefined
-  if (!Array.isArray(content)) return undefined
-  const text = content
-    .map((part) => {
-      const value = recordValue(part)
-      return value?.type === 'text' ? stringValue(value.text) ?? '' : ''
-    })
-    .join('')
-  if (!text) return undefined
-  return eventWithRaw({ type: 'agent_message', text }, raw)
-}
-
-function parseOmpMcpIdentity(value: string, inner?: Record<string, unknown>): { server?: string; tool: string } | undefined {
-  if (!value.startsWith('mcp__')) return undefined
-  const innerServer = stringValue(inner?.serverName)
-  const innerTool = stringValue(inner?.mcpToolName)
-  if (innerTool) return { ...(innerServer ? { server: innerServer } : {}), tool: innerTool }
-  if (value.startsWith('mcp__playwright_')) return { server: 'playwright', tool: value.slice('mcp__playwright_'.length) }
-  if (value.startsWith('mcp__auto_test_control_')) {
-    return { server: 'auto-test-control', tool: value.slice('mcp__auto_test_control_'.length) }
-  }
-  return { tool: value }
-}
-
-function parseOmpXdArguments(value: unknown): unknown {
-  if (typeof value !== 'string') return undefined
-  try {
-    return JSON.parse(value) as unknown
-  } catch {
-    return undefined
-  }
-}
-
-function ompXdInvocation(raw: Record<string, unknown>): {
-  server?: string
-  tool: string
-  arguments?: unknown
-  failed: boolean
-} | undefined {
-  const result = recordValue(raw.result)
-  const xdev = recordValue(recordValue(result?.details)?.xdev)
-  const inner = recordValue(xdev?.inner)
-  const completedIdentity = stringValue(xdev?.mode) === 'execute'
-    ? parseOmpMcpIdentity(stringValue(xdev?.tool) ?? '', inner)
-    : undefined
-  if (completedIdentity) {
-    return {
-      ...completedIdentity,
-      ...(xdev?.args !== undefined ? { arguments: xdev.args } : {}),
-      failed: raw.isError === true || result?.isError === true || inner?.isError === true,
-    }
-  }
-
-  if (raw.type !== 'tool_execution_start' || raw.toolName !== 'write') return undefined
-  const args = recordValue(raw.args)
-  const path = stringValue(args?.path)
-  if (!path?.startsWith('xd://mcp__')) return undefined
-  const identity = parseOmpMcpIdentity(path.slice('xd://'.length))
-  if (!identity) return undefined
-  const invocationArguments = parseOmpXdArguments(args?.content)
-  return {
-    ...identity,
-    ...(invocationArguments !== undefined ? { arguments: invocationArguments } : {}),
-    failed: false,
-  }
-}
-
-/** Normalize Codex SDK events, OMP RPC events, and already-normalized events. */
-export function normalizeAgentEvent(value: unknown): AgentEvent {
-  if (!recordValue(value)) return { type: 'error', message: 'Agent host emitted a non-object event', raw: value }
-  const raw = value as Record<string, unknown>
-  if (isAgentEvent(raw) && [
-    'thread_started', 'turn_started', 'turn_completed', 'turn_failed', 'session_incompatible', 'agent_message',
-    'tool_started', 'tool_completed', 'command_started', 'command_completed', 'file_change_started',
-    'file_change_completed', 'reasoning_started', 'todo_started', 'other',
-  ].includes(raw.type)) return raw as AgentEvent
-
-  if (raw.type === 'thread.started') return eventWithRaw({ type: 'thread_started', threadId: stringValue(raw.thread_id) }, raw)
-  if (raw.type === 'turn.started') return eventWithRaw({ type: 'turn_started' }, raw)
-  if (raw.type === 'turn.completed') return eventWithRaw({ type: 'turn_completed', usage: usageFrom(raw.usage) }, raw)
-  if (raw.type === 'turn.failed') {
-    const error = recordValue(raw.error)
-    const message = stringValue(error?.message) ?? stringValue(raw.message) ?? 'agent turn failed'
-    return isAgentSessionIncompatibleMessage(message)
-      ? eventWithRaw({ type: 'session_incompatible', message }, raw)
-      : eventWithRaw({ type: 'turn_failed', message }, raw)
-  }
-  if (raw.type === 'error' || raw.type === 'extension_error') {
-    const message = stringValue(raw.message) ?? stringValue(raw.error) ?? 'agent host error'
-    return normalizedFailureEvent(message, raw)
-  }
-  if (raw.type === 'notice') {
-    return eventWithRaw({ type: 'other', message: stringValue(raw.message) }, raw)
-  }
-  if (raw.type === 'item.started' || raw.type === 'item.completed') {
-    const item = recordValue(raw.item)
-    return item ? normalizeItemEvent(raw, item) : eventWithRaw({ type: 'other' }, raw)
-  }
-  if (raw.type === 'agent_start') return eventWithRaw({ type: 'turn_started' }, raw)
-  if (raw.type === 'agent_end') {
-    return raw.isTerminal === false
-      ? eventWithRaw({ type: 'other', message: 'Agent host scheduled continuation work' }, raw)
-      : eventWithRaw({ type: 'turn_completed', usage: usageFrom(raw.usage) }, raw)
-  }
-  // OMP turn_start/turn_end describe inner model/tool-loop turns. A single
-  // Auto-Test prompt may contain several of them and completes only at the
-  // terminal agent_end event.
-  if (raw.type === 'turn_start' || raw.type === 'turn_end') return eventWithRaw({ type: 'other' }, raw)
-  // OMP message_update frames are streaming partials. Only message_end is a
-  // complete assistant response that the core may use as a final delivery.
-  if (raw.type === 'message_end') return normalizeOmpMessage(raw) ?? eventWithRaw({ type: 'other' }, raw)
-  if (raw.type === 'message_update' || raw.type === 'message_start') return eventWithRaw({ type: 'other' }, raw)
-  if (raw.type === 'tool_execution_update') return eventWithRaw({ type: 'other' }, raw)
-  if (raw.type === 'tool_execution_start' || raw.type === 'tool_execution_end') {
-    const details = recordValue(raw)
-    const type = raw.type === 'tool_execution_start' ? 'tool_started' : 'tool_completed'
-    const xdev = ompXdInvocation(raw)
-    const toolName = stringValue(details?.toolName) ?? 'agent_tool'
-    const identity = xdev ?? parseOmpMcpIdentity(toolName, recordValue(recordValue(details?.result)?.details))
-    return eventWithRaw({
-      type,
-      id: stringValue(details?.toolCallId),
-      callId: stringValue(details?.toolCallId),
-      ...(identity?.server ? { server: identity.server } : {}),
-      tool: identity?.tool ?? toolName,
-      status: xdev?.failed || details?.isError === true ? 'failed' : 'completed',
-      arguments: xdev?.arguments ?? details?.args,
-      result: details?.result ?? details?.partialResult,
-    }, raw)
-  }
-  if (raw.type === 'ready' || raw.type === 'response' || raw.type === 'prompt_result') return eventWithRaw({ type: 'other' }, raw)
-  return eventWithRaw({ type: 'other' }, raw)
 }
 
 function executableNames(command: string, environment: NodeJS.ProcessEnv): string[] {

--- a/src/compiler/mcp-replay.ts
+++ b/src/compiler/mcp-replay.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { normalizeAgentEvent } from '../agent/host.js'
+import { normalizeAgentEvent } from '../core/agent-events.js'
 
 export interface ReplayDiagnostic {
   severity: 'error' | 'warning'

--- a/src/core/agent-events.ts
+++ b/src/core/agent-events.ts
@@ -1,0 +1,344 @@
+/**
+ * Host-neutral normalized agent event contract: the canonical event/usage types
+ * and the normalization pipeline (Codex SDK, OMP RPC, already-normalized). Hosts
+ * emit these; the workflow layer and the compiler (MCP replay) consume them.
+ * Lives in core so lower layers can consume agent events without reaching into
+ * `agent/`.
+ */
+
+
+export type AgentInputPart =
+  | { type: 'text'; text: string }
+  | { type: 'local_image'; path: string }
+
+export interface AgentUsage {
+  inputTokens: number
+  cachedInputTokens: number
+  outputTokens: number
+}
+
+export type AgentEventType =
+  | 'thread_started'
+  | 'turn_started'
+  | 'turn_completed'
+  | 'turn_failed'
+  | 'session_incompatible'
+  | 'error'
+  | 'agent_message'
+  | 'tool_started'
+  | 'tool_completed'
+  | 'command_started'
+  | 'command_completed'
+  | 'file_change_started'
+  | 'file_change_completed'
+  | 'reasoning_started'
+  | 'todo_started'
+  | 'other'
+
+export interface AgentEvent {
+  type: AgentEventType
+  raw?: unknown | undefined
+  threadId?: string | undefined
+  message?: string | undefined
+  text?: string | undefined
+  usage?: AgentUsage | undefined
+  id?: string | undefined
+  server?: string | undefined
+  tool?: string | undefined
+  callId?: string | undefined
+  status?: 'completed' | 'failed' | undefined
+  arguments?: unknown | undefined
+  result?: unknown | undefined
+  /** Host-neutral classification for provider/runtime failures. */
+  errorKind?: AgentHostErrorKind | undefined
+}
+
+export type AgentHostErrorKind =
+  | 'transport'
+  | 'process'
+  | 'quota'
+  | 'session_incompatible'
+  | 'capability'
+  | 'configuration'
+  | 'protocol'
+  | 'unknown'
+
+export function isAgentEvent(value: unknown): value is AgentEvent {
+  return Boolean(value && typeof value === 'object' && 'type' in value && typeof (value as { type?: unknown }).type === 'string')
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+function eventWithRaw(event: AgentEvent, raw: unknown): AgentEvent {
+  return { ...event, raw }
+}
+
+export function usageFrom(value: unknown): AgentUsage | undefined {
+  const record = recordValue(value)
+  if (!record) return undefined
+  const inputTokens = record.inputTokens ?? record.input_tokens ?? record.input
+  const cachedInputTokens = record.cachedInputTokens ?? record.cached_input_tokens ?? record.cacheRead
+  const outputTokens = record.outputTokens ?? record.output_tokens ?? record.output
+  if (![inputTokens, cachedInputTokens, outputTokens].every((item) => typeof item === 'number')) return undefined
+  return { inputTokens: inputTokens as number, cachedInputTokens: cachedInputTokens as number, outputTokens: outputTokens as number }
+}
+
+const advisoryHostMessagePatterns = [
+  /^Model metadata for `[^`]+` not found\. Defaulting to fallback metadata\b/i,
+  /^Heads up: Long threads and multiple compactions can cause the model to be less accurate\./i,
+  /^Skill descriptions were shortened to fit the skills context budget\./i,
+]
+
+const incompatibleSessionMessagePatterns = [
+  /^This (?:session|thread) was (?:recorded|created|started) with (?:model|provider) .+ but is resuming with .+[.]?$/i,
+  /\bCannot resume (?:session|thread)\b.*\b(?:different|incompatible)\b.*\b(?:model|provider)\b/i,
+  /\b(?:session|thread)\b.*\b(?:model|provider)\b.*\b(?:mismatch|incompatible)\b/i,
+]
+
+const quotaOrCapacityMessagePatterns = [
+  /\ballocated quota exceeded\b/i,
+  /\b(?:quota|usage|credit)(?: limit)?\s+(?:exceeded|depleted|insufficient|exhausted)\b/i,
+  /\binsufficient quota\b/i,
+  /\b(?:rate limit|too many requests)\b/i,
+  /\b(?:tpm|rpm)(?: rate)? limit\b/i,
+  /\btoken[- ]limit\b/i,
+  /\b(?:maximum )?(?:context length|context window)\b/i,
+  /\btoo many tokens\b/i,
+  /\boutput limit\b/i,
+  /\bat capacity\b/i,
+  /\b(?:resource )?exhausted\b/i,
+  /\boverloaded\b/i,
+  /\b429\b/i,
+]
+
+/** These Codex advisories do not stop the following turn from running. */
+function isAdvisoryHostMessage(message: string): boolean {
+  return advisoryHostMessagePatterns.some((pattern) => pattern.test(message))
+}
+
+/** Host adapters use this only for physical-session compatibility failures. */
+export function isAgentSessionIncompatibleMessage(message: string): boolean {
+  return incompatibleSessionMessagePatterns.some((pattern) => pattern.test(message))
+}
+
+/** Normalize common provider error spellings before applying host-neutral rules. */
+export function agentHostErrorMessageForMatching(message: string): string {
+  return message
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+/**
+ * Normalize provider capacity/usage failures at the host boundary. Codex and
+ * OMP may use different wire errors, but the Core must make the same
+ * fail-fast decision for both.
+ */
+export function agentHostErrorKindForMessage(message: string): AgentHostErrorKind | undefined {
+  const normalized = agentHostErrorMessageForMatching(message)
+  return quotaOrCapacityMessagePatterns.some((pattern) => pattern.test(normalized)) ? 'quota' : undefined
+}
+
+function normalizedFailureEvent(message: string, raw: unknown, id?: string): AgentEvent {
+  if (isAdvisoryHostMessage(message)) return eventWithRaw({ type: 'other', ...(id ? { id } : {}), message }, raw)
+  if (isAgentSessionIncompatibleMessage(message)) {
+    return eventWithRaw({ type: 'session_incompatible', ...(id ? { id } : {}), message }, raw)
+  }
+  const errorKind = agentHostErrorKindForMessage(message)
+  return eventWithRaw({ type: 'error', ...(id ? { id } : {}), message, ...(errorKind ? { errorKind } : {}) }, raw)
+}
+
+function normalizeItemEvent(raw: Record<string, unknown>, item: Record<string, unknown>): AgentEvent {
+  const itemType = stringValue(item.type)
+  const itemId = stringValue(item.id)
+  const status = item.status === 'failed' || item.isError === true ? 'failed' : 'completed'
+  if (itemType === 'mcp_tool_call') {
+    return {
+      type: raw.type === 'item.started' ? 'tool_started' : 'tool_completed',
+      id: itemId,
+      callId: itemId,
+      server: stringValue(item.server),
+      tool: stringValue(item.tool) ?? 'mcp_tool',
+      status,
+      arguments: item.arguments,
+      result: item.result,
+      raw,
+    }
+  }
+  if (itemType === 'command_execution') {
+    return {
+      type: raw.type === 'item.started' ? 'command_started' : 'command_completed',
+      id: itemId,
+      callId: itemId,
+      tool: 'command_execution',
+      status,
+      raw,
+    }
+  }
+  if (itemType === 'file_change') {
+    return {
+      type: raw.type === 'item.started' ? 'file_change_started' : 'file_change_completed',
+      id: itemId,
+      callId: itemId,
+      tool: 'file_change',
+      status,
+      raw,
+    }
+  }
+  if (itemType === 'reasoning') return eventWithRaw({ type: 'reasoning_started', id: itemId }, raw)
+  if (itemType === 'todo_list') return eventWithRaw({ type: 'todo_started', id: itemId }, raw)
+  if (itemType === 'web_search') return eventWithRaw({ type: 'tool_completed', id: itemId, tool: 'web_search', status }, raw)
+  if (itemType === 'agent_message') return eventWithRaw({ type: 'agent_message', id: itemId, text: stringValue(item.text) ?? '' }, raw)
+  if (itemType === 'error') {
+    const message = stringValue(item.message) ?? 'agent item failed'
+    return normalizedFailureEvent(message, raw, itemId)
+  }
+  return eventWithRaw({ type: 'other', id: itemId }, raw)
+}
+
+function normalizeOmpMessage(raw: Record<string, unknown>): AgentEvent | undefined {
+  const message = recordValue(raw.message)
+  if (!message) return undefined
+  const role = stringValue(message.role)
+  if (role !== 'assistant') return undefined
+  const content = message.content
+  if (typeof content === 'string') return content ? eventWithRaw({ type: 'agent_message', text: content }, raw) : undefined
+  if (!Array.isArray(content)) return undefined
+  const text = content
+    .map((part) => {
+      const value = recordValue(part)
+      return value?.type === 'text' ? stringValue(value.text) ?? '' : ''
+    })
+    .join('')
+  if (!text) return undefined
+  return eventWithRaw({ type: 'agent_message', text }, raw)
+}
+
+function parseOmpMcpIdentity(value: string, inner?: Record<string, unknown>): { server?: string; tool: string } | undefined {
+  if (!value.startsWith('mcp__')) return undefined
+  const innerServer = stringValue(inner?.serverName)
+  const innerTool = stringValue(inner?.mcpToolName)
+  if (innerTool) return { ...(innerServer ? { server: innerServer } : {}), tool: innerTool }
+  if (value.startsWith('mcp__playwright_')) return { server: 'playwright', tool: value.slice('mcp__playwright_'.length) }
+  if (value.startsWith('mcp__auto_test_control_')) {
+    return { server: 'auto-test-control', tool: value.slice('mcp__auto_test_control_'.length) }
+  }
+  return { tool: value }
+}
+
+function parseOmpXdArguments(value: unknown): unknown {
+  if (typeof value !== 'string') return undefined
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function ompXdInvocation(raw: Record<string, unknown>): {
+  server?: string
+  tool: string
+  arguments?: unknown
+  failed: boolean
+} | undefined {
+  const result = recordValue(raw.result)
+  const xdev = recordValue(recordValue(result?.details)?.xdev)
+  const inner = recordValue(xdev?.inner)
+  const completedIdentity = stringValue(xdev?.mode) === 'execute'
+    ? parseOmpMcpIdentity(stringValue(xdev?.tool) ?? '', inner)
+    : undefined
+  if (completedIdentity) {
+    return {
+      ...completedIdentity,
+      ...(xdev?.args !== undefined ? { arguments: xdev.args } : {}),
+      failed: raw.isError === true || result?.isError === true || inner?.isError === true,
+    }
+  }
+
+  if (raw.type !== 'tool_execution_start' || raw.toolName !== 'write') return undefined
+  const args = recordValue(raw.args)
+  const path = stringValue(args?.path)
+  if (!path?.startsWith('xd://mcp__')) return undefined
+  const identity = parseOmpMcpIdentity(path.slice('xd://'.length))
+  if (!identity) return undefined
+  const invocationArguments = parseOmpXdArguments(args?.content)
+  return {
+    ...identity,
+    ...(invocationArguments !== undefined ? { arguments: invocationArguments } : {}),
+    failed: false,
+  }
+}
+
+/** Normalize Codex SDK events, OMP RPC events, and already-normalized events. */
+export function normalizeAgentEvent(value: unknown): AgentEvent {
+  if (!recordValue(value)) return { type: 'error', message: 'Agent host emitted a non-object event', raw: value }
+  const raw = value as Record<string, unknown>
+  if (isAgentEvent(raw) && [
+    'thread_started', 'turn_started', 'turn_completed', 'turn_failed', 'session_incompatible', 'agent_message',
+    'tool_started', 'tool_completed', 'command_started', 'command_completed', 'file_change_started',
+    'file_change_completed', 'reasoning_started', 'todo_started', 'other',
+  ].includes(raw.type)) return raw as AgentEvent
+
+  if (raw.type === 'thread.started') return eventWithRaw({ type: 'thread_started', threadId: stringValue(raw.thread_id) }, raw)
+  if (raw.type === 'turn.started') return eventWithRaw({ type: 'turn_started' }, raw)
+  if (raw.type === 'turn.completed') return eventWithRaw({ type: 'turn_completed', usage: usageFrom(raw.usage) }, raw)
+  if (raw.type === 'turn.failed') {
+    const error = recordValue(raw.error)
+    const message = stringValue(error?.message) ?? stringValue(raw.message) ?? 'agent turn failed'
+    return isAgentSessionIncompatibleMessage(message)
+      ? eventWithRaw({ type: 'session_incompatible', message }, raw)
+      : eventWithRaw({ type: 'turn_failed', message }, raw)
+  }
+  if (raw.type === 'error' || raw.type === 'extension_error') {
+    const message = stringValue(raw.message) ?? stringValue(raw.error) ?? 'agent host error'
+    return normalizedFailureEvent(message, raw)
+  }
+  if (raw.type === 'notice') {
+    return eventWithRaw({ type: 'other', message: stringValue(raw.message) }, raw)
+  }
+  if (raw.type === 'item.started' || raw.type === 'item.completed') {
+    const item = recordValue(raw.item)
+    return item ? normalizeItemEvent(raw, item) : eventWithRaw({ type: 'other' }, raw)
+  }
+  if (raw.type === 'agent_start') return eventWithRaw({ type: 'turn_started' }, raw)
+  if (raw.type === 'agent_end') {
+    return raw.isTerminal === false
+      ? eventWithRaw({ type: 'other', message: 'Agent host scheduled continuation work' }, raw)
+      : eventWithRaw({ type: 'turn_completed', usage: usageFrom(raw.usage) }, raw)
+  }
+  // OMP turn_start/turn_end describe inner model/tool-loop turns. A single
+  // Auto-Test prompt may contain several of them and completes only at the
+  // terminal agent_end event.
+  if (raw.type === 'turn_start' || raw.type === 'turn_end') return eventWithRaw({ type: 'other' }, raw)
+  // OMP message_update frames are streaming partials. Only message_end is a
+  // complete assistant response that the core may use as a final delivery.
+  if (raw.type === 'message_end') return normalizeOmpMessage(raw) ?? eventWithRaw({ type: 'other' }, raw)
+  if (raw.type === 'message_update' || raw.type === 'message_start') return eventWithRaw({ type: 'other' }, raw)
+  if (raw.type === 'tool_execution_update') return eventWithRaw({ type: 'other' }, raw)
+  if (raw.type === 'tool_execution_start' || raw.type === 'tool_execution_end') {
+    const details = recordValue(raw)
+    const type = raw.type === 'tool_execution_start' ? 'tool_started' : 'tool_completed'
+    const xdev = ompXdInvocation(raw)
+    const toolName = stringValue(details?.toolName) ?? 'agent_tool'
+    const identity = xdev ?? parseOmpMcpIdentity(toolName, recordValue(recordValue(details?.result)?.details))
+    return eventWithRaw({
+      type,
+      id: stringValue(details?.toolCallId),
+      callId: stringValue(details?.toolCallId),
+      ...(identity?.server ? { server: identity.server } : {}),
+      tool: identity?.tool ?? toolName,
+      status: xdev?.failed || details?.isError === true ? 'failed' : 'completed',
+      arguments: xdev?.arguments ?? details?.args,
+      result: details?.result ?? details?.partialResult,
+    }, raw)
+  }
+  if (raw.type === 'ready' || raw.type === 'response' || raw.type === 'prompt_result') return eventWithRaw({ type: 'other' }, raw)
+  return eventWithRaw({ type: 'other' }, raw)
+}


### PR DESCRIPTION
## Summary

Fixes the last architecture-contract violation (`src.compiler.mcp-replay → src.agent.host`) found by `architecture.yml` / `check.py`.

`src/compiler/mcp-replay.ts` imported `normalizeAgentEvent` from `src/agent/host.ts` — an `io → agent` cross-layer reach. The normalized agent event contract (event/usage types + normalization pipeline + error-message helpers, ~300 lines) is now moved into **`src/core/agent-events.ts`**, so the compiler consumes agent events directly from `core` without reaching into `agent/`.

- New `src/core/agent-events.ts` — the host-neutral event contract (a verbatim move).
- `src/agent/host.ts` — keeps the host execution surface (`AgentHost` interface, `AgentHostError`, `normalizeAgentHostError`, `resolveHostExecutable`), imports the types it still uses, re-exports the contract for agent-layer consumers (runner, progress, execution-receipts, tests).
- `src/compiler/mcp-replay.ts` — imports `normalizeAgentEvent` from `core`.

This follows the same design decision as the previous PR (#69): core hosts the host-neutral contracts (model-provider, agent-events) that lower layers share, matching the code's stated philosophy that *"the core consumes the normalized events"*.

## Verification

- `npm run check` (local): typecheck ✓ · **486 vitest tests ✓** · `tsc` build ✓
- Contract checker: **0 violations** (both the workflow→agent cycle and the compiler→agent reach are resolved)
- The full-suite run caught a real runtime ESM pitfall (`export { AgentEventType }` of a type-only binding without `type`), fixed by marking it `export type` — typecheck cannot see this without `verbatimModuleSyntax`, so the full suite gate was load-bearing.

## Notes

- Behavior-preserving: pure verbatim move of the event contract; git detected 67% similarity (copy).
- `architecture.yml` unchanged — the code now complies with the existing contract.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
