### PR TITLE
feat: add upstream PRD to sub-issues primitives

### DIFF
--- a/.claude/skills/to-issues-project/SKILL.md
+++ b/.claude/skills/to-issues-project/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: to-issues-project
+description: Break a PRD into native GitHub sub-issues attached to the parent PRD. Project-local variant of /to-issues, adapted for this repo's PRD-as-parent + native sub-issues + agent:implement multi-session workflow. Argument is the parent PRD issue number.
+---
+
+# To Issues (project)
+
+Break a parent PRD into a flat list of native GitHub sub-issues, in execution order. Each sub-issue is a tracer-bullet vertical slice that the PRD-mode `agent:implement` workflow will pick up one at a time.
+
+## Inputs
+
+- **Argument:** the parent PRD's issue number. If the user invoked the skill without one, ask for it (or for a URL).
+- **Conversation context** (optional): any planning that's already happened. Use it.
+
+## Process
+
+### 1. Fetch the PRD
+
+```
+gh issue view <PRD_NUMBER> --comments
+```
+
+Read the body carefully. The PRD is the spec. Don't add scope; don't redesign. If the PRD is ambiguous, ask the user to clarify _before_ drafting slices — the slices should reflect the PRD as-is, not your interpretation.
+
+### 2. Confirm there are no existing sub-issues
+
+```
+gh api repos/$GH_REPO/issues/<PRD_NUMBER>/sub_issues --jq 'length'
+```
+
+If non-zero, stop and ask the user whether to (a) abort, (b) add more on top of what's there, or (c) close/delete the existing ones first. Don't silently double up.
+
+### 3. Explore the codebase (optional)
+
+If you haven't already, explore the repo to understand the area you're touching. Use established terms in `docs/` and respect any ADRs under `docs/adr/`. Sub-issue titles and bodies should use the project's vocabulary.
+
+Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+### 4. Draft vertical slices
+
+Break the PRD into **tracer-bullet** sub-issues. Each slice is a thin vertical cut through every layer (schema → API → UI → tests), NOT a horizontal slice of one layer.
+
+<vertical-slice-rules>
+- Each slice delivers a narrow but COMPLETE path through every layer
+- A completed slice is demoable or verifiable on its own
+- Sub-issues are **flat** — a sub-issue must not itself need sub-issues. If a slice is too big to leaf, split it into multiple peer slices instead of nesting
+- Any prefactoring should be done first, in its own slice(s) at the start of the list
+- Sub-issues run in **list order** under the PRD. Order them so dependencies are satisfied: if slice B builds on slice A's schema, A must come first
+</vertical-slice-rules>
+
+The PRD-mode workflow implements sub-issues one at a time, each in its own agent session, committing to a shared branch. Keep that in mind:
+
+- Each slice must stand on its own in a single session — no slice should require state from a previous session beyond what's on the branch.
+- A reasonable session can build a couple of files, write tests, and run typecheck/test. Don't draft slices that are unrealistic for one session.
+
+### 5. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title** — short, imperative
+- **What it builds** — one or two sentences
+- **Depends on** — which earlier slice(s) it builds on (by position in the list), or "none"
+
+Ask:
+
+- Is the granularity right? (too coarse / too fine)
+- Is the order right?
+- Should any slices be merged, split, or dropped?
+
+Iterate until the user approves.
+
+### 6. Publish sub-issues to GitHub
+
+Publish in order. For each slice:
+
+1. **Create the issue:**
+
+   ```
+   gh issue create --title "<title>" --body "$(cat <<'EOF'
+   <body — see template>
+   EOF
+   )"
+   ```
+
+   This prints the new issue URL. Capture the issue number.
+
+2. **Get its node ID** (needed by the sub-issues API):
+
+   ```
+   gh api repos/$GH_REPO/issues/<sub_issue_number> --jq '.id'
+   ```
+
+   The `.id` field is the REST integer ID. Save it.
+
+3. **Attach as sub-issue of the PRD:**
+   ```
+   gh api -X POST "repos/$GH_REPO/issues/<PRD_NUMBER>/sub_issues" \
+     -f sub_issue_id=<sub_issue_id>
+   ```
+   This is the native sub-issues link — it shows up in the PRD's progress bar and is what the `agent-implement-prd.yml` workflow reads.
+
+Do **not** apply `agent:implement` to the sub-issues — they're never labeled directly. The user (or you, if asked) adds `agent:implement` to the **PRD** when ready to start work.
+
+### 7. Sub-issue body template
+
+<sub-issue-template>
+## Parent PRD
+
+#&lt;PRD_NUMBER&gt;
+
+## What to build
+
+A concise description of this slice's end-to-end behavior. One to three short paragraphs. Frame it around what the slice _delivers_, not which files change.
+
+Avoid specific file paths or code snippets — they go stale fast.
+
+Exception: a prototype-derived snippet (state machine, reducer, schema, type shape) may be inlined when prose can't encode the decision as precisely. Trim to the decision-rich parts.
+
+## Acceptance criteria
+
+- [ ] Concrete, checkable outcome 1
+- [ ] Concrete, checkable outcome 2
+- [ ] Tests cover the new behavior
+
+## Depends on
+
+If this slice builds on an earlier sub-issue's work, name it (e.g. "Sub-issue #N — &lt;title&gt;"). If not, omit this section.
+</sub-issue-template>
+
+The body intentionally does NOT include a `Closes` directive. Closing this sub-issue is the PRD-mode workflow's job (it closes the sub-issue at the end of its implementation run). Closing the PRD itself happens when the bundled PR merges via `Closes #<PRD>` in the PR description.
+
+## After publishing
+
+- Output the PRD URL and the count of sub-issues attached.
+- Tell the user: "Add `agent:implement` to PRD #&lt;N&gt; when ready. The workflow will implement sub-issues in order, accumulating commits on a single `agent/prd-<N>-...` branch, and open a draft PR after the first sub-issue."
+- Remind them that the order of sub-issues in the PRD determines execution order. If they want to reorder, they can drag in the GitHub UI before labeling, or use the `PATCH /repos/{owner}/{repo}/issues/{issue_number}/sub_issues/priority` endpoint.

