### PR TITLE
feat(afk): planner orchestration loop (pnpm ralph)

### DIFF
--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -1,0 +1,49 @@
+# TASK
+
+Fix issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}} on branch {{BRANCH}}.
+
+Pull in the issue using `gh issue view`, with comments. If it has a parent
+PRD, pull that in too. Only work on the issue specified.
+
+# CONTEXT
+
+Read the relevant files under `docs/` and any ADRs under `docs/adr/` before
+starting. Explore the repo and fill your context window with the parts
+relevant to this issue — especially test files that touch the area you'll
+change.
+
+# EXPLORATION
+
+Explore the repo and fill your context with relevant information that will
+allow you to complete the task.
+
+# EXECUTION
+
+Use red-green-refactor where applicable:
+
+1. RED: write one failing test
+2. GREEN: implement to pass it
+3. REPEAT until the issue is done
+4. REFACTOR the code
+
+# FEEDBACK LOOPS
+
+Before committing, run `npm run check` (typecheck + tests + build) and
+`git diff --check` to ensure everything passes. Do not weaken or skip checks.
+
+# COMMIT
+
+Make git commits on `{{BRANCH}}` with **Conventional Commit** messages
+(`feat:`, `fix:`, `refactor:`, `test:`, `docs:`). Reference the issue in the
+body. Keep the diff focused.
+
+Do **not** push, merge, or close the issue, and do not modify GitHub state —
+the planner loop handles delivery.
+
+# FINAL RULES
+
+- ONLY WORK ON A SINGLE TASK.
+- Once complete, output `<promise>COMPLETE</promise>`.
+- If a required human decision, credential, or external environment is
+  missing, do not guess; explain the blocker and output
+  `<promise>BLOCKED</promise>`.

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -1,0 +1,49 @@
+# TASK
+
+Merge the following branches into the current branch (main) and deliver them:
+
+{{BRANCHES}}
+
+For each branch:
+
+1. Run `git merge <branch> --no-edit`
+2. If there are merge conflicts, resolve them intelligently by reading both
+   sides and choosing the correct resolution
+3. After resolving conflicts, run `npm run check` to verify everything works
+4. If tests fail, fix the issues before proceeding to the next branch
+
+After all branches are merged, make a single Conventional Commit summarizing
+the merge (e.g. `feat: ...` covering the merged work, or `merge: planner
+iteration`), using `git commit --amend` on the merge commit if the default
+message is not Conventional.
+
+# DELIVERY (push main)
+
+You are authorized to push to `main` from inside this environment:
+
+1. Set the git identity and use the provided GitHub token:
+   ```bash
+   git config user.name "claude-code[bot]"
+   git config user.email "claude-code[bot]@users.noreply.github.com"
+   gh auth setup-git
+   ```
+2. Push the merged `main` to origin:
+   ```bash
+   git push origin main
+   ```
+
+# CLOSE ISSUES
+
+For each branch that was merged, close its issue with a comment. If there are
+parent issues (such as PRDs) whose closing the issue would complete, close
+those too.
+
+Here are all the issues:
+
+{{ISSUES}}
+
+Use `gh issue close <number> --comment "..."` for each.
+
+Once you've merged, verified, pushed, and closed everything you can, output
+`<promise>COMPLETE</promise>`. If a blocker needs a human decision, output
+`<promise>BLOCKED</promise>`.

