### PR TITLE
test(legacy): add removal boundary checks and replay CLI smoke

### DIFF
--- a/tests/legacy-ir-removal.test.ts
+++ b/tests/legacy-ir-removal.test.ts
@@ -1,11 +1,56 @@
-import { access, readFile } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
+import { access, readdir, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const root = resolve(import.meta.dirname, '..')
 
+const removedScriptNames = [
+  'import',
+  'compile',
+  'explore',
+  'validate:locators',
+  'classify',
+  'repair',
+  'report',
+  'fixture',
+  'demo:compile',
+  'demo:test',
+  'demo:report',
+  'plan:workflow',
+  'plan-recovery:workflow',
+  'explore:workflow',
+  'refine:workflow',
+  'approve:workflow',
+  'execute:workflow',
+] as const
+
+const historicalDocuments = new Set([
+  'docs/architecture-journey-ir-runtime-to-codex-native.md',
+  'docs/e2e-charge-acceptance.md',
+  'docs/mvp-spec.md',
+  'docs/repository-audit.md',
+])
+
+const legacyImportPattern = /from\s+['"](?:(?:\.\.?)\/)+(?:compiler\/playwright|exploration\/|repair\/|report\/|runtime\/|importer|ir\/|validation\/)(?:[^'"\n]+)?['"]/
+
 async function expectMissing(relativePath: string): Promise<void> {
   await expect(access(resolve(root, relativePath))).rejects.toThrow()
+}
+
+async function relativeFiles(directory: string, suffix: string): Promise<string[]> {
+  const entries = await readdir(resolve(root, directory), { recursive: true })
+  return entries.filter((entry) => entry.endsWith(suffix)).map((entry) => `${directory}/${entry}`)
+}
+
+function removedScriptCommandPattern(name: string): RegExp {
+  return new RegExp(`npm run ${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![A-Za-z0-9_:-])`, 'g')
+}
+
+function runCliHelp(entry: string): string {
+  const result = spawnSync(process.execPath, ['--import', 'tsx', resolve(root, 'src', 'cli', entry), '--help'], { encoding: 'utf8' })
+  expect(result.status, result.stderr).toBe(0)
+  return result.stdout.toString()
 }
 
 describe('legacy IR to Playwright chain removal', () => {
@@ -15,7 +60,13 @@ describe('legacy IR to Playwright chain removal', () => {
       'src/importer.ts',
       'src/ir/parse.ts',
       'src/exploration/apply-candidate.ts',
+      'src/exploration/cli-session.ts',
+      'src/exploration/locator-parser.ts',
+      'src/exploration/types.ts',
       'src/repair/classifier.ts',
+      'src/repair/orchestrator.ts',
+      'src/repair/planner.ts',
+      'src/repair/types.ts',
       'src/validation/schema.ts',
       'src/validation/locator-validator.ts',
       'src/cli/import-xlsx.ts',
@@ -25,6 +76,13 @@ describe('legacy IR to Playwright chain removal', () => {
       'src/cli/classify-failures.ts',
       'src/cli/repair.ts',
       'src/cli/report.ts',
+      'src/cli/plan-workflow.ts',
+      'src/cli/plan-recovery-workflow.ts',
+      'src/cli/explore-workflow.ts',
+      'src/cli/refine-workflow.ts',
+      'src/cli/approve-workflow.ts',
+      'src/cli/execute-workflow.ts',
+      'src/cli/workflow-pipeline.ts',
       'src/report/playwright-json.ts',
       'src/report/build.ts',
       'src/report/html.ts',
@@ -33,6 +91,9 @@ describe('legacy IR to Playwright chain removal', () => {
       'src/runtime/data.ts',
       'src/runtime/locator.ts',
       'schemas/test-case-ir.schema.json',
+      'schemas/workflow-captcha-response.schema.json',
+      'schemas/workflow-locator-response.schema.json',
+      'schemas/workflow-planner-response.schema.json',
       'examples/login-suite.ir.json',
       'examples/local-login-suite.ir.json',
       'playwright.demo.config.ts',
@@ -44,7 +105,7 @@ describe('legacy IR to Playwright chain removal', () => {
 
   it('removes the legacy npm commands while preserving replay compilation and workflow acceptance reporting', async () => {
     const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { scripts: Record<string, string> }
-    for (const name of ['import', 'compile', 'explore', 'validate:locators', 'classify', 'repair', 'report', 'fixture', 'demo:compile', 'demo:test', 'demo:report']) {
+    for (const name of removedScriptNames) {
       expect(manifest.scripts, name).not.toHaveProperty(name)
     }
     expect(manifest.scripts['compile:replay']).toBeDefined()
@@ -53,8 +114,64 @@ describe('legacy IR to Playwright chain removal', () => {
 
   it('stops re-exporting the removed modules from the public index', async () => {
     const source = await readFile(resolve(root, 'src/index.ts'), 'utf8')
-    for (const specifier of ['./compiler/playwright.js', './exploration/', './repair/', './report/', './runtime/', './validation/schema.js', './validation/locator-validator.js', './importer.js', './agent/competition.js']) {
+    for (const specifier of [
+      './compiler/playwright.js',
+      './exploration/',
+      './repair/',
+      './report/',
+      './runtime/',
+      './validation/schema.js',
+      './validation/locator-validator.js',
+      './importer.js',
+      './workflow/planner.js',
+      './workflow/plan-exploration.js',
+      './workflow/autonomy-state.js',
+      './workflow/autonomy-types.js',
+      './workflow/autonomous-controller.js',
+      './workflow/failure-diagnosis.js',
+      './workflow/policy-gate.js',
+      './workflow/recovery-planner.js',
+      './workflow/playwright-driver.js',
+      './workflow/runtime-engine.js',
+      './workflow/runtime-validation.js',
+      './workflow/structured-model-cli.js',
+      './workflow/table-entities.js',
+      './agent/competition.js',
+    ]) {
       expect(source, specifier).not.toContain(specifier)
+    }
+  })
+
+  it('does not expose removed runtime commands or legacy parameters in CLI help', () => {
+    const helpText = [
+      runCliHelp('agent-test.ts'),
+      runCliHelp('easy.ts'),
+      runCliHelp('compile-mcp-replay.ts'),
+    ].join('\n')
+
+    expect(helpText).not.toContain('--legacy-runtime')
+    for (const name of removedScriptNames) expect(helpText, name).not.toMatch(removedScriptCommandPattern(name))
+  })
+
+  it('keeps current main-chain source imports from reaching the removed report, compiler, or runtime modules', async () => {
+    for (const file of await relativeFiles('src', '.ts')) {
+      const source = await readFile(resolve(root, file), 'utf8')
+      expect(source, file).not.toMatch(legacyImportPattern)
+    }
+  })
+
+  it('keeps product documentation free of removed executable entry points while exempting historical documents', async () => {
+    const files = [
+      'README.md',
+      'templates/README.md',
+      ...(await relativeFiles('docs', '.md')),
+    ]
+
+    for (const file of files) {
+      if (historicalDocuments.has(file)) continue
+      const source = await readFile(resolve(root, file), 'utf8')
+      expect(source, file).not.toContain('--legacy-runtime')
+      for (const name of removedScriptNames) expect(source, file).not.toMatch(removedScriptCommandPattern(name))
     }
   })
 

--- a/tests/mcp-replay-cli.test.ts
+++ b/tests/mcp-replay-cli.test.ts
@@ -1,0 +1,77 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const directories: string[] = []
+const script = resolve('src', 'cli', 'compile-mcp-replay.ts')
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+function runReplayCli(args: string[]): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, ['--import', 'tsx', script, ...args], { encoding: 'utf8' })
+}
+
+function event(id: string, server: string, tool: string, args: object, text = ''): object {
+  return {
+    type: 'item.completed',
+    item: {
+      id,
+      type: 'mcp_tool_call',
+      server,
+      tool,
+      arguments: args,
+      result: { content: [{ type: 'text', text }] },
+      status: 'completed',
+    },
+  }
+}
+
+describe('MCP replay CLI smoke', () => {
+  it('prints read-only help without requiring events or result inputs', () => {
+    const result = runReplayCli(['--help'])
+    const stdout = result.stdout.toString()
+
+    expect(result.status, result.stderr.toString()).toBe(0)
+    expect(stdout).toContain('Usage: npm run compile:replay')
+    expect(stdout).toContain('--events')
+    expect(stdout).toContain('--result')
+  })
+
+  it('compiles synthetic events and result inputs into a spec and config', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-replay-cli-'))
+    directories.push(directory)
+    const eventsPath = resolve(directory, 'codex-agent.events.jsonl')
+    const resultPath = resolve(directory, 'codex-agent.result.json')
+    const outputPath = resolve(directory, 'replay.spec.ts')
+    const configPath = resolve(directory, 'replay.config.ts')
+
+    const events = [
+      event('1', 'auto-test-control', 'case_execution_begin', { caseId: 'case-1' }),
+      event('2', 'playwright', 'browser_navigate', {}, "### Ran Playwright code\n```js\nawait page.goto('https://example.test');\n```"),
+      event('3', 'playwright', 'browser_verify_text_visible', {}, "### Ran Playwright code\n```js\nawait expect(page.getByText('Ready')).toBeVisible();\n```"),
+      event('4', 'auto-test-control', 'case_execution_end', { caseId: 'case-1' }),
+    ]
+    await Promise.all([
+      writeFile(eventsPath, `${events.map((item) => JSON.stringify(item)).join('\n')}\n`),
+      writeFile(resultPath, JSON.stringify({ cases: [{ caseId: 'case-1', outcome: 'passed' }] })),
+    ])
+
+    const result = runReplayCli(['--events', eventsPath, '--result', resultPath, '--output', outputPath])
+
+    expect(result.status, result.stderr.toString()).toBe(0)
+    const stdout = result.stdout.toString()
+    const spec = await readFile(outputPath, 'utf8')
+    const config = await readFile(configPath, 'utf8')
+    expect(spec).toContain("import { test, expect } from '@playwright/test'")
+    expect(spec).toContain('case-1')
+    expect(spec).toContain("page.goto('https://example.test')")
+    expect(config).toContain("import { defineConfig } from '@playwright/test'")
+    expect(config).toContain('replay.spec.ts')
+    expect(config).toContain("workers: 1")
+    expect(stdout).toContain('Compiled 1 passed case(s)')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #98. Adds negative boundary checks for the legacy-removal work and a replay-CLI smoke test:

- `tests/legacy-ir-removal.test.ts`: asserts package manifest scripts contain no legacy entries, CLI help exposes no legacy flags, legacy source entry files are absent, package entry exports nothing old, current main-chain module imports do not reach old report/compiler/runtime, and product docs do not present old commands as runnable (historical migration docs exempt)
- `tests/mcp-replay-cli.test.ts`: read-only `--help` plus synthetic events/result input smoke — generates spec/config without importing the legacy chain

## Verification

- `npm run typecheck`, `npm run build`, `git diff --check` pass
- Full suite: 52 files / 377 tests green (including the new boundary + replay CLI tests)
- Existing replay compiler / replay-assets / result-contract / runner integration tests stay green