### PR TITLE
refactor: narrow easy entry and summary to AgentHost-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "eval:suite": "tsx src/cli/run-eval-suite.ts",
     "import": "tsx src/cli/import-xlsx.ts",
     "intake:workflow": "tsx src/cli/intake-workflow.ts",
-    "pipeline:workflow": "tsx src/cli/workflow-pipeline.ts",
-    "autonomous:workflow": "tsx src/cli/workflow-pipeline.ts --autonomous",
     "afk": "tsx .sandcastle/main.ts",
     "prd:to-issues": "tsx .sandcastle/to-issues-prd/to-issues-prd.ts",
     "plan:workflow": "tsx src/cli/plan-workflow.ts",

--- a/src/cli/easy.ts
+++ b/src/cli/easy.ts
@@ -44,7 +44,6 @@ interface EasyRunOptions {
   model?: string
   headed?: boolean
   slowMo?: number
-  legacyRuntime?: boolean
   resume?: boolean
   testDataAccess?: 'direct' | 'opaque'
   modelProfileId?: string
@@ -156,10 +155,6 @@ async function registerInteractive(
   return result.profile.id
 }
 
-function npmExecutable(): string {
-  return process.platform === 'win32' ? 'npm.cmd' : 'npm'
-}
-
 async function windowsExcelPicker(): Promise<string | undefined> {
   if (process.platform !== 'win32') return undefined
   const script = [
@@ -202,9 +197,6 @@ async function printSummary(statePath: string): Promise<void> {
 }
 
 export async function runEasyWorkflow(options: EasyRunOptions): Promise<number> {
-  if (options.legacyRuntime && options.caseLimit !== undefined) {
-    throw new Error('--one/--case-limit 只适用于 AgentHost 入口；旧 IR/Runtime 不提供等价的 Manifest 限制')
-  }
   const filePath = resolve(stripDraggedPath(options.filePath))
   if (extname(filePath).toLowerCase() !== '.xlsx') throw new Error('请选择 .xlsx 测试用例文件')
   const configuredHost = process.env.AUTO_TEST_AGENT_HOST
@@ -257,50 +249,33 @@ export async function runEasyWorkflow(options: EasyRunOptions): Promise<number> 
   const outputDirectory = resolve(options.outputDirectory ?? defaultRunDirectory(filePath))
   await mkdir(outputDirectory, { recursive: true, mode: 0o750 })
   console.log(`\n本次结果目录：${outputDirectory}`)
-  let exitCode: number
-  let statePath: string
-  if (options.legacyRuntime) {
-    const args = [
-      'run', 'autonomous:workflow', '--',
-      '--file', filePath,
-      ...agentExecutionUrls.flatMap((url) => ['--url', url]),
-      ...(profileId ? ['--profile', profileId] : []),
-      ...(options.maxIterations ? ['--max-iterations', String(options.maxIterations)] : []),
-      options.headed ? '--headed' : '--headless',
-      ...(options.slowMo !== undefined ? ['--slow-mo', String(options.slowMo)] : []),
-      '--output-dir', outputDirectory,
-    ]
-    exitCode = await spawnInherited(npmExecutable(), args)
-    statePath = resolve(outputDirectory, 'autonomous-job.state.json')
-  } else {
-    exitCode = await runAgentTestCli({
-      filePath,
-      urls: agentExecutionUrls,
-      images: options.images ?? [],
-      ...(options.briefPath ? { briefPath: resolve(options.briefPath) } : {}),
-      ...(profileId ? { profileId } : {}),
-      profileRegistryPath: defaultEnvironmentProfileRegistryPath(),
-      outputDirectory,
-      ...(options.model ? { model: options.model } : {}),
-      headed: options.headed === true,
-      ...(options.slowMo !== undefined ? { slowMo: options.slowMo } : {}),
-      ...(options.maxIterations !== undefined ? { maxIterations: options.maxIterations } : {}),
-      ...(options.caseLimit !== undefined ? { caseLimit: options.caseLimit } : {}),
-      ...(options.resume ? { resume: true } : {}),
-      ...(options.modelProfileId ? { modelProfileId: options.modelProfileId } : {}),
-      ...(effectiveAgentHostId ? { agentHostId: effectiveAgentHostId } : {}),
-      ...(options.agentExecutable ? { agentExecutable: options.agentExecutable } : {}),
-      ...(options.agentSourceHome ? { agentSourceHome: options.agentSourceHome } : {}),
-      modelProfileRegistryPath: defaultModelProfileRegistryPath(),
-      testDataAccess: options.testDataAccess ?? 'direct',
-    })
-    statePath = resolve(outputDirectory, 'codex-agent.state.json')
-  }
+  const exitCode = await runAgentTestCli({
+    filePath,
+    urls: agentExecutionUrls,
+    images: options.images ?? [],
+    ...(options.briefPath ? { briefPath: resolve(options.briefPath) } : {}),
+    ...(profileId ? { profileId } : {}),
+    profileRegistryPath: defaultEnvironmentProfileRegistryPath(),
+    outputDirectory,
+    ...(options.model ? { model: options.model } : {}),
+    headed: options.headed === true,
+    ...(options.slowMo !== undefined ? { slowMo: options.slowMo } : {}),
+    ...(options.maxIterations !== undefined ? { maxIterations: options.maxIterations } : {}),
+    ...(options.caseLimit !== undefined ? { caseLimit: options.caseLimit } : {}),
+    ...(options.resume ? { resume: true } : {}),
+    ...(options.modelProfileId ? { modelProfileId: options.modelProfileId } : {}),
+    ...(effectiveAgentHostId ? { agentHostId: effectiveAgentHostId } : {}),
+    ...(options.agentExecutable ? { agentExecutable: options.agentExecutable } : {}),
+    ...(options.agentSourceHome ? { agentSourceHome: options.agentSourceHome } : {}),
+    modelProfileRegistryPath: defaultModelProfileRegistryPath(),
+    testDataAccess: options.testDataAccess ?? 'direct',
+  })
+  const statePath = resolve(outputDirectory, 'codex-agent.state.json')
   try {
     await printSummary(statePath)
   } catch {
     console.log('\n框架未能生成结果摘要，请查看上方错误信息。')
-    console.log(`运行诊断：${resolve(outputDirectory, options.legacyRuntime ? 'run-events.jsonl' : 'codex-agent.events.jsonl')}`)
+    console.log(`运行诊断：${resolve(outputDirectory, 'codex-agent.events.jsonl')}`)
   }
   return exitCode
 }
@@ -382,7 +357,7 @@ async function latestStatePath(): Promise<string | undefined> {
   try {
     const entries = await readdir(root, { recursive: true, withFileTypes: true })
     const candidates = await Promise.all(entries
-      .filter((entry) => entry.isFile() && ['codex-agent.state.json', 'autonomous-job.state.json'].includes(entry.name))
+      .filter((entry) => entry.isFile() && entry.name === 'codex-agent.state.json')
       .map(async (entry) => {
         const path = resolve(entry.parentPath, entry.name)
         return { path, modified: (await stat(path)).mtimeMs }
@@ -583,13 +558,13 @@ async function main(): Promise<void> {
     return
   }
   if (command === 'run') {
+    if (args.includes('--legacy-runtime')) throw new Error('未知参数：--legacy-runtime')
     const filePath = valueAfter(args, '--file')
     const urls = valuesAfter(args, '--url')
     if (!filePath) throw new Error('run 必须提供 --file')
     if (urls.length === 0) throw new Error('run 必须至少提供一个 --url；Excel 中的链接仅作为测试材料上下文')
     if (args.includes('--headed') && args.includes('--headless')) throw new Error('--headed 与 --headless 不能同时使用')
     if (args.includes('--resume') && !valueAfter(args, '--output-dir')) throw new Error('--resume 必须同时提供原运行的 --output-dir')
-    if (args.includes('--resume') && args.includes('--legacy-runtime')) throw new Error('--resume 仅适用于 AgentHost 测试代理')
     const slowMoValue = valueAfter(args, '--slow-mo')
     const slowMo = slowMoValue === undefined ? undefined : Number(slowMoValue)
     if (slowMo !== undefined && (!Number.isInteger(slowMo) || slowMo < 0)) throw new Error('--slow-mo 必须是非负整数')
@@ -631,7 +606,6 @@ async function main(): Promise<void> {
       ...(agentHome || codexHome || ompHome ? { agentSourceHome: resolve((agentHome ?? codexHome ?? ompHome)!) } : {}),
       headed: args.includes('--headed'),
       ...(slowMo !== undefined ? { slowMo } : {}),
-      legacyRuntime: args.includes('--legacy-runtime'),
       resume: args.includes('--resume'),
       testDataAccess: args.includes('--opaque-test-data') ? 'opaque' : 'direct',
     })
@@ -651,7 +625,7 @@ async function main(): Promise<void> {
     console.log('      Codex 和 OMP 获得相同原始材料、可写 run 工作区、shell、网络、完整 Playwright 与结果合同')
     console.log('      中断恢复：在原命令后加入 --resume，并复用原 --output-dir')
     console.log('      AgentHost 通用模型供应商：默认 deepseek；--model-profile volcengine 或自定义 Profile 可切换；Codex/OMP 各自生成原生隔离配置')
-    console.log('      默认 AgentHost 为 codex；使用 --agent-host omp 切换到 OMP RPC；仅兼容旧链路时使用 --legacy-runtime')
+    console.log('      默认 AgentHost 为 codex；使用 --agent-host omp 切换到 OMP RPC')
     console.log('      npm run easy -- register --profile test --url https://example.test/ [--capture-login]')
     console.log('      npm run easy -- status')
     console.log('      npm run easy -- doctor [--agent-host codex|omp]')

--- a/src/cli/easy.ts
+++ b/src/cli/easy.ts
@@ -354,14 +354,24 @@ async function runInteractive(): Promise<void> {
 
 async function latestStatePath(): Promise<string | undefined> {
   const root = defaultRunRoot()
+  const candidates: { path: string; modified: number }[] = []
   try {
-    const entries = await readdir(root, { recursive: true, withFileTypes: true })
-    const candidates = await Promise.all(entries
-      .filter((entry) => entry.isFile() && entry.name === 'codex-agent.state.json')
-      .map(async (entry) => {
-        const path = resolve(entry.parentPath, entry.name)
-        return { path, modified: (await stat(path)).mtimeMs }
-      }))
+    // Walk one directory at a time: `readdir(recursive + withFileTypes)`
+    // reports unreliable Dirent types on Windows, so `isFile()` there can
+    // miss every candidate. A per-directory walk keeps the same result on
+    // every platform.
+    const pending = [root]
+    while (pending.length > 0) {
+      const directory = pending.pop()!
+      const entries = await readdir(directory, { withFileTypes: true })
+      for (const entry of entries) {
+        if (entry.isDirectory()) pending.push(resolve(directory, entry.name))
+        else if (entry.isFile() && entry.name === 'codex-agent.state.json') {
+          const path = resolve(directory, entry.name)
+          candidates.push({ path, modified: (await stat(path)).mtimeMs })
+        }
+      }
+    }
     return candidates.sort((left, right) => right.modified - left.modified)[0]?.path
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined

--- a/src/usability/result-summary.ts
+++ b/src/usability/result-summary.ts
@@ -10,21 +10,6 @@ import type {
   CodexTestMutationResult,
 } from '../agent/types.js'
 import { redactSensitiveText } from '../input/text.js'
-import type { AutonomousWorkflowJobState, WorkflowHumanInputRequest } from '../workflow/autonomy-types.js'
-
-const questionLabels: Record<string, string> = {
-  'authorization.recovery-cleanup': '需要明确本次测试创建的数据是否允许停止、删除或回滚。',
-  'authorization.environment-access': '测试账号、租户或环境权限当前不可用，需要管理员恢复或换用有权限的账号。',
-  'business-rule.identifier-conflict': '固定编号已存在时的处理规则不明确：复用、报错，还是删除后重建。',
-  'test-data.private-input': '缺少账号、验证码来源或其他私有测试数据。',
-  'test-data.environment-option': '目标环境缺少用例要求的选项或设备类型。',
-}
-
-const questionKindLabels: Record<WorkflowHumanInputRequest['questions'][number]['kind'], string> = {
-  authorization: '需要补充本次测试允许执行的操作范围或环境权限。',
-  business_rule: '需要测试工程师补充当前业务场景的处理规则。',
-  test_data: '需要补充本次测试使用的私有测试数据或环境选项。',
-}
 
 export interface FriendlyRunSummary {
   title: string
@@ -147,7 +132,7 @@ async function readJson<T>(path: string): Promise<T> {
   return JSON.parse((await readFile(path, 'utf8')).replace(/^\uFEFF/, '')) as T
 }
 
-async function diagnosticLine(statePath: string, fileName = 'run-events.jsonl'): Promise<string | undefined> {
+async function diagnosticLine(statePath: string, fileName = 'codex-agent.events.jsonl'): Promise<string | undefined> {
   const path = resolve(dirname(statePath), fileName)
   return access(path).then(() => `运行诊断：${path}`, () => undefined)
 }
@@ -279,47 +264,9 @@ async function codexAgentSummary(statePath: string, state: CodexTestAgentState):
 }
 
 export async function friendlyRunSummary(statePath: string): Promise<FriendlyRunSummary> {
-  const input = await readJson<AutonomousWorkflowJobState | CodexTestAgentState>(statePath)
-  if ('workflowId' in input && !('jobId' in input)) return codexAgentSummary(statePath, input)
-  const state = input
-  const diagnostics = await diagnosticLine(statePath)
-  if (state.outcome === 'passed') {
-    return {
-      title: '测试通过',
-      outcome: 'passed',
-      lines: [
-        `已完成 ${state.executionAttempts} 次正式执行。`,
-        state.runtimeResultPath ? `详细执行证据：${state.runtimeResultPath}` : '执行证据已保存在本次输出目录。',
-      ],
-    }
+  const state = await readJson<CodexTestAgentState>(statePath)
+  if (state.version !== '2.0' || typeof state.workflowId !== 'string' || typeof state.sourceSha256 !== 'string') {
+    throw new Error('结果摘要只支持当前 AgentHost 状态文件（version 2.0）')
   }
-  if (state.outcome === 'product_failed') {
-    return {
-      title: '发现产品或业务结果不符合预期',
-      outcome: 'product_failed',
-      lines: [
-        state.diagnosis?.reason ?? state.error ?? '页面操作完成，但业务断言没有通过。',
-        state.runtimeResultPath ? `详细执行证据：${state.runtimeResultPath}` : '请查看本次输出目录中的 Runtime 结果。',
-        ...(diagnostics ? [diagnostics] : []),
-      ],
-    }
-  }
-  if (state.outcome === 'blocked' || state.status === 'blocked') {
-    const lines: string[] = []
-    if (state.humanInputRequestPath) {
-      const request = await readJson<WorkflowHumanInputRequest>(state.humanInputRequestPath)
-      for (const question of request.questions) lines.push(questionLabels[question.id] ?? questionKindLabels[question.kind])
-    }
-    if (lines.length === 0) lines.push(state.diagnosis?.reason ?? state.error ?? '框架需要补充信息后才能继续。')
-    if (diagnostics) lines.push(diagnostics)
-    return { title: '测试暂时无法继续', outcome: 'blocked', lines: [...new Set(lines)] }
-  }
-  if (state.status === 'running') {
-    return { title: '测试仍在运行', outcome: 'running', lines: [`当前阶段：${state.stage}，已完成 ${state.round} 轮修订。`] }
-  }
-  return {
-    title: '测试执行异常结束',
-    outcome: 'failed',
-    lines: [state.error ?? '请查看控制台输出和本次运行目录。', ...(diagnostics ? [diagnostics] : [])],
-  }
+  return codexAgentSummary(statePath, state)
 }

--- a/tests/easy-cli-legacy-removal.test.ts
+++ b/tests/easy-cli-legacy-removal.test.ts
@@ -1,0 +1,75 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '..')
+const tsxCli = resolve(root, 'node_modules/tsx/dist/cli.mjs')
+const easyCli = resolve(root, 'src/cli/easy.ts')
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+function runEasy(...args: string[]): SpawnSyncReturns<string> {
+  return runEasyFrom(root, ...args)
+}
+
+function runEasyFrom(cwd: string, ...args: string[]): SpawnSyncReturns<string> {
+  return spawnSync(process.execPath, [tsxCli, easyCli, ...args], { cwd, encoding: 'utf8' })
+}
+
+describe('AgentHost-only easy CLI surface', () => {
+  it('keeps --legacy-runtime out of easy help', () => {
+    const result = runEasy('--help')
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).not.toContain('--legacy-runtime')
+    expect(result.stdout).not.toContain('autonomous:workflow')
+  })
+
+  it('turns the removed --legacy-runtime flag into an unknown argument error', () => {
+    const result = runEasy('run', '--legacy-runtime')
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('未知参数：--legacy-runtime')
+  })
+
+  it('ignores legacy autonomous state files when finding the latest AgentHost state', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-status-'))
+    temporaryDirectories.push(directory)
+    const legacyDirectory = resolve(directory, 'artifacts', 'runs', 'legacy')
+    const agentDirectory = resolve(directory, 'artifacts', 'runs', 'agent')
+    await mkdir(legacyDirectory, { recursive: true })
+    await mkdir(agentDirectory, { recursive: true })
+    const legacyStatePath = resolve(legacyDirectory, 'autonomous-job.state.json')
+    const agentStatePath = resolve(agentDirectory, 'codex-agent.state.json')
+    await writeFile(legacyStatePath, JSON.stringify({
+      version: '1.0', jobId: 'fixture-job', requestSha256: 'a'.repeat(64), status: 'failed', stage: 'failed',
+      outcome: 'failed', round: 0, environmentRetries: 0, executionAttempts: 0, events: [],
+      createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:01:00.000Z',
+    }))
+    await writeFile(agentStatePath, JSON.stringify({
+      version: '2.0', status: 'running', stage: 'executing', workflowId: 'catalog', sourceSha256: 'b'.repeat(64),
+      startedAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:01:00.000Z', threadGeneration: 0, completedCaseIds: [],
+    }))
+    const future = new Date(Date.now() + 60_000)
+    await utimes(legacyStatePath, future, future)
+
+    const result = runEasyFrom(directory, 'status')
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout).toContain('测试仍在运行')
+  })
+
+  it('removes old workflow pipeline scripts from the package manifest', async () => {
+    const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { scripts: Record<string, string> }
+
+    expect(manifest.scripts['pipeline:workflow']).toBeUndefined()
+    expect(manifest.scripts['autonomous:workflow']).toBeUndefined()
+    expect(manifest.scripts['easy']).toBe('tsx src/cli/easy.ts')
+    expect(manifest.scripts['agent:test']).toBe('tsx src/cli/agent-test.ts')
+  })
+})

--- a/tests/easy-cli-legacy-removal.test.ts
+++ b/tests/easy-cli-legacy-removal.test.ts
@@ -21,6 +21,10 @@ function runEasyFrom(cwd: string, ...args: string[]): SpawnSyncReturns<string> {
   return spawnSync(process.execPath, [tsxCli, easyCli, ...args], { cwd, encoding: 'utf8' })
 }
 
+function runEasyStatusFrom(cwd: string, env?: NodeJS.ProcessEnv): SpawnSyncReturns<string> {
+  return spawnSync(process.execPath, [tsxCli, easyCli, 'status'], { cwd, ...(env ? { env } : {}), encoding: 'utf8' })
+}
+
 describe('AgentHost-only easy CLI surface', () => {
   it('keeps --legacy-runtime out of easy help', () => {
     const result = runEasy('--help')
@@ -40,8 +44,15 @@ describe('AgentHost-only easy CLI surface', () => {
   it('ignores legacy autonomous state files when finding the latest AgentHost state', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-status-'))
     temporaryDirectories.push(directory)
-    const legacyDirectory = resolve(directory, 'artifacts', 'runs', 'legacy')
-    const agentDirectory = resolve(directory, 'artifacts', 'runs', 'agent')
+    // The CLI's run root is cwd-relative on POSIX but %LOCALAPPDATA%\auto-test\runs
+    // on Windows; scope it to this temp dir so the fixture layout matches where
+    // `easy status` actually searches on both platforms.
+    const scopedLocalAppData = resolve(directory, '.localdata')
+    const runRoot = process.platform === 'win32'
+      ? resolve(scopedLocalAppData, 'auto-test', 'runs')
+      : resolve(directory, 'artifacts', 'runs')
+    const legacyDirectory = resolve(runRoot, 'legacy')
+    const agentDirectory = resolve(runRoot, 'agent')
     await mkdir(legacyDirectory, { recursive: true })
     await mkdir(agentDirectory, { recursive: true })
     const legacyStatePath = resolve(legacyDirectory, 'autonomous-job.state.json')
@@ -58,7 +69,8 @@ describe('AgentHost-only easy CLI surface', () => {
     const future = new Date(Date.now() + 60_000)
     await utimes(legacyStatePath, future, future)
 
-    const result = runEasyFrom(directory, 'status')
+    const env = process.platform === 'win32' ? { ...process.env, LOCALAPPDATA: scopedLocalAppData } : undefined
+    const result = runEasyStatusFrom(directory, env)
 
     expect(result.status, result.stderr).toBe(0)
     expect(result.stdout).toContain('测试仍在运行')

--- a/tests/easy-result-summary.test.ts
+++ b/tests/easy-result-summary.test.ts
@@ -4,66 +4,61 @@ import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { friendlyRunSummary } from '../src/usability/result-summary.js'
 import type { CodexTestAgentResult, CodexTestAgentState } from '../src/agent/types.js'
-import type { AutonomousWorkflowJobState, WorkflowHumanInputRequest } from '../src/workflow/autonomy-types.js'
 
-function state(overrides: Partial<AutonomousWorkflowJobState>): AutonomousWorkflowJobState {
-  return {
-    version: '1.0',
-    jobId: 'fixture-job',
-    requestSha256: 'a'.repeat(64),
-    status: 'completed',
-    stage: 'completed',
-    round: 2,
-    environmentRetries: 0,
-    executionAttempts: 1,
-    events: [],
-    createdAt: '2026-07-31T00:00:00.000Z',
-    updatedAt: '2026-07-31T00:01:00.000Z',
-    ...overrides,
-  }
-}
-
-describe('friendly autonomous result summary', () => {
-  it('summarizes a passed job without exposing internal state fields', async () => {
+describe('friendly AgentHost result summary', () => {
+  it('summarizes a passed AgentHost run from the structured result', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-result-'))
     try {
-      const path = resolve(directory, 'state.json')
-      await writeFile(path, JSON.stringify(state({ outcome: 'passed', runtimeResultPath: resolve(directory, 'runtime.json') })))
+      const resultPath = resolve(directory, 'codex-agent.result.json')
+      const statePath = resolve(directory, 'codex-agent.state.json')
+      const result: CodexTestAgentResult = {
+        version: '1.0', workflowId: 'catalog', sourceSha256: 'b'.repeat(64), outcome: 'passed',
+        summary: 'The catalog behaved as expected.', startedAt: '2026-08-01T00:00:00.000Z', finishedAt: '2026-08-01T00:01:00.000Z',
+        cases: [{
+          caseId: 'filter', title: 'Filter', outcome: 'passed', summary: 'Count matched.',
+          evidence: [{ kind: 'observation', description: 'Two rows remained.' }],
+        }],
+        mutations: [], environmentRequirements: [], blockers: [], productDefects: [], nextActions: [],
+      }
+      const agentState: CodexTestAgentState = {
+        version: '2.0', status: 'completed', stage: 'completed', workflowId: 'catalog', sourceSha256: 'b'.repeat(64),
+        startedAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:01:00.000Z', threadGeneration: 0,
+        completedCaseIds: ['filter'], outcome: 'passed', resultPath,
+      }
+      await writeFile(resultPath, JSON.stringify(result))
+      await writeFile(statePath, JSON.stringify(agentState))
 
-      const result = await friendlyRunSummary(path)
+      const summary = await friendlyRunSummary(statePath)
 
-      expect(result.title).toBe('测试通过')
-      expect(result.lines.join(' ')).toContain('1 次正式执行')
+      expect(summary.outcome).toBe('passed')
+      expect(summary.lines).toContain('完成情况：1/1 个用例已验证通过。')
+      expect(summary.lines).toContain('业务残留：Mutation Ledger 未记录待恢复写入（pending=0）。')
+      expect(summary.lines).toContain(`详细结果和证据索引：${resultPath}`)
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
   })
 
-  it('turns structured human-input questions into concise Chinese actions', async () => {
+  it('rejects legacy autonomous workflow state files', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-blocked-'))
     try {
-      const requestPath = resolve(directory, 'request.json')
       const statePath = resolve(directory, 'state.json')
-      const request: WorkflowHumanInputRequest = {
-        version: '1.0', kind: 'workflow-human-input-request', requestId: 'request', jobId: 'fixture-job',
-        status: 'pending', createdAt: '2026-07-31T00:00:00.000Z', blockedBy: 'missing data',
-        questions: [{
-          id: 'test-data.private-input', kind: 'test_data', prompt: 'internal prompt', reasons: [], sourceRefs: [],
-        }],
-        responseInstructions: [],
-      }
-      await writeFile(requestPath, JSON.stringify(request))
-      await writeFile(resolve(directory, 'run-events.jsonl'), '{}\n')
-      await writeFile(statePath, JSON.stringify(state({
-        status: 'blocked', stage: 'blocked', outcome: 'blocked', humanInputRequestPath: requestPath,
-      })))
+      await writeFile(statePath, JSON.stringify({
+        version: '1.0',
+        jobId: 'fixture-job',
+        requestSha256: 'a'.repeat(64),
+        status: 'blocked',
+        stage: 'blocked',
+        outcome: 'blocked',
+        round: 2,
+        environmentRetries: 0,
+        executionAttempts: 1,
+        events: [],
+        createdAt: '2026-07-31T00:00:00.000Z',
+        updatedAt: '2026-07-31T00:01:00.000Z',
+      }))
 
-      const result = await friendlyRunSummary(statePath)
-
-      expect(result.title).toBe('测试暂时无法继续')
-      expect(result.lines).toContain('缺少账号、验证码来源或其他私有测试数据。')
-      expect(result.lines.some((line) => line.includes('run-events.jsonl'))).toBe(true)
-      expect(result.lines).not.toContain('internal prompt')
+      await expect(friendlyRunSummary(statePath)).rejects.toThrow(/只支持当前 AgentHost 状态文件/)
     } finally {
       await rm(directory, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

Closes #93. Removes the legacy autonomous-pipeline runtime from `easy`/`agent:test`:

- `src/cli/easy.ts`: drop `--legacy-runtime` flag, its parsing/mutual-exclusion validation, the legacy spawn branch, and old state-file lookup
- `src/usability/result-summary.ts`: drop the legacy summary branch; `friendlyRunSummary` now requires the current AgentHost `CodexTestAgentState` (`version: '2.0'`)
- `package.json`: remove `pipeline:workflow` / `autonomous:workflow` scripts (no broken references)
- Tests: legacy-branch removal + legacy-state rejection coverage

## Verification

- `npm run typecheck`, `npm run build`, `git diff --check` pass
- Focused tests pass; full suite (65 files / 518 tests) green on host **and** in the Sandcastle container