--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -1,0 +1,41 @@
+# ISSUES
+
+Here are the open issues in the repo that are **ready for an agent** (labelled `ready-for-agent`):
+
+<issues-json>
+
+!`gh issue list --state open --label ready-for-agent --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+</issues-json>
+
+# TASK
+
+Analyze the issues and build a dependency graph. For each issue, determine
+whether it **blocks** or **is blocked by** any other open issue.
+
+An issue B is **blocked by** issue A if:
+
+- B requires code or infrastructure that A introduces
+- B and A modify overlapping files or modules, making concurrent work likely to produce merge conflicts
+- B's requirements depend on a decision or API shape that A will establish
+
+An issue is **unblocked** if it has zero blocking dependencies on the other
+candidate issues.
+
+For each unblocked issue, assign a branch name using the format
+`agent/issue-{number}-{slug}` (slug = short kebab-case of the title).
+
+If an issue appears to be a PRD that has implementation sub-issues linked to
+it, the PRD itself cannot be worked on — only its leaf sub-issues can.
+
+# OUTPUT
+
+Output your plan as a JSON object wrapped in `<plan>` tags:
+
+<plan>
+{"issues": [{"number": 42, "title": "Fix auth bug", "branch": "agent/issue-42-fix-auth-bug"}]}
+</plan>
+
+Include only unblocked issues. If every issue is blocked, include the single
+highest-priority candidate (the one with the fewest or weakest dependencies).
+If there are no issues, output `{"issues": []}`.

--- a/.sandcastle/planner.ts
+++ b/.sandcastle/planner.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env tsx
+// Planner orchestration (port of mattpocock/course-video-manager/.sandcastle/main.ts):
+//
+//   loop (max AFK_RALPH_ITERATIONS):
+//     Plan      — a planner agent lists open `ready-for-agent` issues, builds a
+//                 dependency graph, and emits <plan>{issues[]}</plan>
+//     Execute   — each issue implemented + reviewed in its own docker worktree,
+//                 up to AFK_RALPH_PARALLEL at once
+//     Merge     — a merger agent merges the completed branches into main, runs
+//                 the full check, pushes main, and closes the issues
+//
+// Unlike the single-issue runner (.sandcastle/main.ts), the merge phase is
+// intentionally done inside the container (push main + close issues) — this is
+// an explicit user-authorized override of the "host owns delivery" rule.
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { run, createSandbox, type RunResult } from "@ai-hero/sandcastle";
+import { claudeProfile } from "./profile.js";
+
+const MAX_ITERATIONS = Number(process.env.AFK_RALPH_ITERATIONS ?? 10);
+const MAX_PARALLEL = Number(process.env.AFK_RALPH_PARALLEL ?? 4);
+const INSTALL_CMD = process.env.AFK_INSTALL_CMD ?? "npm ci";
+const PROFILE = process.env.AFK_PROFILE;
+
+// --- testable pure helpers -------------------------------------------------
+
+export function extractGhToken(hostsYaml: string): string | undefined {
+  const m = hostsYaml.match(/oauth_token:\s*([^\s]+)/);
+  return m?.[1];
+}
+
+export function parsePlanOutput(stdout: string): { number: number; title: string; branch: string }[] {
+  const m = stdout.match(/<plan>([\s\S]*?)<\/plan>/);
+  if (!m) throw new Error("Planner did not produce a <plan> tag.\n\n" + stdout);
+  const { issues } = JSON.parse(m[1]!) as {
+    issues: { number: number; title: string; branch: string }[];
+  };
+  return Array.isArray(issues) ? issues : [];
+}
+
+// --- git helpers -----------------------------------------------------------
+
+function currentBranch(): string {
+  return execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim();
+}
+
+function ensureOnMain(): void {
+  if (currentBranch() !== "main") {
+    execSync("git checkout main", { stdio: "inherit" });
+  }
+  execSync("git fetch --prune origin", { stdio: "inherit" });
+  execSync("git merge --ff-only origin/main", { stdio: "inherit" });
+}
+
+function profileConfig() {
+  let token: string | undefined;
+  try {
+    token = extractGhToken(
+      readFileSync(resolve(homedir(), ".config/gh/hosts.yml"), "utf8"),
+    );
+  } catch {
+    /* no gh auth on host — planner/merge will fail with a clear gh error */
+  }
+  return claudeProfile(PROFILE, token ? { GH_TOKEN: token } : undefined);
+}
+
+// --- planner loop ----------------------------------------------------------
+
+async function main(): Promise<void> {
+  execSync("git fetch --prune origin", { stdio: "inherit" });
+
+  for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+    console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
+
+    // Phase 1: Plan
+    const plan = await run({
+      ...profileConfig(),
+      name: "Planner",
+      promptFile: ".sandcastle/plan-prompt.md",
+    });
+    const issues = parsePlanOutput(plan.stdout);
+
+    if (issues.length === 0) {
+      console.log("No issues to work on. Exiting.");
+      break;
+    }
+    console.log(`Planning complete. ${issues.length} issue(s) to work in parallel:`);
+    for (const issue of issues) console.log(`  #${issue.number}: ${issue.title} → ${issue.branch}`);
+
+    // Phase 2: Execute + Review (max MAX_PARALLEL in parallel)
+    let running = 0;
+    const queue: (() => void)[] = [];
+    const acquire = () =>
+      running < MAX_PARALLEL
+        ? (running++, Promise.resolve())
+        : new Promise<void>((resolveQueue) => queue.push(resolveQueue));
+    const release = () => {
+      running--;
+      const next = queue.shift();
+      if (next) {
+        running++;
+        next();
+      }
+    };
+
+    const settled = await Promise.allSettled(
+      issues.map(async (issue) => {
+        await acquire();
+        try {
+          const sandbox = await createSandbox({
+            ...profileConfig(),
+            branch: issue.branch,
+            baseBranch: "origin/main",
+            hooks: {
+              host: {
+                onSandboxReady: [{ command: INSTALL_CMD }],
+              },
+            },
+          });
+          try {
+            const result = await sandbox.run({
+              ...profileConfig(),
+              name: `Implementer #${issue.number}`,
+              promptFile: ".sandcastle/implement-prompt.md",
+              promptArgs: {
+                ISSUE_NUMBER: String(issue.number),
+                ISSUE_TITLE: issue.title,
+                BRANCH: issue.branch,
+              },
+              maxIterations: 3,
+              completionSignal: ["<promise>COMPLETE</promise>", "<promise>BLOCKED</promise>"],
+            });
+
+            if (result.commits.length > 0) {
+              await sandbox.run({
+                ...profileConfig(),
+                name: `Reviewer #${issue.number}`,
+                promptFile: ".sandcastle/review-prompt.md",
+                promptArgs: {
+                  ISSUE_NUMBER: String(issue.number),
+                  ISSUE_TITLE: issue.title,
+                  BRANCH: issue.branch,
+                },
+                completionSignal: ["<promise>COMPLETE</promise>", "<promise>BLOCKED</promise>"],
+              });
+            }
+            return result;
+          } finally {
+            await sandbox.close();
+          }
+        } finally {
+          release();
+        }
+      }),
+    );
+
+    for (const [i, outcome] of settled.entries()) {
+      if (outcome.status === "rejected") {
+        console.error(`  ✗ #${issues[i]!.number} (${issues[i]!.branch}) failed: ${outcome.reason}`);
+      }
+    }
+
+    const completed = settled
+      .map((outcome, i) => ({ outcome, issue: issues[i]! }))
+      .filter(
+        (
+          entry,
+        ): entry is {
+          outcome: PromiseFulfilledResult<RunResult>;
+          issue: { number: number; title: string; branch: string };
+        } => entry.outcome.status === "fulfilled" && entry.outcome.value.commits.length > 0,
+      );
+
+    const completedBranches = completed.map((entry) => entry.issue.branch);
+    console.log(`\nExecution complete. ${completedBranches.length} branch(es) with commits:`);
+    for (const branch of completedBranches) console.log(`  ${branch}`);
+
+    if (completedBranches.length === 0) {
+      console.log("No commits produced. Nothing to merge.");
+      continue;
+    }
+
+    // Phase 3: Merge — on main, in-container (user-authorized: push main + close issues)
+    ensureOnMain();
+    await run({
+      ...profileConfig(),
+      name: "Merger",
+      maxIterations: 10,
+      promptFile: ".sandcastle/merge-prompt.md",
+      promptArgs: {
+        BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),
+        ISSUES: completed.map((entry) => `- #${entry.issue.number}: ${entry.issue.title}`).join("\n"),
+      },
+      completionSignal: ["<promise>COMPLETE</promise>", "<promise>BLOCKED</promise>"],
+    });
+
+    console.log("\nBranches merged.");
+  }
+
+  console.log("\nAll done.");
+}
+
+const isMain = process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { claudeCode, codex } from "@ai-hero/sandcastle";
+import { claudeCode, codex, type AgentProvider, type SandboxProvider } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
 const profiles = {
@@ -51,7 +51,10 @@ function ensureAliyunSettings(baseUrl: string): void {
   writeFileSync(aliyunSettings, content, { mode: 0o600 });
 }
 
-export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<string, string>) {
+export function claudeProfile(
+  profile = process.env.AFK_PROFILE,
+  env?: Record<string, string>,
+): { agent: AgentProvider; sandbox: SandboxProvider } {
   if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude, claude-ark, psydo, or aliyun-deepseek.");
   const settingsPath = profile ? profiles[profile as keyof typeof profiles] : undefined;
   if (settingsPath && !existsSync(settingsPath)) throw new Error(`Profile settings not found: ${settingsPath}`);
@@ -66,7 +69,7 @@ export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<st
     agent: useCodex
       ? codex(process.env.AFK_MODEL ?? (useAliyun ? "deepseek-v4-pro-0813" : "gpt-5.6-sol"), { env: { CODEX_HOME: "/home/agent/.codex" } })
       : claudeCode(process.env.AFK_MODEL ?? "claude-sonnet-4-6", {
-      env: profile ? { AFK_PROFILE: profile } : undefined,
+      ...(profile ? { env: { AFK_PROFILE: profile } } : {}),
     }),
     sandbox: docker({
       // Use the same image name that `npx sandcastle docker build-image`
@@ -79,12 +82,12 @@ export function claudeProfile(profile = process.env.AFK_PROFILE, env?: Record<st
         ...(usePsydo ? { OPENAI_API_KEY: readFileSync(psydoKey, "utf8").trim() } : {}),
         ...(aliyun ? { DASHSCOPE_API_KEY: aliyun.apiKey } : {}),
       },
-      network: profile === "claude-ark" || useCodex ? "host" : undefined,
-      mounts: useCodex
-        ? [{ hostPath: useAliyun ? aliyunSettings : codexSettings, sandboxPath: "/home/agent/.codex/config.toml", readonly: true }]
+      ...(profile === "claude-ark" || useCodex ? { network: "host" as const } : {}),
+      ...(useCodex
+        ? { mounts: [{ hostPath: useAliyun ? aliyunSettings : codexSettings, sandboxPath: "/home/agent/.codex/config.toml", readonly: true }] }
         : settingsPath
-          ? [{ hostPath: settingsPath, sandboxPath: "/home/agent/.afk-profile-settings.json", readonly: true }]
-          : undefined,
+          ? { mounts: [{ hostPath: settingsPath, sandboxPath: "/home/agent/.afk-profile-settings.json", readonly: true }] }
+          : {}),
     }),
   };
 }

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -1,0 +1,80 @@
+# TASK
+
+Review the code changes on branch {{BRANCH}} for issue #{{ISSUE_NUMBER}}:
+{{ISSUE_TITLE}}.
+
+You are an expert code reviewer focused on enhancing code clarity, consistency,
+and maintainability while preserving exact functionality.
+
+# CONTEXT
+
+<issue>
+
+!`gh issue view {{ISSUE_NUMBER}}`
+
+</issue>
+
+<diff-to-main>
+
+!`git diff origin/main...HEAD`
+
+</diff-to-main>
+
+# REVIEW PROCESS
+
+## 1. Read the diff and look for anything dodgy
+
+Read the diff carefully. For anything that looks suspicious — fragile logic,
+unchecked assumptions, tricky conditions, implicit type coercions, missing
+guards — write a test that exercises it. Try to actually break it. If you can
+break it, fix it.
+
+## 2. Stress-test edge cases
+
+Go beyond the happy path. For every changed code path, think about what inputs
+or states could cause problems:
+
+- Empty arrays, empty strings, zero, negative numbers
+- Missing optional fields, null values, undefined properties
+- Rapid repeated calls, race conditions, state that changes mid-operation
+- Off-by-one errors in loops or slice/substring operations
+- Regressions in adjacent functionality
+
+Write tests for anything that isn't already covered.
+
+## 3. Analyze for code quality improvements
+
+Look for opportunities to:
+
+- Reduce unnecessary complexity and nesting
+- Eliminate redundant code and abstractions
+- Improve readability through clear variable and function names
+- Consolidate related logic
+- Avoid nested ternary operators — prefer switch statements or if/else chains
+- Choose clarity over brevity
+
+## 4. Maintain balance
+
+Avoid over-simplification that could reduce code clarity, create overly clever
+solutions, combine too many concerns, or remove helpful abstractions.
+
+## 5. Preserve functionality
+
+Never change what the code does — only how it does it. All original features,
+outputs, and behaviors must remain intact.
+
+# EXECUTION
+
+1. Run `npm run check` first to confirm the current state passes.
+2. Attempt to reproduce the original bug with new test cases — if you can, fix it.
+3. Write edge-case tests that stress the implementation.
+4. Make code quality improvements directly on this branch.
+5. Run `npm run check` again to ensure nothing is broken.
+6. Commit with a Conventional Commit message (`refactor:`, `test:`, `fix:`)
+   describing the refinements.
+
+If the code is already clean, well-tested, and handles edge cases properly, do
+nothing.
+
+Once complete, output `<promise>COMPLETE</promise>`. If a blocker needs a
+human decision, output `<promise>BLOCKED</promise>`.

