### PR TITLE
fix: authenticate self-hosted runner checkout with gh

### DIFF
--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -136,13 +136,14 @@ jobs:
         if: steps.shape.outputs.mode == 'run'
         run: |
           set -euo pipefail
+          gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "git@github.com:${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --prune origin
             git checkout -B main origin/main
           else
-            git clone git@github.com:${GH_REPO}.git .
+            git clone "https://github.com/${GH_REPO}.git" .
             git checkout main
           fi
 

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -76,13 +76,14 @@ jobs:
         if: steps.shape.outputs.mode == 'run'
         run: |
           set -euo pipefail
+          gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "git@github.com:${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --depth 1 origin main
             git checkout -B main FETCH_HEAD
           else
-            git clone --branch main --depth 1 "git@github.com:${GH_REPO}.git" .
+            git clone --branch main --depth 1 "https://github.com/${GH_REPO}.git" .
           fi
 
       - name: Setup Node.js 22


### PR DESCRIPTION
Use gh auth setup-git and HTTPS remotes so the self-hosted runner does not require an SSH deploy key. The Git governance hook remains enabled.