### PR TITLE
feat: add profile-backed PRD implementation workflows

### DIFF
--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -1,0 +1,323 @@
+name: Agent Implement PRD
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement-prd:
+    if: github.event.label.name == 'agent:implement'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    concurrency:
+      group: agent-implement-prd-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    env:
+      PRD_NUMBER: ${{ github.event.issue.number }}
+      PRD_TITLE: ${{ github.event.issue.title }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Detect — sub-issues + parent shape
+        id: shape
+        run: |
+          set -euo pipefail
+          sub_issues_json=$(gh api "repos/${GH_REPO}/issues/${PRD_NUMBER}/sub_issues" 2>/dev/null || echo "[]")
+          sub_count=$(echo "$sub_issues_json" | jq 'length')
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          parent_number=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { parent { number } } } }' \
+            -f owner="$owner" -f repo="$repo" -F num="$PRD_NUMBER" \
+            --jq '.data.repository.issue.parent.number // empty' 2>/dev/null || echo "")
+
+          # Reject nested PRDs: a PRD with sub-issues that itself has a parent.
+          nested="false"
+          if [ "$sub_count" != "0" ] && [ -n "$parent_number" ]; then
+            nested="true"
+          fi
+
+          # Reject if any sub-issue has its own sub-issues (v1 is flat-only).
+          has_nested_child="false"
+          if [ "$sub_count" != "0" ]; then
+            for child_num in $(echo "$sub_issues_json" | jq -r '.[].number'); do
+              child_sub_count=$(gh api "repos/${GH_REPO}/issues/${child_num}/sub_issues" --jq 'length' 2>/dev/null || echo "0")
+              if [ "$child_sub_count" != "0" ]; then
+                has_nested_child="true"
+                echo "nested_child_number=$child_num" >> "$GITHUB_OUTPUT"
+                break
+              fi
+            done
+          fi
+
+          # First still-open sub-issue, in the order returned by the sub-issues API.
+          next_open=$(echo "$sub_issues_json" | jq -r '[.[] | select(.state == "open")] | .[0] // empty')
+          next_open_number=""
+          next_open_title=""
+          if [ -n "$next_open" ]; then
+            next_open_number=$(echo "$next_open" | jq -r '.number')
+            next_open_title=$(echo "$next_open" | jq -r '.title')
+          fi
+
+          # Decide proceed and refuse reasons.
+          if [ "$sub_count" = "0" ]; then
+            mode="silent"   # Not a PRD; single-issue workflow handles it.
+          elif [ "$nested" = "true" ]; then
+            mode="refuse-nested-prd"
+          elif [ "$has_nested_child" = "true" ]; then
+            mode="refuse-nested-child"
+          elif [ -z "$next_open_number" ]; then
+            mode="refuse-all-closed"
+          else
+            mode="run"
+          fi
+
+          echo "sub_count=$sub_count" >> "$GITHUB_OUTPUT"
+          echo "parent_number=$parent_number" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "next_open_number=$next_open_number" >> "$GITHUB_OUTPUT"
+          # Title may contain special chars; write via heredoc.
+          {
+            echo "next_open_title<<EOF"
+            echo "$next_open_title"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Refuse — nested PRD
+        if: steps.shape.outputs.mode == 'refuse-nested-prd'
+        env:
+          PARENT_NUMBER: ${{ steps.shape.outputs.parent_number }}
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:implement" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "Refused to run: this issue has sub-issues but is itself a sub-issue of #${PARENT_NUMBER}. Nested PRDs are not supported in v1. Flatten the structure before retrying."
+
+      - name: Refuse — sub-issue has its own sub-issues
+        if: steps.shape.outputs.mode == 'refuse-nested-child'
+        env:
+          NESTED_CHILD: ${{ steps.shape.outputs.nested_child_number }}
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:implement" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "Refused to run: sub-issue #${NESTED_CHILD} itself has sub-issues. Nested sub-issues are not supported in v1 — each sub-issue must be a leaf. Flatten the structure before retrying."
+
+      - name: Refuse — all sub-issues already closed
+        if: steps.shape.outputs.mode == 'refuse-all-closed'
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:implement" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "Refused to run: all sub-issues are already closed; nothing to implement. If you want to do more work on this PRD, reopen or add a sub-issue first."
+
+      - name: Transition labels — PRD into in-progress
+        if: steps.shape.outputs.mode == 'run'
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:implement" || true
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:blocked" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:in-progress" || true
+
+      - name: Compute branch name
+        if: steps.shape.outputs.mode == 'run'
+        id: branch
+        run: |
+          slug=$(echo "$PRD_TITLE" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+            | cut -c1-50)
+          branch="agent/prd-${PRD_NUMBER}-${slug}"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout — resume PRD branch if it exists, else create from main
+        if: steps.shape.outputs.mode == 'run'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # AGENT_PAT lets us push changes to files under .github/workflows/.
+          # Falls back to GITHUB_TOKEN if AGENT_PAT is unset.
+          token: ${{ secrets.AGENT_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Set up git identity and resume/create branch
+        if: steps.shape.outputs.mode == 'run'
+        id: branchstate
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          git config user.name "claude-code[bot]"
+          git config user.email "claude-code[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            echo "is_first=false" >> "$GITHUB_OUTPUT"
+          else
+            git checkout -b "$BRANCH"
+            echo "is_first=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node.js 22
+        if: steps.shape.outputs.mode == 'run'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        if: steps.shape.outputs.mode == 'run'
+        run: npm ci
+
+      - name: Install Claude Code
+        if: steps.shape.outputs.mode == 'run'
+        run: true
+
+      - name: Run implement-prd.ts
+        if: steps.shape.outputs.mode == 'run'
+        id: implement
+        env:
+          AFK_PROFILE: claude-ark
+          BRANCH: ${{ steps.branch.outputs.name }}
+          PRD_NUMBER: ${{ env.PRD_NUMBER }}
+          PRD_TITLE: ${{ env.PRD_TITLE }}
+          SUB_ISSUE_NUMBER: ${{ steps.shape.outputs.next_open_number }}
+          SUB_ISSUE_TITLE: ${{ steps.shape.outputs.next_open_title }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/implement-prd/implement-prd.ts
+
+      - name: Push branch
+        if: steps.shape.outputs.mode == 'run' && success()
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        # NOT force-push: the branch accumulates commits across sub-issue runs.
+        run: git push origin "$BRANCH"
+
+      - name: Close completed sub-issue
+        if: steps.shape.outputs.mode == 'run' && success()
+        env:
+          SUB_ISSUE_NUMBER: ${{ steps.shape.outputs.next_open_number }}
+        run: |
+          commit_sha=$(git rev-parse HEAD)
+          gh issue close "$SUB_ISSUE_NUMBER" --comment "Implemented in ${commit_sha}. Part of #${PRD_NUMBER}."
+
+      - name: Check whether a PR already exists for this branch
+        if: steps.shape.outputs.mode == 'run' && success()
+        id: pr_lookup
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          existing_pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          echo "existing_pr=$existing_pr" >> "$GITHUB_OUTPUT"
+
+      - name: Write PR title and description (only when opening a new PR)
+        if: steps.shape.outputs.mode == 'run' && success() && steps.pr_lookup.outputs.existing_pr == ''
+        env:
+          AFK_PROFILE: claude-ark
+          PRD_NUMBER: ${{ env.PRD_NUMBER }}
+          PRD_TITLE: ${{ env.PRD_TITLE }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/write-prd-pr/write-prd-pr.ts
+
+      - name: Open draft PR if one doesn't exist for this branch
+        if: steps.shape.outputs.mode == 'run' && success()
+        id: open_pr
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+          EXISTING_PR: ${{ steps.pr_lookup.outputs.existing_pr }}
+        run: |
+          set -euo pipefail
+          if [ -n "$EXISTING_PR" ]; then
+            echo "pr_number=$EXISTING_PR" >> "$GITHUB_OUTPUT"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+          else
+            PR_TITLE=$(cat "${RUNNER_TEMP}/pr_title.txt")
+            PR_TITLE="${PR_TITLE:0:256}"
+            pr_url=$(gh pr create \
+              --draft \
+              --base main \
+              --head "$BRANCH" \
+              --title "$PR_TITLE" \
+              --body-file "${RUNNER_TEMP}/pr_description.txt" | tail -n1)
+            pr_number=$(basename "$pr_url")
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-check remaining open sub-issues
+        if: steps.shape.outputs.mode == 'run' && success()
+        id: remaining
+        run: |
+          set -euo pipefail
+          remaining=$(gh api "repos/${GH_REPO}/issues/${PRD_NUMBER}/sub_issues" \
+            --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo "0")
+          echo "count=$remaining" >> "$GITHUB_OUTPUT"
+
+      - name: Chain — re-label PRD to pick up next sub-issue
+        if: steps.shape.outputs.mode == 'run' && success() && steps.remaining.outputs.count != '0'
+        env:
+          AGENT_PAT: ${{ secrets.AGENT_PAT }}
+          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
+        # Need AGENT_PAT to fire the next workflow run — GITHUB_TOKEN-driven
+        # label adds don't trigger downstream workflows. Without AGENT_PAT,
+        # the chain stops here and a human will need to re-add the label.
+        run: |
+          set +e
+          if [ -n "$AGENT_PAT" ]; then
+            GH_TOKEN="$AGENT_PAT" gh issue edit "$PRD_NUMBER" --add-label "agent:implement"
+            status=$?
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            echo "AGENT_PAT label add failed (status $status); falling back to GITHUB_TOKEN."
+          fi
+          GH_TOKEN="$GITHUB_TOKEN_FALLBACK" gh issue edit "$PRD_NUMBER" --add-label "agent:implement"
+
+      - name: Hand off — request review on the PR
+        if: steps.shape.outputs.mode == 'run' && success() && steps.remaining.outputs.count == '0'
+        env:
+          PR_NUMBER: ${{ steps.open_pr.outputs.pr_number }}
+          AGENT_PAT: ${{ secrets.AGENT_PAT }}
+          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          if [ -n "$AGENT_PAT" ]; then
+            GH_TOKEN="$AGENT_PAT" gh pr edit "$PR_NUMBER" --add-label "agent:review"
+            status=$?
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            echo "AGENT_PAT label add failed (status $status); falling back to GITHUB_TOKEN."
+          fi
+          GH_TOKEN="$GITHUB_TOKEN_FALLBACK" gh pr edit "$PR_NUMBER" --add-label "agent:review"
+
+      - name: Mark blocked on failure
+        if: steps.shape.outputs.mode == 'run' && failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SUB_ISSUE_NUMBER: ${{ steps.shape.outputs.next_open_number }}
+        run: |
+          reason="(no reason file written — check workflow logs)"
+          if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
+            reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
+          fi
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "$(cat <<EOF
+          \`agent:implement\` (PRD mode) run failed while implementing sub-issue #${SUB_ISSUE_NUMBER}.
+
+          **Reason:** $reason
+
+          **Workflow run:** $RUN_URL
+
+          Once the cause is resolved, remove \`agent:blocked\` and re-add \`agent:implement\` to retry from this sub-issue.
+          EOF
+          )"
+          if [ -n "${SUB_ISSUE_NUMBER:-}" ]; then
+            gh issue comment "$SUB_ISSUE_NUMBER" --body "Implementation attempt failed. See PRD #${PRD_NUMBER} for status. Workflow run: $RUN_URL" || true
+          fi
+
+      - name: Always remove in-progress from PRD
+        if: always() && steps.shape.outputs.mode == 'run'
+        run: gh issue edit "$PRD_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -1,0 +1,129 @@
+name: Agent To-Issues PRD
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  to-issues-prd:
+    if: github.event.label.name == 'agent:to-issues'
+    runs-on: self-hosted
+    timeout-minutes: 30
+    concurrency:
+      group: agent-to-issues-prd-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+
+    env:
+      PRD_NUMBER: ${{ github.event.issue.number }}
+      PRD_TITLE: ${{ github.event.issue.title }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Detect — existing sub-issues + parent shape
+        id: shape
+        run: |
+          set -euo pipefail
+          sub_count=$(gh api "repos/${GH_REPO}/issues/${PRD_NUMBER}/sub_issues" --jq 'length' 2>/dev/null || echo "0")
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          parent_number=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { parent { number } } } }' \
+            -f owner="$owner" -f repo="$repo" -F num="$PRD_NUMBER" \
+            --jq '.data.repository.issue.parent.number // empty' 2>/dev/null || echo "")
+
+          if [ "$sub_count" != "0" ]; then
+            mode="refuse-has-sub-issues"
+          elif [ -n "$parent_number" ]; then
+            mode="refuse-nested-prd"
+          else
+            mode="run"
+          fi
+
+          echo "sub_count=$sub_count" >> "$GITHUB_OUTPUT"
+          echo "parent_number=$parent_number" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse — PRD already has sub-issues
+        if: steps.shape.outputs.mode == 'refuse-has-sub-issues'
+        env:
+          SUB_COUNT: ${{ steps.shape.outputs.sub_count }}
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:to-issues" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "Refused to run: this PRD already has ${SUB_COUNT} sub-issue(s). \`agent:to-issues\` only runs against a PRD with no sub-issues. Close or detach the existing sub-issues before retrying."
+
+      - name: Refuse — PRD is itself a sub-issue
+        if: steps.shape.outputs.mode == 'refuse-nested-prd'
+        env:
+          PARENT_NUMBER: ${{ steps.shape.outputs.parent_number }}
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:to-issues" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "Refused to run: this issue is itself a sub-issue of #${PARENT_NUMBER}. Nested PRDs are not supported. Flatten the structure before retrying."
+
+      - name: Transition labels — PRD into in-progress
+        if: steps.shape.outputs.mode == 'run'
+        run: |
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:to-issues" || true
+          gh issue edit "$PRD_NUMBER" --remove-label "agent:blocked" || true
+          gh issue edit "$PRD_NUMBER" --add-label "agent:in-progress" || true
+
+      - name: Checkout main
+        if: steps.shape.outputs.mode == 'run'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Setup Node.js 22
+        if: steps.shape.outputs.mode == 'run'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        if: steps.shape.outputs.mode == 'run'
+        run: npm ci
+
+      - name: Install Claude Code
+        if: steps.shape.outputs.mode == 'run'
+        run: true
+
+      - name: Run to-issues-prd.ts
+        if: steps.shape.outputs.mode == 'run'
+        env:
+          AFK_PROFILE: claude-ark
+          PRD_NUMBER: ${{ env.PRD_NUMBER }}
+          PRD_TITLE: ${{ env.PRD_TITLE }}
+          GH_REPO: ${{ env.GH_REPO }}
+        run: npm exec tsx .sandcastle/to-issues-prd/to-issues-prd.ts
+
+      - name: Mark blocked on failure
+        if: steps.shape.outputs.mode == 'run' && failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set +e
+          created=$(gh api "repos/${GH_REPO}/issues/${PRD_NUMBER}/sub_issues" --jq '[.[] | "#\(.number)"] | join(", ")' 2>/dev/null || echo "")
+          if [ -z "$created" ]; then
+            created="(none)"
+          fi
+          gh issue edit "$PRD_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$PRD_NUMBER" --body "$(cat <<EOF
+          \`agent:to-issues\` run failed.
+
+          **Sub-issues created before the failure:** ${created}
+
+          **Workflow run:** ${RUN_URL}
+
+          Clean up any partial sub-issues, then remove \`agent:blocked\` and re-add \`agent:to-issues\` to retry.
+          EOF
+          )"
+
+      - name: Always remove in-progress from PRD
+        if: always() && steps.shape.outputs.mode == 'run'
+        run: gh issue edit "$PRD_NUMBER" --remove-label "agent:in-progress" || true

--- a/.sandcastle/implement-prd/implement-prd.ts
+++ b/.sandcastle/implement-prd/implement-prd.ts
@@ -1,0 +1,40 @@
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import * as path from "node:path";
+
+const PRD_NUMBER = required("PRD_NUMBER");
+const PRD_TITLE = required("PRD_TITLE");
+const SUB_ISSUE_NUMBER = required("SUB_ISSUE_NUMBER");
+const SUB_ISSUE_TITLE = required("SUB_ISSUE_TITLE");
+const BRANCH = required("BRANCH");
+
+const result = await sandcastle.run({
+  name: `implement-prd-#${PRD_NUMBER}-sub-#${SUB_ISSUE_NUMBER}`,
+  ...claudeProfile(),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PRD_NUMBER,
+    PRD_TITLE,
+    SUB_ISSUE_NUMBER,
+    SUB_ISSUE_TITLE,
+    BRANCH,
+  },
+});
+
+// No "did this produce commits?" check: a sub-issue's work may already have
+// been completed by a previous iteration, in which case the agent legitimately
+// produces zero new commits and we still want the workflow to proceed (close
+// the sub-issue, advance to the next one).
+
+console.log(`\nImplementation finished for sub-issue #${SUB_ISSUE_NUMBER}.`);
+console.log(`  commits this run: ${result.commits.length}`);
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/.sandcastle/implement-prd/prompt.md
+++ b/.sandcastle/implement-prd/prompt.md
@@ -1,0 +1,53 @@
+# TASK
+
+You are implementing one sub-issue of a multi-session PRD.
+
+- **PRD:** #{{PRD_NUMBER}} — {{PRD_TITLE}}
+- **This sub-issue:** #{{SUB_ISSUE_NUMBER}} — {{SUB_ISSUE_TITLE}}
+- **Branch:** `{{BRANCH}}`
+
+The branch may already have commits from earlier sub-issues. Do **not** rebase
+or rewrite that history. Add your work on top.
+
+Pull both issues in for context:
+
+- `gh issue view {{PRD_NUMBER}} --comments` — the full PRD. Read this carefully; your implementation of this sub-issue must fit the larger plan.
+- `gh issue view {{SUB_ISSUE_NUMBER}} --comments` — the specific step you are implementing now.
+
+You also have access to the full list of sibling sub-issues:
+
+`gh api repos/$GH_REPO/issues/{{PRD_NUMBER}}/sub_issues`
+
+Use this to understand what work has already shipped on this branch and what
+is still ahead — but **only implement #{{SUB_ISSUE_NUMBER}}** in this session.
+Do not touch work that belongs to a different sub-issue.
+
+# CONTEXT
+
+Read the relevant files under `docs/` and any ADRs under `docs/adr/` before starting.
+Explore the repo and fill your context with the parts relevant to this
+sub-issue — especially test files that touch the area you'll change.
+
+# EXECUTION
+
+Use red-green-refactor where applicable.
+
+1. RED: write one failing test
+2. GREEN: implement to pass it
+3. REPEAT until the sub-issue is done
+4. REFACTOR
+
+Before committing, run `npm run typecheck` and `npm test`.
+
+# COMMIT
+
+Make one or more git commits on `{{BRANCH}}`. Use conventional-commit
+messages (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`). Do NOT use a
+`RALPH:` prefix.
+
+Include `Part of #{{PRD_NUMBER}}` in each commit body so the history is
+linkable from the PRD. Do **not** include `Closes` in commits — closing the
+sub-issue is the workflow's job, and closing the PRD is the merged PR's job.
+
+Do not close the sub-issue yourself. Do not push the branch. The workflow
+handles both.

--- a/.sandcastle/write-prd-pr/prompt.md
+++ b/.sandcastle/write-prd-pr/prompt.md
@@ -1,0 +1,38 @@
+# TASK
+
+Write the title and description for a pull request that delivers PRD #{{PRD_NUMBER}}: {{PRD_TITLE}}.
+
+The PRD ships as a chain of sub-issue runs, all committing to the same
+branch. This PR will be reused across every sub-issue run, so the
+title and description must describe the **whole PRD**, not any
+individual sub-issue. You are NOT implementing anything.
+
+# CONTEXT
+
+Read the PRD and its sub-issues:
+
+```
+gh issue view {{PRD_NUMBER}} --comments
+gh api repos/$GH_REPO/issues/{{PRD_NUMBER}}/sub_issues
+```
+
+Draft the title and description, framed around the whole PRD.
+
+# OUTPUT
+
+Based on the PRD and sub-issues you just read, emit a single `<output>` block as the **last thing** in your response:
+
+<output>
+{
+  "prTitle": "feat: short imperative summary of the PRD as a whole",
+  "prDescription": "## Summary\n\nWhat the PRD delivers, in 1–3 paragraphs framed around the whole effort.\n\n## Sub-issues\n\n- #N — title\n- #M — title\n\nCloses #{{PRD_NUMBER}}"
+}
+</output>
+
+Rules:
+
+- `prTitle` must be a single line, under 70 characters, conventional-commit style (`feat:`, `fix:`, `refactor:`, etc.), framed around the PRD as a whole.
+- `prDescription` must:
+  - describe the PRD's overall intent (restate the goal from the PRD body),
+  - list every sub-issue with its number and title,
+  - end with `Closes #{{PRD_NUMBER}}` so the PR auto-closes the PRD on merge.

--- a/.sandcastle/write-prd-pr/write-prd-pr.ts
+++ b/.sandcastle/write-prd-pr/write-prd-pr.ts
@@ -1,0 +1,48 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import { runWithRetry } from "../run-with-retry.js";
+
+const PRD_NUMBER = required("PRD_NUMBER");
+const PRD_TITLE = required("PRD_TITLE");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const PromptOutput = z.object({
+  prTitle: z.string().min(1).max(256),
+  prDescription: z.string().min(1),
+});
+
+const result = await runWithRetry({
+  name: `write-prd-pr-#${PRD_NUMBER}`,
+  ...claudeProfile(),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PRD_NUMBER,
+    PRD_TITLE,
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: PromptOutput,
+  }),
+});
+
+fs.writeFileSync(path.join(OUTPUT_DIR, "pr_title.txt"), result.output.prTitle);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "pr_description.txt"),
+  result.output.prDescription
+);
+
+console.log(`\nWrote PR metadata to ${OUTPUT_DIR}`);
+console.log(`  title: ${result.output.prTitle}`);
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
- copy the upstream PRD sub-issue implementation and draft PR flow
- add PRD implementation and PRD-to-sub-issues GitHub workflows
- run workflows on the self-hosted server and reuse `AFK_PROFILE=claude-ark`
- use Auto-Test `npm ci`, `npm test`, and existing Docker/profile bridge

## Verification
- `npm run typecheck`
- focused Vitest: 10 tests passed
- `git diff --check`