--- a/.claude/skills/to-prd-project/SKILL.md
+++ b/.claude/skills/to-prd-project/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: to-prd-project
+description: Turn the current conversation context into a PRD and publish it as a GitHub issue that is ready to receive sub-issues from /to-issues-project. Project-local variant of /to-prd, adapted for this repo's PRD-as-parent-issue + sub-issues + agent:implement workflow.
+---
+
+This skill writes a PRD and publishes it as a GitHub issue in `kilbertert/Auto_Test`. It does **not** apply `agent:implement` — labeling happens _after_ sub-issues have been created.
+
+Do NOT interview the user — just synthesize what you already know from the conversation. If context is thin, ask the user to talk through the problem first; don't run the skill on an empty plate.
+
+## Process
+
+1. **Explore the repo** to understand the current state of the codebase, if you haven't already. Use established terms in `docs/` and respect any ADRs under `docs/adr/` for areas you're touching.
+
+2. **Sketch the major modules** you'd build or modify. Actively look for opportunities to extract deep modules that can be tested in isolation. A deep module encapsulates a lot of functionality behind a simple, testable interface that rarely changes.
+
+   Check with the user that these modules match their expectations and which they want tests written for.
+
+3. **Write the PRD** using the template below and publish it via `gh issue create`. Use a heredoc for the body. Do **not** apply `agent:implement` — that's reserved for after sub-issues exist. Add no labels unless the user asks.
+
+4. **Output the issue URL** so the user can pass it to `/to-issues-project` next.
+
+## PRD template
+
+The PRD will be read by:
+
+- **Humans** deciding whether the plan is sound.
+- **`/to-issues-project`** when breaking it into sub-issues.
+- The **PRD-mode implement workflow** at the start of each sub-issue run (the prompt pulls in the PRD body for context).
+- The **review workflow** when checking "does the PR match the spec?"
+
+So the PRD must be a _spec_, not a sketch — concrete enough that a sub-issue agent can implement against it without re-deriving decisions.
+
+<prd-template>
+
+## Problem Statement
+
+The problem the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each in the format:
+
+1. As a &lt;actor&gt;, I want &lt;feature&gt;, so that &lt;benefit&gt;
+
+This list should cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions, including:
+
+- The modules to build/modify
+- The interfaces of those modules
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do **not** include specific file paths or code snippets. They go stale fast.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note that it came from a prototype. Trim to the decision-rich parts.
+
+## Testing Decisions
+
+- What makes a good test in this codebase (only external behavior, not implementation details)
+- Which modules will be tested
+- Prior art (similar tests in the codebase)
+
+## Out of Scope
+
+Things explicitly excluded from this PRD. Be specific — "we are not building X" rather than "X is out of scope."
+
+## Further Notes
+
+Anything else worth recording: open questions, known risks, deferred decisions.
+
+</prd-template>
+
+## After publishing
+
+- Tell the user: "PRD published at &lt;URL&gt;. Run `/to-issues-project &lt;issue-number&gt;` to break it into sub-issues, then add `agent:implement` to start work."
+- Do **not** add `agent:implement` yourself. The PRD has no sub-issues yet, so labeling it now would either silently bounce (regular single-issue workflow would try to run it as a leaf and might do unexpected work) or land in the wrong place. The user labels once sub-issues are in place.

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -21,11 +21,11 @@ RUN groupmod -o -g ${AGENT_GID} node \
 RUN npm install --global @anthropic-ai/claude-code \
   && mv /usr/local/bin/claude /usr/local/bin/claude-real \
   && printf '%s\n' \
