### PR TITLE
feat: make AFK model profiles switchable

### DIFF
--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -183,7 +183,7 @@ jobs:
         if: steps.shape.outputs.mode == 'run'
         id: implement
         env:
-          AFK_PROFILE: psydo
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
           BRANCH: ${{ steps.branch.outputs.name }}
           PRD_NUMBER: ${{ env.PRD_NUMBER }}
           PRD_TITLE: ${{ env.PRD_TITLE }}
@@ -220,7 +220,7 @@ jobs:
       - name: Write PR title and description (only when opening a new PR)
         if: steps.shape.outputs.mode == 'run' && success() && steps.pr_lookup.outputs.existing_pr == ''
         env:
-          AFK_PROFILE: psydo
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
           PRD_NUMBER: ${{ env.PRD_NUMBER }}
           PRD_TITLE: ${{ env.PRD_TITLE }}
           OUTPUT_DIR: ${{ runner.temp }}

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run to-issues-prd.ts
         if: steps.shape.outputs.mode == 'run'
         env:
-          AFK_PROFILE: psydo
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
           PRD_NUMBER: ${{ env.PRD_NUMBER }}
           PRD_TITLE: ${{ env.PRD_TITLE }}
           GH_REPO: ${{ env.GH_REPO }}

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -9,7 +9,7 @@ const issue = process.argv.slice(2).find((arg, index) =>
   /^\d+$/.test(arg) && (profileIndex < 0 || index + 2 !== profileIndex + 1),
 );
 if (!issue || !/^\d+$/.test(issue)) {
-  throw new Error("Usage: npm run afk -- [--profile claude|claude-ark] <issue-number>");
+  throw new Error("Usage: npm run afk -- [--profile claude|claude-ark|psydo] <issue-number>");
 }
 
 const root = resolve(import.meta.dirname, "..");

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -25,9 +25,11 @@ export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<st
     }),
     sandbox: docker({
       imageName: process.env.AFK_IMAGE ?? "auto-test-sandcastle:local",
-      env,
+      env: {
+        ...env,
+        ...(useCodex ? { OPENAI_API_KEY: readFileSync(psydoKey, "utf8").trim() } : {}),
+      },
       network: profile === "claude-ark" || useCodex ? "host" : undefined,
-      env: useCodex ? { OPENAI_API_KEY: readFileSync(psydoKey, "utf8").trim() } : undefined,
       mounts: useCodex
         ? [{ hostPath: codexSettings, sandboxPath: "/home/agent/.codex/config.toml", readonly: true }]
         : settingsPath

--- a/docs/afk-development.md
+++ b/docs/afk-development.md
@@ -2,11 +2,31 @@
 
 The first development loop is intentionally local and single-issue:
 
+Select the model supply explicitly. The profile is resolved on the server and
+credentials never belong in the repository:
+
 ```bash
-cp .sandcastle/.env.example .sandcastle/.env
-# set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY in .sandcastle/.env
-npm run afk -- <issue-number>
+# GPT via Psydo Responses API
+AFK_PROFILE=psydo pnpm afk -- <issue-number>
+
+# GLM via the configured Ark Claude-compatible endpoint
+AFK_PROFILE=claude-ark pnpm afk -- <issue-number>
+
+# Direct Claude profile from .sandcastle/.env
+AFK_PROFILE=claude pnpm afk -- <issue-number>
 ```
+
+The `psydo` profile uses Sandcastle's Codex provider and `gpt-5.6-sol` by
+default. Override the model only when the selected provider supports it:
+
+```bash
+AFK_PROFILE=psydo AFK_MODEL=gpt-5.6-sol pnpm afk -- <issue-number>
+AFK_PROFILE=claude-ark AFK_MODEL=glm-latest pnpm afk -- <issue-number>
+```
+
+GitHub Actions reads the repository variable `AFK_PROFILE` and defaults to
+`psydo`. Set it to `claude-ark` to move PRD runs to GLM, or back to `psydo` for
+GPT; workflow files do not need editing.
 
 The runner creates an isolated Docker worktree on `agent/issue-<number>` (or
 the `AFK_BRANCH` override), runs at most three iterations, and leaves delivery

--- a/tests/afk-runner.test.ts
+++ b/tests/afk-runner.test.ts
@@ -10,6 +10,7 @@ describe("AFK runner", () => {
     expect(prompt).toContain("Do not merge, push, close issues");
     expect(runner).toContain('branchStrategy: { type: "branch", branch }');
     expect(runner).toContain('maxIterations: Number(process.env.AFK_ITERATIONS ?? 3)');
+    expect(runner).toContain('claude|claude-ark|psydo');
   });
 
   it("keeps the copied PRD workflow wired to native sub-issues and server profiles", async () => {


### PR DESCRIPTION
## Changes
- select GPT/Psydo or GLM/Ark with AFK_PROFILE
- let GitHub Actions read repository variable AFK_PROFILE
- document local and Actions switching
- preserve runtime environment when injecting Psydo credentials

## Profiles
- psydo: Codex Responses, gpt-5.6-sol
- claude-ark: Claude-compatible Ark, glm-latest
- claude: existing .sandcastle/.env profile

## Checks
- npm run typecheck
- focused AFK runner tests
- git diff --check