### PR TITLE
fix: route AFK implementation through Psydo profile

### DIFF
--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -183,7 +183,7 @@ jobs:
         if: steps.shape.outputs.mode == 'run'
         id: implement
         env:
-          AFK_PROFILE: claude-ark
+          AFK_PROFILE: psydo
           BRANCH: ${{ steps.branch.outputs.name }}
           PRD_NUMBER: ${{ env.PRD_NUMBER }}
           PRD_TITLE: ${{ env.PRD_TITLE }}
@@ -220,7 +220,7 @@ jobs:
       - name: Write PR title and description (only when opening a new PR)
         if: steps.shape.outputs.mode == 'run' && success() && steps.pr_lookup.outputs.existing_pr == ''
         env:
-          AFK_PROFILE: claude-ark
+          AFK_PROFILE: psydo
           PRD_NUMBER: ${{ env.PRD_NUMBER }}
           PRD_TITLE: ${{ env.PRD_TITLE }}
           OUTPUT_DIR: ${{ runner.temp }}

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run to-issues-prd.ts
         if: steps.shape.outputs.mode == 'run'
         env:
-          AFK_PROFILE: claude-ark
+          AFK_PROFILE: psydo
           PRD_NUMBER: ${{ env.PRD_NUMBER }}
           PRD_TITLE: ${{ env.PRD_TITLE }}
           GH_REPO: ${{ env.GH_REPO }}

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -25,7 +25,7 @@ RUN npm install --global @anthropic-ai/claude-code \
     'set -eu' \
     'case "${AFK_PROFILE:-claude}" in' \
     '  claude) exec /usr/local/bin/claude-real "$@" ;;' \
-    '  claude-ark) args=(); while [ "$#" -gt 0 ]; do if [ "$1" = "--model" ]; then shift 2; else args+=("$1"); shift; fi; done; exec env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_REASONING_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL /usr/local/bin/claude-real --settings /home/agent/.afk-profile-settings.json "${args[@]}" ;;' \
+    '  claude-ark|psydo) args=(); while [ "$#" -gt 0 ]; do if [ "$1" = "--model" ]; then shift 2; else args+=("$1"); shift; fi; done; exec env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_REASONING_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT=1 /usr/local/bin/claude-real --settings /home/agent/.afk-profile-settings.json "${args[@]}" ;;' \
     '  *) echo "unsupported AFK_PROFILE" >&2; exit 2 ;;' \
     'esac' > /usr/local/bin/claude \
   && chmod 755 /usr/local/bin/claude \

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -5,10 +5,11 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 const profiles = {
   claude: undefined,
   "claude-ark": process.env.AFK_CLAUDE_ARK_SETTINGS ?? "/home/claude/cliproxyapi/settings.ark.json",
+  psydo: process.env.AFK_PSYDO_SETTINGS ?? "/home/claude/.config/auto-test/settings.psydo.json",
 } as const;
 
 export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<string, string>) {
-  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude or claude-ark.");
+  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude, claude-ark, or psydo.");
   const settingsPath = profile ? profiles[profile as keyof typeof profiles] : undefined;
   if (settingsPath && !existsSync(settingsPath)) throw new Error(`Profile settings not found: ${settingsPath}`);
 
@@ -19,7 +20,7 @@ export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<st
     sandbox: docker({
       imageName: process.env.AFK_IMAGE ?? "auto-test-sandcastle:local",
       env,
-      network: profile === "claude-ark" ? "host" : undefined,
+      network: profile === "claude-ark" || profile === "psydo" ? "host" : undefined,
       mounts: settingsPath
         ? [{ hostPath: settingsPath, sandboxPath: "/home/agent/.afk-profile-settings.json", readonly: true }]
         : undefined,


### PR DESCRIPTION
Use the existing server-side CLIProxyAPI Psydo configuration for AFK Claude runs.

- add psydo profile and host networking
- select gpt-5.6-sol through the private settings bridge
- update PRD workflows

Checks: npm run typecheck; npm test; git diff --check