### PR TITLE
fix(afk): align sandbox image name with sandcastle build default

### DIFF
--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -69,7 +69,11 @@ export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<st
       env: profile ? { AFK_PROFILE: profile } : undefined,
     }),
     sandbox: docker({
-      imageName: process.env.AFK_IMAGE ?? "auto-test-sandcastle:local",
+      // Use the same image name that `npx sandcastle docker build-image`
+      // produces (defaultImageName = sandcastle:<repo>). A hardcoded custom
+      // name here means rebuilds target a different tag and the sandbox keeps
+      // running a stale image — the cause of repeated false BLOCKEDs.
+      imageName: process.env.AFK_IMAGE ?? "sandcastle:auto-test",
       env: {
         ...env,
         ...(usePsydo ? { OPENAI_API_KEY: readFileSync(psydoKey, "utf8").trim() } : {}),


### PR DESCRIPTION
## Problem

The AFK runner pinned a custom image tag `auto-test-sandcastle:local` (`.sandcastle/profile.ts`), but `npx sandcastle docker build-image` always builds `sandcastle:<repo>` (`sandcastle:auto-test`). Rebuilds therefore tagged the wrong image and the sandbox kept running a stale node:22 image with no Playwright deps — the cause of repeated false `<promise>BLOCKED</promise>` on issues #93 and #97 (container cannot run the full suite even though the work is complete and green on the host).

## Change

`imageName` default → `sandcastle:auto-test` (same name `sandcastle docker build-image` produces), so rebuilds and the runner agree. `AFK_IMAGE` env override retained.

Both `sandcastle:auto-test` and the previously-pinned image are now rebuilt from the Dockerfile with node 24 + Playwright chromium; full suite verified green inside the container.

## Verification

- Rebuilt image: node v24.19.0, chromium-1234 + headless shell at `/opt/ms-playwright`, `libnspr4` present
- `npm run check` (51 files / 372 tests) passes inside the rebuilt container
- `git diff --check` clean