### PR TITLE
fix: preserve Git hook environment on self-hosted runner

### DIFF
--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -132,15 +132,19 @@ jobs:
           branch="agent/prd-${PRD_NUMBER}-${slug}"
           echo "name=$branch" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout — resume PRD branch if it exists, else create from main
+      - name: Checkout — clone with runner HOME and managed Git hooks
         if: steps.shape.outputs.mode == 'run'
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-          # AGENT_PAT lets us push changes to files under .github/workflows/.
-          # Falls back to GITHUB_TOKEN if AGENT_PAT is unset.
-          token: ${{ secrets.AGENT_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "git@github.com:${GH_REPO}.git"
+            git fetch --prune origin
+            git checkout -B main origin/main
+          else
+            git clone git@github.com:${GH_REPO}.git .
+            git checkout main
+          fi
 
       - name: Set up git identity and resume/create branch
         if: steps.shape.outputs.mode == 'run'

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -72,12 +72,18 @@ jobs:
           gh issue edit "$PRD_NUMBER" --remove-label "agent:blocked" || true
           gh issue edit "$PRD_NUMBER" --add-label "agent:in-progress" || true
 
-      - name: Checkout main
+      - name: Checkout main with runner HOME and managed Git hooks
         if: steps.shape.outputs.mode == 'run'
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 1
+        run: |
+          set -euo pipefail
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "git@github.com:${GH_REPO}.git"
+            git fetch --depth 1 origin main
+            git checkout -B main FETCH_HEAD
+          else
+            git clone --branch main --depth 1 "git@github.com:${GH_REPO}.git" .
+          fi
 
       - name: Setup Node.js 22
         if: steps.shape.outputs.mode == 'run'


### PR DESCRIPTION
Replace actions/checkout with runner-local SSH fetch so the server Git governance hook can load its managed library from the stable claude HOME. No hooks are disabled and no verification bypass is added.