--- a/docs/afk-development.md
+++ b/docs/afk-development.md
@@ -40,5 +40,34 @@ to the host. The container may edit, test, and commit, but must not push,
 merge, close issues, or mutate GitHub state. Review the resulting branch and
 run the repository checks before opening a pull request.
 
-The current tracer bullet does not yet include grill-me, PRD decomposition,
-GitHub Actions, QA issue automation, or parallel agents.
+## Planner orchestration (`pnpm ralph`)
+
+Beyond the single-issue runner, a planner loop ports the upstream
+`course-video-manager` orchestration: Plan → parallel Implement + Review →
+Merge.
+
+```bash
+# Planner loop over `ready-for-agent` open issues (max 4 in parallel)
+AFK_PROFILE=claude-ark pnpm ralph
+```
+
+Each iteration:
+
+1. **Plan** — a planner agent lists open issues labelled `ready-for-agent`,
+   builds a dependency graph, and emits `<plan>{issues[]}</plan>` for the
+   unblocked ones.
+2. **Execute + Review** — each issue is implemented and reviewed in its own
+   Docker worktree (`agent/issue-<n>-<slug>`), up to `AFK_RALPH_PARALLEL`
+   (default 4) at once. `AFK_INSTALL_CMD` (default `npm ci`) runs on the host
+   worktree before each agent starts.
+3. **Merge** — a merger agent merges the completed branches into `main`, runs
+   `npm run check`, then **pushes `main` and closes the issues from inside the
+   container**. This deliberately overrides the "host owns delivery" rule for
+   the planner loop (container needs a GH token, injected from the server's
+   `~/.config/gh/hosts.yml`).
+
+Tuning: `AFK_RALPH_ITERATIONS` (default 10), `AFK_RALPH_PARALLEL` (default 4).
+
+The single-issue runner and the PRD Actions keep the original "host owns
+delivery" boundary — only the planner loop's merge phase pushes from the
+container.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prd:to-issues": "tsx .sandcastle/to-issues-prd/to-issues-prd.ts",
     "compile:replay": "tsx src/cli/compile-mcp-replay.ts",
     "report:workflow": "tsx src/cli/workflow-acceptance-report.ts",
