### PR TITLE
chore(build): allow esbuild build script for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
pnpm 11 (`strictDepBuilds`) fails `pnpm install` on unreviewed build scripts; the AFK runner auto-runs it, so `pnpm afk` died on `esbuild@0.28.2`. Adds `pnpm-workspace.yaml` with `allowBuilds: { esbuild: true }` (also absorbs the previously-untracked local file, correcting `esbuild: false` → `true`).