### PR TITLE
feat: add Alibaba DeepSeek AFK profile

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -9,7 +9,7 @@ const issue = process.argv.slice(2).find((arg, index) =>
   /^\d+$/.test(arg) && (profileIndex < 0 || index + 2 !== profileIndex + 1),
 );
 if (!issue || !/^\d+$/.test(issue)) {
-  throw new Error("Usage: npm run afk -- [--profile claude|claude-ark|psydo] <issue-number>");
+  throw new Error("Usage: npm run afk -- [--profile claude|claude-ark|psydo|aliyun-deepseek] <issue-number>");
 }
 
 const root = resolve(import.meta.dirname, "..");

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -12,7 +12,7 @@ const profiles = {
 const codexSettings = process.env.AFK_CODEX_SETTINGS ?? "/home/claude/.config/auto-test/codex.psydo.toml";
 const psydoKey = process.env.AFK_PSYDO_KEY_FILE ?? "/home/claude/.config/aiops-diagnostics/keys/psydo-primary.key";
 const aliyunSettings = process.env.AFK_ALIYUN_SETTINGS ?? "/home/claude/.config/auto-test/codex.aliyun-deepseek.toml";
-const aliyunCsv = process.env.AFK_ALIYUN_CSV ?? "/home/claude/Projects/Auto-Test/ai ali-apiKey-6789048.csv";
+const aliyunCsv = process.env.AFK_ALIYUN_CSV ?? "/home/claude/.config/auto-test/aliyun-deepseek.csv";
 
 function readAliyunCsv(path: string): { apiKey: string; baseUrl: string } {
   const values = new Map<string, string>();

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { claudeCode, codex } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
@@ -6,20 +7,64 @@ const profiles = {
   claude: undefined,
   "claude-ark": process.env.AFK_CLAUDE_ARK_SETTINGS ?? "/home/claude/cliproxyapi/settings.ark.json",
   psydo: undefined,
+  "aliyun-deepseek": undefined,
 } as const;
 const codexSettings = process.env.AFK_CODEX_SETTINGS ?? "/home/claude/.config/auto-test/codex.psydo.toml";
 const psydoKey = process.env.AFK_PSYDO_KEY_FILE ?? "/home/claude/.config/aiops-diagnostics/keys/psydo-primary.key";
+const aliyunSettings = process.env.AFK_ALIYUN_SETTINGS ?? "/home/claude/.config/auto-test/codex.aliyun-deepseek.toml";
+const aliyunCsv = process.env.AFK_ALIYUN_CSV ?? "/home/claude/Projects/Auto-Test/ai ali-apiKey-6789048.csv";
+
+function readAliyunCsv(path: string): { apiKey: string; baseUrl: string } {
+  const values = new Map<string, string>();
+  for (const line of readFileSync(path, "utf8").replace(/^\uFEFF/, "").split(/\r?\n/)) {
+    const separator = line.indexOf(",");
+    if (separator < 0) continue;
+    values.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+  }
+  const apiKey = values.get("apiKey");
+  const baseUrl = values.get("openAiCompatible");
+  if (!apiKey || !baseUrl) throw new Error("Aliyun CSV must contain apiKey and openAiCompatible");
+  try {
+    if (new URL(baseUrl).protocol !== "https:") throw new Error();
+  } catch {
+    throw new Error("Aliyun openAiCompatible must be an HTTPS URL");
+  }
+  return { apiKey, baseUrl: baseUrl.replace(/\/$/, "") };
+}
+
+function ensureAliyunSettings(baseUrl: string): void {
+  const content = [
+    'model = "deepseek-v4-pro-0813"',
+    'model_provider = "aliyun-deepseek"',
+    'model_reasoning_effort = "high"',
+    'model_context_window = 1000000',
+    "",
+    "[model_providers.aliyun-deepseek]",
+    'name = "Alibaba Cloud DeepSeek V4 Pro"',
+    `base_url = ${JSON.stringify(baseUrl)}`,
+    'wire_api = "responses"',
+    'env_key = "DASHSCOPE_API_KEY"',
+    "requires_openai_auth = false",
+    "",
+  ].join("\n");
+  mkdirSync(dirname(aliyunSettings), { recursive: true, mode: 0o700 });
+  writeFileSync(aliyunSettings, content, { mode: 0o600 });
+}
 
 export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<string, string>) {
-  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude, claude-ark, or psydo.");
+  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude, claude-ark, psydo, or aliyun-deepseek.");
   const settingsPath = profile ? profiles[profile as keyof typeof profiles] : undefined;
   if (settingsPath && !existsSync(settingsPath)) throw new Error(`Profile settings not found: ${settingsPath}`);
-  if (profile === "psydo" && !existsSync(codexSettings)) throw new Error(`Codex settings not found: ${codexSettings}`);
-  const useCodex = profile === "psydo";
+  const usePsydo = profile === "psydo";
+  const useAliyun = profile === "aliyun-deepseek";
+  const useCodex = usePsydo || useAliyun;
+  const aliyun = useAliyun ? readAliyunCsv(aliyunCsv) : undefined;
+  if (usePsydo && !existsSync(codexSettings)) throw new Error(`Codex settings not found: ${codexSettings}`);
+  if (aliyun) ensureAliyunSettings(aliyun.baseUrl);
 
   return {
     agent: useCodex
-      ? codex(process.env.AFK_MODEL ?? "gpt-5.6-sol", { env: { CODEX_HOME: "/home/agent/.codex" } })
+      ? codex(process.env.AFK_MODEL ?? (useAliyun ? "deepseek-v4-pro-0813" : "gpt-5.6-sol"), { env: { CODEX_HOME: "/home/agent/.codex" } })
       : claudeCode(process.env.AFK_MODEL ?? "claude-sonnet-4-6", {
       env: profile ? { AFK_PROFILE: profile } : undefined,
     }),
@@ -27,11 +72,12 @@ export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<st
       imageName: process.env.AFK_IMAGE ?? "auto-test-sandcastle:local",
       env: {
         ...env,
-        ...(useCodex ? { OPENAI_API_KEY: readFileSync(psydoKey, "utf8").trim() } : {}),
+        ...(usePsydo ? { OPENAI_API_KEY: readFileSync(psydoKey, "utf8").trim() } : {}),
+        ...(aliyun ? { DASHSCOPE_API_KEY: aliyun.apiKey } : {}),
       },
       network: profile === "claude-ark" || useCodex ? "host" : undefined,
       mounts: useCodex
-        ? [{ hostPath: codexSettings, sandboxPath: "/home/agent/.codex/config.toml", readonly: true }]
+        ? [{ hostPath: useAliyun ? aliyunSettings : codexSettings, sandboxPath: "/home/agent/.codex/config.toml", readonly: true }]
         : settingsPath
           ? [{ hostPath: settingsPath, sandboxPath: "/home/agent/.afk-profile-settings.json", readonly: true }]
           : undefined,

--- a/docs/afk-development.md
+++ b/docs/afk-development.md
@@ -9,6 +9,9 @@ credentials never belong in the repository:
 # GPT via Psydo Responses API
 AFK_PROFILE=psydo pnpm afk -- <issue-number>
 
+# DeepSeek V4 Pro via Alibaba Cloud Model Studio Responses API
+AFK_PROFILE=aliyun-deepseek pnpm afk -- <issue-number>
+
 # GLM via the configured Ark Claude-compatible endpoint
 AFK_PROFILE=claude-ark pnpm afk -- <issue-number>
 
@@ -22,11 +25,14 @@ default. Override the model only when the selected provider supports it:
 ```bash
 AFK_PROFILE=psydo AFK_MODEL=gpt-5.6-sol pnpm afk -- <issue-number>
 AFK_PROFILE=claude-ark AFK_MODEL=glm-latest pnpm afk -- <issue-number>
+AFK_PROFILE=aliyun-deepseek AFK_MODEL=deepseek-v4-pro-0813 pnpm afk -- <issue-number>
 ```
 
 GitHub Actions reads the repository variable `AFK_PROFILE` and defaults to
-`psydo`. Set it to `claude-ark` to move PRD runs to GLM, or back to `psydo` for
-GPT; workflow files do not need editing.
+`psydo`. Set it to `claude-ark`, `psydo`, or `aliyun-deepseek` to select the
+provider; workflow files do not need editing. The Alibaba credential and
+endpoint are read from the server-local `AFK_ALIYUN_CSV` path and are never
+committed.
 
 The runner creates an isolated Docker worktree on `agent/issue-<number>` (or
 the `AFK_BRANCH` override), runs at most three iterations, and leaves delivery

--- a/tests/afk-runner.test.ts
+++ b/tests/afk-runner.test.ts
@@ -10,7 +10,7 @@ describe("AFK runner", () => {
     expect(prompt).toContain("Do not merge, push, close issues");
     expect(runner).toContain('branchStrategy: { type: "branch", branch }');
     expect(runner).toContain('maxIterations: Number(process.env.AFK_ITERATIONS ?? 3)');
-    expect(runner).toContain('claude|claude-ark|psydo');
+    expect(runner).toContain('claude|claude-ark|psydo|aliyun-deepseek');
   });
 
   it("keeps the copied PRD workflow wired to native sub-issues and server profiles", async () => {


### PR DESCRIPTION
## Changes
- add `AFK_PROFILE=aliyun-deepseek`
- read the server-local Alibaba API key and Responses endpoint from `AFK_ALIYUN_CSV`
- use Sandcastle Codex provider with `deepseek-v4-pro-0813`
- set the documented 1M context window
- document local and GitHub Actions switching

## Security
- CSV remains ignored and is not committed
- generated Codex config contains no API key
- key is injected only into the Docker runtime

## Verification
- npm run typecheck
- npm run build
- focused AFK runner tests
- real Docker canary returned `ALIYUN_DEEPSEEK_CANARY`
- git diff --check