### PR TITLE
fix(afk): base task worktree on origin/main instead of HEAD

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { run } from "@ai-hero/sandcastle";
@@ -19,11 +20,17 @@ if (!existsSync(envFile) && !profile) {
   throw new Error("Missing .sandcastle/.env; select an existing profile or configure an explicit credential.");
 }
 
+// Base the task worktree on origin/<default>, not the current checkout HEAD,
+// so an AFK run never inherits an unrelated in-progress branch. This file is
+// the copy-verbatim baseline for bootstrap-afk.sh, so the fix propagates to
+// every bootstrapped project too. Ensure origin/main is current first; the
+// sandcastle library falls back to HEAD if baseBranch is omitted.
+execSync("git fetch --prune origin", { cwd: root, stdio: "inherit" });
 const result = await run({
   cwd: root,
   name: `auto-test-issue-${issue}`,
   ...claudeProfile(profile),
-  branchStrategy: { type: "branch", branch },
+  branchStrategy: { type: "branch", branch, baseBranch: "origin/main" },
   promptFile: ".sandcastle/implement.md",
   promptArgs: { ISSUE_NUMBER: issue, ISSUE_TITLE: process.env.AFK_TITLE ?? "specified issue" },
   copyToWorktree: existsSync(envFile) ? [".sandcastle/.env"] : [],


### PR DESCRIPTION
Fixes the AFK runner basing task worktrees on the wrong ref — applied at the copy-verbatim baseline.

## Problem

`branchStrategy: { type: "branch", branch }` makes `@ai-hero/sandcastle` default the new branch's base to `HEAD`, so a task worktree inherits whatever branch the canonical checkout is on. This file is the **copy-verbatim baseline for `bootstrap-afk.sh`**, so the bug and fix propagate to every bootstrapped project.

## Change

- `.sandcastle/main.ts`: pin `branchStrategy.baseBranch` to `origin/main` and run `git fetch --prune origin` before `run()`. On resume (branch already exists) the library ignores `baseBranch`, so existing work is untouched.

## Verification

- `npx tsx .sandcastle/main.ts` loads and hits the usage guard (no syntax/import errors).
- `git diff --check` clean.