-    "check": "npm run typecheck && npm test && npm run build"
+    "check": "npm run typecheck && npm test && npm run build",
+    "ralph": "tsx .sandcastle/planner.ts"
   },
   "engines": {
     "node": ">=24"

--- a/tests/planner.test.ts
+++ b/tests/planner.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { extractGhToken, parsePlanOutput } from '../.sandcastle/planner.js'
+
+describe('extractGhToken', () => {
+  it('extracts the oauth_token from a gh hosts.yml', () => {
+    const yaml = [
+      'github.com:',
+      '    oauth_token: gho_abc123',
+      '    git_protocol: ssh',
+      '    users:',
+      '        kilbertert:',
+      '            oauth_token: gho_def456',
+    ].join('\n')
+
+    expect(extractGhToken(yaml)).toBe('gho_abc123')
+  })
+
+  it('returns undefined when there is no token', () => {
+    expect(extractGhToken('github.com:\n    git_protocol: https\n')).toBeUndefined()
+  })
+})
+
+describe('parsePlanOutput', () => {
+  it('parses a valid <plan> block', () => {
+    const stdout = [
+      'Here is my plan:',
+      '<plan>',
+      '{"issues": [{"number": 42, "title": "Fix auth bug", "branch": "agent/issue-42-fix-auth-bug"}]}',
+      '</plan>',
+    ].join('\n')
+
+    expect(parsePlanOutput(stdout)).toEqual([
+      { number: 42, title: 'Fix auth bug', branch: 'agent/issue-42-fix-auth-bug' },
+    ])
+  })
+
+  it('returns an empty list for an empty plan', () => {
+    expect(parsePlanOutput('<plan>{"issues": []}</plan>')).toEqual([])
+  })
+
+  it('throws when the planner did not emit a <plan> tag', () => {
+    expect(() => parsePlanOutput('I could not plan this iteration.')).toThrow(/<plan>/)
+  })
+})


### PR DESCRIPTION
## Summary

Port the planner orchestration from `mattpocock/course-video-manager/.sandcastle` into the AFK workflow: **Plan → parallel Implement+Review → Merge** loop.

- `.sandcastle/planner.ts` — loop (default 10 iterations, 4 parallel) over open `ready-for-agent` issues. Profile-backed agents (`claude-ark`/`psydo`/`aliyun-deepseek`). GH_TOKEN injected from the server's `~/.config/gh/hosts.yml` so the container merge can push + close issues.
- 4 prompts: `plan-prompt.md`, `implement-prompt.md`, `review-prompt.md`, `merge-prompt.md` (node, `npm run check`).
- **Merge phase pushes `main` + closes issues from the container** — a deliberate, user-authorized override of the "host owns delivery" rule for the planner loop only. Single-issue `pnpm afk` and PRD Actions keep the original boundary.
- `profile.ts`: fixed `exactOptionalPropertyTypes` (conditional spread) and added an explicit return type (TS4058 declaration-emit error surfaced when `planner.ts` imported it).
- `tests/planner.test.ts`: `extractGhToken` + `parsePlanOutput` (5 tests).
- `docs/afk-development.md`: planner section.

Run: `AFK_PROFILE=claude-ark pnpm ralph` (tune with `AFK_RALPH_ITERATIONS`/`AFK_RALPH_PARALLEL`/`AFK_INSTALL_CMD`).

## Verification

- `npm run typecheck` clean; full `npm run check` green (52 files / 379 tests).
- `tests/planner.test.ts` passes.
- **Not yet run**: a real end-to-end `pnpm ralph` canary — it pushes to `main` and closes real issues, so it needs a controlled target issue before running against the live queue.