-    '#!/bin/sh' \
+    '#!/usr/bin/env bash' \
     'set -eu' \
     'case "${AFK_PROFILE:-claude}" in' \
     '  claude) exec /usr/local/bin/claude-real "$@" ;;' \
-    '  claude-ark) exec env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_REASONING_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL /usr/local/bin/claude-real --settings /run/afk/profile-settings.json "$@" ;;' \
+    '  claude-ark) args=(); while [ "$#" -gt 0 ]; do if [ "$1" = "--model" ]; then shift 2; else args+=("$1"); shift; fi; done; exec env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_REASONING_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL /usr/local/bin/claude-real --settings /home/agent/.afk-profile-settings.json "${args[@]}" ;;' \
     '  *) echo "unsupported AFK_PROFILE" >&2; exit 2 ;;' \
     'esac' > /usr/local/bin/claude \
   && chmod 755 /usr/local/bin/claude \

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { run, claudeCode } from "@ai-hero/sandcastle";
-import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { run } from "@ai-hero/sandcastle";
+import { claudeProfile } from "./profile.js";
 
 const profileIndex = process.argv.indexOf("--profile");
 const profile = profileIndex >= 0 ? process.argv[profileIndex + 1] : process.env.AFK_PROFILE;
@@ -14,13 +14,6 @@ if (!issue || !/^\d+$/.test(issue)) {
 
 const root = resolve(import.meta.dirname, "..");
 const branch = process.env.AFK_BRANCH ?? `agent/issue-${issue}`;
-const profiles = {
-  claude: undefined,
-  "claude-ark": process.env.AFK_CLAUDE_ARK_SETTINGS ?? "/home/claude/cliproxyapi/settings.ark.json",
-} as const;
-if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude or claude-ark.");
-const settingsPath = profile ? profiles[profile as keyof typeof profiles] : undefined;
-if (settingsPath && !existsSync(settingsPath)) throw new Error(`Profile settings not found: ${settingsPath}`);
 const envFile = resolve(root, ".sandcastle/.env");
 if (!existsSync(envFile) && !profile) {
   throw new Error("Missing .sandcastle/.env; select an existing profile or configure an explicit credential.");
@@ -29,14 +22,7 @@ if (!existsSync(envFile) && !profile) {
 const result = await run({
   cwd: root,
   name: `auto-test-issue-${issue}`,
-  agent: claudeCode(process.env.AFK_MODEL ?? "claude-sonnet-4-6", {
-    env: profile ? { AFK_PROFILE: profile } : undefined,
-  }),
-  sandbox: docker({
-    imageName: process.env.AFK_IMAGE ?? "auto-test-sandcastle:local",
-    network: profile === "claude-ark" ? "host" : undefined,
-    mounts: settingsPath ? [{ hostPath: settingsPath, sandboxPath: "/run/afk/profile-settings.json", readonly: true }] : undefined,
-  }),
+  ...claudeProfile(profile),
   branchStrategy: { type: "branch", branch },
   promptFile: ".sandcastle/implement.md",
   promptArgs: { ISSUE_NUMBER: issue, ISSUE_TITLE: process.env.AFK_TITLE ?? "specified issue" },

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import { claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+const profiles = {
+  claude: undefined,
+  "claude-ark": process.env.AFK_CLAUDE_ARK_SETTINGS ?? "/home/claude/cliproxyapi/settings.ark.json",
+} as const;
+
+export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<string, string>) {
+  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude or claude-ark.");
+  const settingsPath = profile ? profiles[profile as keyof typeof profiles] : undefined;
+  if (settingsPath && !existsSync(settingsPath)) throw new Error(`Profile settings not found: ${settingsPath}`);
+
+  return {
+    agent: claudeCode(process.env.AFK_MODEL ?? "claude-sonnet-4-6", {
+      env: profile ? { AFK_PROFILE: profile } : undefined,
+    }),
+    sandbox: docker({
+      imageName: process.env.AFK_IMAGE ?? "auto-test-sandcastle:local",
+      env,
+      network: profile === "claude-ark" ? "host" : undefined,
+      mounts: settingsPath
+        ? [{ hostPath: settingsPath, sandboxPath: "/home/agent/.afk-profile-settings.json", readonly: true }]
+        : undefined,
+    }),
+  };
+}

--- a/.sandcastle/retry-feedback.ts
+++ b/.sandcastle/retry-feedback.ts
@@ -1,0 +1,82 @@
+import { StructuredOutputError } from "@ai-hero/sandcastle";
+
+/**
+ * Build the feedback block appended to (or sent as) the extraction prompt on a
+ * retry. It shows the agent exactly what it emitted last time and why it failed
+ * validation — the highest-leverage signal for getting valid output next time.
+ *
+ * The returned text always contains the literal opening tag (`<tag>`), which
+ * satisfies Sandcastle's "resolved prompt must contain the opening tag literal"
+ * constraint when this block is used as a standalone retry prompt.
+ *
+ * Shared by both two-phase wrappers: `runWithExtraction` (resumes the produce
+ * session) and `runWithRetry` (resumes the failed call's own session).
+ */
+export function buildRetryFeedback(
+  error: StructuredOutputError,
+  attempt: number,
+  maxAttempts: number
+): string {
+  const header = `## Previous attempt failed (now on attempt ${attempt} of ${maxAttempts})`;
+
+  if (error.rawMatched === undefined) {
+    return [
+      header,
+      "",
+      `Your previous response did not contain a \`<${error.tag}>\` block at all.`,
+      `Emit exactly one \`<${error.tag}>\` block as described above. Do not change any code.`,
+    ].join("\n");
+  }
+
+  return [
+    header,
+    "",
+    "This is what you emitted last time:",
+    "```",
+    error.rawMatched,
+    "```",
+    "",
+    "It failed validation for this reason:",
+    "```",
+    describeCause(error.cause),
+    "```",
+    "",
+    `Fix the problem and re-emit a single corrected \`<${error.tag}>\` block. Do not change any code — only the output.`,
+  ].join("\n");
+}
+
+/** Render a StructuredOutputError `cause` (JSON parse error or schema issues) as readable text. */
+function describeCause(cause: unknown): string {
+  const issues = extractIssues(cause);
+  if (issues) {
+    return issues
+      .map((issue) => {
+        const path = issue.path
+          ?.map((p) => (typeof p === "object" && p !== null ? p.key : p))
+          .join(".");
+        return path ? `- ${path}: ${issue.message}` : `- ${issue.message}`;
+      })
+      .join("\n");
+  }
+  if (cause instanceof Error) return cause.message;
+  return String(cause);
+}
+
+interface SchemaIssue {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey | { key: PropertyKey }>;
+}
+
+/** Pull Standard Schema issues out of a cause, whether it's an array or `{ issues }`. */
+function extractIssues(cause: unknown): readonly SchemaIssue[] | undefined {
+  if (Array.isArray(cause)) return cause as SchemaIssue[];
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "issues" in cause &&
+    Array.isArray((cause as { issues: unknown }).issues)
+  ) {
+    return (cause as { issues: SchemaIssue[] }).issues;
+  }
+  return undefined;
+}

--- a/.sandcastle/run-with-retry.ts
+++ b/.sandcastle/run-with-retry.ts
@@ -1,0 +1,95 @@
+import {
+  run,
+  StructuredOutputError,
+  type OutputObjectDefinition,
+  type RunOptions,
+  type RunResult,
+} from "@ai-hero/sandcastle";
+import { buildRetryFeedback } from "./retry-feedback.js";
+
+/**
+ * Options for {@link runWithRetry} — the standard `run()` options with `output`
+ * required and a `maxAttempts` cap added.
+ */
+export interface RunWithRetryOptions<T> extends Omit<RunOptions, "output"> {
+  /** Structured output to extract. Applied to the first call and every retry. */
+  readonly output: OutputObjectDefinition<T>;
+  /**
+   * Total number of attempts (the first call plus retries) before giving up.
+   * Default: 3 — one initial call and up to two resumed retries.
+   */
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Run an agent in a single call that both does the work and emits structured
+ * output, retrying the *same session* if extraction fails.
+ *
+ * Use this for **side-effect-free** scripts where the structured output IS the
+ * work (e.g. drafting a PR title/description, breaking a PRD into slices). For
+ * these, splitting into a separate produce + extract pass (see
+ * {@link import("./run-with-extraction").runWithExtraction}) buys nothing — the
+ * drafting and the emission are the same act — so we keep one combined prompt:
+ *
+ * 1. Run `prompt`/`promptFile` WITH the `output` definition. On the happy path
+ *    this is a single call.
+ * 2. If `run()` throws {@link StructuredOutputError}, resume that same session
+ *    (via `error.sessionId`) with a feedback message describing exactly what it
+ *    emitted and why it failed. The session still holds all the agent's work, so
+ *    it only needs to re-emit corrected output — nothing is re-done. Retry up to
+ *    `maxAttempts` times total.
+ *
+ * Resuming the failed session (rather than re-running from scratch) is only
+ * possible because `StructuredOutputError` carries `sessionId` — see the host's
+ * Sandcastle dependency (>= 0.5.12).
+ *
+ * Throws the final {@link StructuredOutputError} if every attempt fails, which
+ * mirrors the pre-wrapper failure path.
+ */
+export async function runWithRetry<T>(
+  options: RunWithRetryOptions<T>
+): Promise<RunResult & { output: T }> {
+  const { output, maxAttempts = 3, ...runOptions } = options;
+
+  let lastError: StructuredOutputError | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      if (!lastError) {
+        // First attempt: the original prompt does the work AND emits output.
+        return await run({ ...runOptions, output });
+      }
+
+      // Retry: resume the failed session and feed back what went wrong. The
+      // session still holds everything the agent did, so it only re-emits.
+      const sessionId = lastError.sessionId;
+      if (!sessionId) {
+        throw new Error(
+          "runWithRetry: the failed run carried no sessionId, so it cannot be " +
+            "resumed for a retry. Session capture must be enabled (Claude Code " +
+            "provider with sessions written to the host)."
+        );
+      }
+
+      // The retry uses an inline `prompt` (the feedback message), so drop
+      // `promptArgs` — Sandcastle only allows promptArgs alongside a promptFile,
+      // and the feedback prompt needs no substitution.
+      const { promptArgs: _retryArgs, promptFile: _promptFile, name: _name, ...retryOptions } = runOptions;
+      return await run({
+        ...retryOptions,
+        ...(runOptions.name ? { name: `${runOptions.name} (retry ${attempt - 1})` } : {}),
+        prompt: buildRetryFeedback(lastError, attempt, maxAttempts),
+        resumeSession: sessionId,
+        output,
+      });
+    } catch (error) {
+      if (error instanceof StructuredOutputError) {
+        lastError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw lastError;
+}

--- a/.sandcastle/to-issues-prd/prompt.md
+++ b/.sandcastle/to-issues-prd/prompt.md
@@ -1,0 +1,77 @@
+# TASK
+
+You are breaking a PRD into a flat list of native GitHub sub-issues. You do
+**not** create the issues yourself. You emit a structured plan; the wrapping
+script creates and attaches the sub-issues deterministically.
+
+- **PRD:** #{{PRD_NUMBER}} — {{PRD_TITLE}}
+
+# CONTEXT
+
+1. Fetch the PRD:
+
+   ```
+   gh issue view {{PRD_NUMBER}} --comments
+   ```
+
+   If the PRD is ambiguous, make the most reasonable interpretation and proceed; do not stop to ask.
+
+2. Read the relevant files under `docs/` and skim `docs/adr/` when present for decisions that bear on the area the PRD touches. Sub-issue titles and bodies must use the project's vocabulary.
+
+3. Explore the codebase to ground the breakdown in the real shape of the files you'll be cutting through.
+
+   During exploration, look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+# DRAFTING SUB-ISSUES
+
+Break the PRD into **tracer-bullet** vertical slices. Each slice is a thin vertical cut through every layer (schema → API → UI → tests), NOT a horizontal slice of one layer.
+
+Rules:
+
+- Each slice delivers a narrow but COMPLETE path through every layer.
+- A completed slice is demoable or verifiable on its own.
+- Sub-issues are **flat** — a sub-issue must not itself need sub-issues. If a slice is too big to leaf, split it into multiple peer slices.
+- Prefactoring should be done before feature work.
+- Sub-issues run in **list order** under the PRD. Order them so dependencies are satisfied: if slice B builds on slice A's schema, A must come first.
+- Each slice must stand on its own in a single agent session. A reasonable session can build a couple of files, write tests, and run typecheck/test. Don't draft slices that are unrealistic for one session.
+
+Draft the ordered list of slices, each with a title, what to build, and
+acceptance criteria.
+
+# OUTPUT
+
+Emit the breakdown you just drafted as a single `<output>` block — the last thing in your response. The script parses it with a strict schema.
+
+<output>
+{
+  "slices": [
+    {
+      "title": "short imperative title",
+      "whatToBuild": "One to three short paragraphs describing this slice's end-to-end behavior, framed around what it delivers. No file paths. Plain text — embed newlines literally as \\n in the JSON.",
+      "acceptanceCriteria": [
+        "Concrete, checkable outcome 1",
+        "Concrete, checkable outcome 2",
+        "Tests cover the new behavior"
+      ]
+    }
+  ]
+}
+</output>
+
+Field rules:
+
+- `slices` — ordered array. List order is execution order; the script
+  attaches them in this order under the PRD. A later slice may build on
+  any earlier slice's work; the ordering is the only signal of phase.
+- `title` — short, imperative. No leading `feat:` / `fix:` prefix.
+- `whatToBuild` — prose, not a list. Avoid specific file paths or code
+  snippets. Exception: a prototype-derived snippet (state machine,
+  reducer, schema, type shape) may be inlined when prose can't encode the
+  decision as precisely.
+- `acceptanceCriteria` — array of strings. The script renders them as a
+  GitHub checklist (`- [ ] ...`). Always include one item that asserts
+  tests cover the new behavior.
+
+Do NOT include a `Closes` directive anywhere in the body — the script
+omits one by design. Closing sub-issues is the implement-prd workflow's
+job; closing the PRD is the merged PR's job.

--- a/.sandcastle/to-issues-prd/to-issues-prd.ts
+++ b/.sandcastle/to-issues-prd/to-issues-prd.ts
@@ -1,0 +1,133 @@
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { runWithRetry } from "../run-with-retry";
+import { claudeProfile } from "../profile.js";
+
+const PRD_NUMBER = required("PRD_NUMBER");
+const PRD_TITLE = required("PRD_TITLE");
+const GH_REPO = required("GH_REPO");
+const GH_TOKEN = process.env.GH_TOKEN ?? execFileSync("gh", ["auth", "token"], { encoding: "utf8" }).trim();
+
+const Slice = z.object({
+  title: z.string().min(1).max(200),
+  whatToBuild: z.string().min(1),
+  acceptanceCriteria: z.array(z.string().min(1)).min(1),
+});
+
+const PromptOutput = z.object({
+  slices: z.array(Slice).min(1),
+});
+
+const result = await runWithRetry({
+  name: `to-issues-prd-#${PRD_NUMBER}`,
+  ...claudeProfile(process.env.AFK_PROFILE, { GH_TOKEN, GH_REPO }),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PRD_NUMBER,
+    PRD_TITLE,
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: PromptOutput,
+  }),
+});
+
+const slices = result.output.slices;
+const createdNumbers: number[] = [];
+
+for (let i = 0; i < slices.length; i++) {
+  const slice = slices[i]!;
+  const position = i + 1;
+
+  const body = renderBody({
+    prdNumber: Number(PRD_NUMBER),
+    whatToBuild: slice.whatToBuild,
+    acceptanceCriteria: slice.acceptanceCriteria,
+  });
+
+  let createOutput: string;
+  try {
+    createOutput = execFileSync(
+      "gh",
+      ["issue", "create", "--title", slice.title, "--body", body],
+      { encoding: "utf8" }
+    ).trim();
+  } catch (err) {
+    console.error(
+      `Failed to create sub-issue at position ${position} ("${slice.title}").`
+    );
+    console.error(
+      `Created so far: ${createdNumbers.map((n) => `#${n}`).join(", ") || "(none)"}`
+    );
+    throw err;
+  }
+
+  const urlMatch = createOutput.match(/\/issues\/(\d+)\s*$/);
+  if (!urlMatch) {
+    console.error(
+      `Could not parse issue number from \`gh issue create\` output: ${createOutput}`
+    );
+    process.exit(1);
+  }
+  const subIssueNumber = Number(urlMatch[1]);
+  createdNumbers.push(subIssueNumber);
+
+  const subIssueId = execFileSync(
+    "gh",
+    ["api", `repos/${GH_REPO}/issues/${subIssueNumber}`, "--jq", ".id"],
+    { encoding: "utf8" }
+  ).trim();
+
+  execFileSync(
+    "gh",
+    [
+      "api",
+      "-X",
+      "POST",
+      `repos/${GH_REPO}/issues/${PRD_NUMBER}/sub_issues`,
+      "-F",
+      `sub_issue_id=${subIssueId}`,
+    ],
+    { encoding: "utf8" }
+  );
+
+  console.log(
+    `  [${position}/${slices.length}] created #${subIssueNumber} — ${slice.title}`
+  );
+}
+
+console.log(
+  `\nAttached ${createdNumbers.length} sub-issue(s) to PRD #${PRD_NUMBER}.`
+);
+
+function renderBody(opts: {
+  prdNumber: number;
+  whatToBuild: string;
+  acceptanceCriteria: string[];
+}): string {
+  const criteria = opts.acceptanceCriteria.map((c) => `- [ ] ${c}`).join("\n");
+  return `## Parent PRD
+
+#${opts.prdNumber}
+
+## What to build
+
+${opts.whatToBuild}
+
+## Acceptance criteria
+
+${criteria}
+`;
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pipeline:workflow": "tsx src/cli/workflow-pipeline.ts",
     "autonomous:workflow": "tsx src/cli/workflow-pipeline.ts --autonomous",
     "afk": "tsx .sandcastle/main.ts",
+    "prd:to-issues": "tsx .sandcastle/to-issues-prd/to-issues-prd.ts",
     "plan:workflow": "tsx src/cli/plan-workflow.ts",
     "plan-recovery:workflow": "tsx src/cli/plan-recovery-workflow.ts",
     "explore:workflow": "tsx src/cli/explore-workflow.ts",

--- a/tests/afk-runner.test.ts
+++ b/tests/afk-runner.test.ts
@@ -11,4 +11,15 @@ describe("AFK runner", () => {
     expect(runner).toContain('branchStrategy: { type: "branch", branch }');
     expect(runner).toContain('maxIterations: Number(process.env.AFK_ITERATIONS ?? 3)');
   });
+
+  it("keeps the copied PRD workflow wired to native sub-issues and server profiles", async () => {
+    const prdSkill = await readFile(".claude/skills/to-prd-project/SKILL.md", "utf8");
+    const issueSkill = await readFile(".claude/skills/to-issues-project/SKILL.md", "utf8");
+    const runner = await readFile(".sandcastle/to-issues-prd/to-issues-prd.ts", "utf8");
+
+    expect(prdSkill).toContain("kilbertert/Auto_Test");
+    expect(issueSkill).toContain("sub_issues");
+    expect(runner).toContain('from "../profile.js"');
+    expect(runner).toContain("/sub_issues");
+  });
 });

--- a/tests/sandcastle-run-with-retry.test.ts
+++ b/tests/sandcastle-run-with-retry.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { run, StructuredOutputError, Output } from "@ai-hero/sandcastle";
+import { z } from "zod";
+import { runWithRetry } from "../.sandcastle/run-with-retry.js";
+
+vi.mock("@ai-hero/sandcastle", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ai-hero/sandcastle")>();
+  return { ...actual, run: vi.fn() };
+});
+
+const mockRun = vi.mocked(run);
+
+const schema = z.object({ value: z.string() });
+const output = Output.object({ tag: "output", schema });
+
+function baseOptions() {
+  return {
+    name: "test-run",
+    agent: {} as never,
+    sandbox: {} as never,
+    promptFile: "/repo/prompt.md",
+    output,
+  };
+}
+
+function successResult(value: string) {
+  return {
+    iterations: [{ sessionId: "sess-1" }],
+    stdout: "stdout",
+    commits: [{ sha: "abc123" }],
+    branch: "feat/x",
+    output: { value },
+  } as never;
+}
+
+function structuredError(
+  rawMatched: string | undefined,
+  opts: { sessionId?: string | undefined; cause?: unknown } = {}
+) {
+  // Use `in` so an explicit `{ sessionId: undefined }` is honoured rather than
+  // falling back to the default (a default would swallow the undefined case).
+  const sessionId = "sessionId" in opts ? opts.sessionId : "sess-1";
+  const cause = opts.cause ?? new Error("Unexpected end of JSON input");
+  return new StructuredOutputError("extraction failed", {
+    tag: "output",
+    rawMatched,
+    cause,
+    commits: [],
+    branch: "feat/x",
+    ...(sessionId ? { sessionId } : {}),
+  });
+}
+
+beforeEach(() => {
+  mockRun.mockReset();
+});
+
+describe("runWithRetry", () => {
+  it("returns on the first call when extraction succeeds", async () => {
+    mockRun.mockResolvedValueOnce(successResult("ok"));
+
+    const result = await runWithRetry(baseOptions());
+
+    expect(result.output).toEqual({ value: "ok" });
+    expect(mockRun).toHaveBeenCalledTimes(1);
+
+    // First call carries output, runs the original prompt, no resume.
+    const firstCall = mockRun.mock.calls[0]![0];
+    expect(firstCall.output).toBe(output);
+    expect(firstCall.promptFile).toBe("/repo/prompt.md");
+    expect(firstCall).not.toHaveProperty("resumeSession");
+  });
+
+  it("resumes the failed session with feedback on StructuredOutputError", async () => {
+    mockRun
+      .mockRejectedValueOnce(
+        structuredError('{"value":}', {
+          cause: new Error("Unexpected token }"),
+        })
+      )
+      .mockResolvedValueOnce(successResult("recovered"));
+
+    const result = await runWithRetry(baseOptions());
+
+    expect(result.output).toEqual({ value: "recovered" });
+    expect(mockRun).toHaveBeenCalledTimes(2);
+
+    const retryCall = mockRun.mock.calls[1]![0];
+    // The retry resumes the *failed call's own* session, via error.sessionId.
+    expect(retryCall.resumeSession).toBe("sess-1");
+    expect(retryCall.output).toBe(output);
+    expect(retryCall.promptFile).toBeUndefined();
+
+    const retryPrompt = retryCall.prompt as string;
+    expect(retryPrompt).toContain("Previous attempt failed");
+    expect(retryPrompt).toContain('{"value":}');
+    expect(retryPrompt).toContain("Unexpected token }");
+  });
+
+  it("keeps promptArgs on the first call but drops it from the inline retry", async () => {
+    mockRun
+      .mockRejectedValueOnce(structuredError('{"value":}'))
+      .mockResolvedValueOnce(successResult("recovered"));
+
+    const promptArgs = { PR_NUMBER: "878" };
+    await runWithRetry({ ...baseOptions(), promptArgs });
+
+    // First call uses promptFile, so promptArgs is valid there.
+    const firstCall = mockRun.mock.calls[0]![0];
+    expect(firstCall.promptArgs).toBe(promptArgs);
+    expect(firstCall.promptFile).toBe("/repo/prompt.md");
+
+    // The retry swaps to an inline feedback prompt; Sandcastle rejects
+    // promptArgs alongside an inline prompt, so it must be dropped.
+    const retryCall = mockRun.mock.calls[1]![0];
+    expect(retryCall.promptFile).toBeUndefined();
+    expect(retryCall).not.toHaveProperty("promptArgs");
+  });
+
+  it("describes a missing tag distinctly from a validation failure", async () => {
+    mockRun
+      .mockRejectedValueOnce(structuredError(undefined))
+      .mockResolvedValueOnce(successResult("ok"));
+
+    await runWithRetry(baseOptions());
+
+    const retryPrompt = mockRun.mock.calls[1]![0].prompt as string;
+    expect(retryPrompt).toContain("did not contain a `<output>` block");
+  });
+
+  it("rethrows the final StructuredOutputError after exhausting attempts", async () => {
+    const finalError = structuredError('{"c":3}');
+    mockRun
+      .mockRejectedValueOnce(structuredError('{"a":1}'))
+      .mockRejectedValueOnce(structuredError('{"b":2}'))
+      .mockRejectedValueOnce(finalError);
+
+    await expect(runWithRetry(baseOptions())).rejects.toBe(finalError);
+    // Default maxAttempts = 3 total calls (initial + 2 retries).
+    expect(mockRun).toHaveBeenCalledTimes(3);
+  });
+
+  it("honours a custom maxAttempts", async () => {
+    mockRun
+      .mockRejectedValueOnce(structuredError('{"a":1}'))
+      .mockRejectedValueOnce(structuredError('{"b":2}'));
+
+    await expect(
+      runWithRetry({ ...baseOptions(), maxAttempts: 2 })
+    ).rejects.toBeInstanceOf(StructuredOutputError);
+    expect(mockRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on a non-StructuredOutputError", async () => {
+    const boom = new Error("network down");
+    mockRun.mockRejectedValueOnce(boom);
+
+    await expect(runWithRetry(baseOptions())).rejects.toBe(boom);
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error when the failed run carried no sessionId", async () => {
+    mockRun.mockRejectedValueOnce(
+      structuredError('{"a":1}', { sessionId: undefined })
+    );
+
+    await expect(runWithRetry(baseOptions())).rejects.toThrow(/no sessionId/);
+    // Initial call only — we can't resume without a sessionId.
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- copy the upstream project-local PRD and native sub-issue skills
- add Sandcastle structured-output retry helper and regression tests
- add PRD-to-sub-issues runner using the server Claude profile bridge
- adapt profile wiring to Auto-Test's Docker image and `npm` toolchain

## Verification
- `npm run typecheck`
- focused Vitest: 10 tests passed
- `git diff --check`

GitHub Actions and PRD implementation workflows are intentionally a follow-up: the upstream hosted-runner OAuth model does not satisfy Auto-Test's requirement to reuse the server's configured `claude`/`claude-ark` profiles.
