### PR TITLE
feat(easy): add --version flag to the easy CLI (merge agent/issue-120-easy-version-flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ npx playwright install chromium
 npm run easy
 ```
 
+`npm run easy -- --version`（或 `-v`）打印 `package.json` 中的当前包版本并直接退出，不会进入交互菜单或启动 Run。
+
 命令行方式：
 
 ```bash

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -55,6 +55,8 @@ npm run easy -- run \
 
 `--one` 是 `--case-limit 1` 的快捷方式，真正把 Manifest 限制为一条 case，并只保留该 case 引用的材料链接；未执行 case 中的链接不会提前阻断 canary。完整执行省略 `--case-limit` 即可。
 
+`npm run easy -- --version`（或 `-v`）只打印当前 Auto-Test 包版本并退出；它不是 `run` 的子参数，不会创建 Run 或工作区。
+
 底层入口：
 
 ```bash

--- a/docs/windows-package-quick-start.md
+++ b/docs/windows-package-quick-start.md
@@ -93,7 +93,7 @@ $Run = "D:\Auto-Test-results\acceptance-$(Get-Date -Format yyyyMMdd-HHmmss)"
 
 Excel、同名 .auto-test sidecar 和必要 URL 必须一起交付；它们共同决定本轮 manifest。测试结束后，以 codex-agent.result.json、实际证据和 Mutation Ledger 为准。若验收 Codex/OMP 竞争，必须为两个宿主使用不同输出目录，再用 `npm run agent:compare` 只读比较，不能在同一业务实体上盲目重复破坏性操作。
 
-构建脚本还会把不含密钥的 `Auto-Test.build.json` 写入私有 ZIP，运行结果会据此记录包版本和构建 commit；在没有该元数据的源码运行中，框架会尽力从 `package.json` 和 Git 读取版本，读取不到时不会伪造 commit。
+构建脚本还会把不含密钥的 `Auto-Test.build.json` 写入私有 ZIP，运行结果会据此记录包版本和构建 commit；在没有该元数据的源码运行中，框架会尽力从 `package.json` 和 Git 读取版本，读取不到时不会伪造 commit。`npm run easy -- --version`（或 `-v`）按同一优先级解析并打印包版本后直接退出，不会启动 Run。
 
 ## 常见失败
 

--- a/src/agent/build-info.ts
+++ b/src/agent/build-info.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const execFileAsync = promisify(execFile)
+const moduleDirectory = dirname(fileURLToPath(import.meta.url))
 
 export interface AgentBuildInfo {
   packageVersion?: string
@@ -24,13 +25,38 @@ async function readJson(path: string): Promise<Record<string, unknown> | undefin
   }
 }
 
-export async function readAgentBuildInfo(): Promise<AgentBuildInfo> {
-  const moduleDirectory = dirname(fileURLToPath(import.meta.url))
-  const metadata = await readJson(resolve(process.cwd(), 'Auto-Test.build.json')) ??
+async function readBuildMetadata(): Promise<Record<string, unknown> | undefined> {
+  return await readJson(resolve(process.cwd(), 'Auto-Test.build.json')) ??
     await readJson(resolve(moduleDirectory, '../../../Auto-Test.build.json'))
-  const packageJson = await readJson(resolve(moduleDirectory, '../../package.json')) ??
+}
+
+async function readPackageJson(): Promise<Record<string, unknown> | undefined> {
+  return await readJson(resolve(moduleDirectory, '../../package.json')) ??
     await readJson(resolve(moduleDirectory, '../../../package.json')) ??
     await readJson(resolve(process.cwd(), 'package.json'))
+}
+
+/**
+ * Resolves the Auto-Test package version without touching Git or run state, so
+ * entry points (for example `easy --version`) stay cheap and side-effect free.
+ * Precedence matches `readAgentBuildInfo`: packaging environment override, then
+ * `Auto-Test.build.json`, then the nearest `package.json`.
+ */
+export async function readAutoTestPackageVersion(): Promise<string | undefined> {
+  return packageVersionFrom(await readBuildMetadata(), await readPackageJson())
+}
+
+function packageVersionFrom(
+  metadata: Record<string, unknown> | undefined,
+  packageJson: Record<string, unknown> | undefined,
+): string | undefined {
+  return process.env.AUTO_TEST_PACKAGE_VERSION ??
+    (typeof metadata?.packageVersion === 'string' ? metadata.packageVersion : undefined) ??
+    (typeof packageJson?.version === 'string' ? packageJson.version : undefined)
+}
+
+export async function readAgentBuildInfo(): Promise<AgentBuildInfo> {
+  const metadata = await readBuildMetadata()
   let commit = process.env.AUTO_TEST_BUILD_COMMIT ?? (typeof metadata?.commit === 'string' ? metadata.commit : undefined)
   if (!commit) {
     try {
@@ -42,9 +68,7 @@ export async function readAgentBuildInfo(): Promise<AgentBuildInfo> {
       // remains sufficient for a precise acceptance record in that case.
     }
   }
-  const packageVersion = process.env.AUTO_TEST_PACKAGE_VERSION ??
-    (typeof metadata?.packageVersion === 'string' ? metadata.packageVersion : undefined) ??
-    (typeof packageJson?.version === 'string' ? packageJson.version : undefined)
+  const packageVersion = packageVersionFrom(metadata, await readPackageJson())
   return {
     ...(packageVersion ? { packageVersion } : {}),
     ...(commit ? { commit } : {}),

--- a/src/cli/easy.ts
+++ b/src/cli/easy.ts
@@ -29,6 +29,7 @@ import {
   type ModelProfile,
 } from '../workflow/model-profile.js'
 import { isBuiltInAgentHostId } from '../agent/host-registry.js'
+import { readAutoTestPackageVersion } from '../agent/build-info.js'
 import type { AgentHostId } from '../agent/host.js'
 import { defaultRunDirectory, defaultRunRoot } from '../usability/run-directory.js'
 
@@ -533,6 +534,12 @@ async function main(): Promise<void> {
   }
   const args = process.argv.slice(2)
   const command = args[0]
+  if (command === '--version' || command === '-v') {
+    const version = await readAutoTestPackageVersion()
+    if (!version) throw new Error('无法确定 Auto-Test 版本')
+    console.log(version)
+    return
+  }
   if (!command) {
     if (!input.isTTY) throw new Error('非交互模式请使用 easy run、easy register 或 easy doctor')
     banner()

--- a/tests/easy-cli-version.test.ts
+++ b/tests/easy-cli-version.test.ts
@@ -1,40 +1,72 @@
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 const root = resolve(import.meta.dirname, '..')
 const tsxCli = resolve(root, 'node_modules/tsx/dist/cli.mjs')
 const easyCli = resolve(root, 'src/cli/easy.ts')
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+/**
+ * The packaging environment can override the resolved version; strip it so each
+ * test only sees the version sources it arranges itself.
+ */
+function envWithoutVersionOverride(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  delete env.AUTO_TEST_PACKAGE_VERSION
+  return env
+}
 
 function runEasy(...args: string[]): SpawnSyncReturns<string> {
-  // The package version can be overridden by the packaging environment; pin the
-  // test to what `package.json` declares so the assertion stays deterministic.
-  const env = { ...process.env }
-  delete env.AUTO_TEST_PACKAGE_VERSION
-  return spawnSync(process.execPath, [tsxCli, easyCli, ...args], { cwd: root, env, encoding: 'utf8' })
+  return runEasyIn({}, ...args)
+}
+
+function runEasyIn(
+  { cwd = root, env = envWithoutVersionOverride() }: { cwd?: string; env?: NodeJS.ProcessEnv },
+  ...args: string[]
+): SpawnSyncReturns<string> {
+  return spawnSync(process.execPath, [tsxCli, easyCli, ...args], { cwd, env, encoding: 'utf8' })
 }
 
 describe('easy CLI --version', () => {
-  it('prints the package version and exits 0 for --version', async () => {
+  it.each(['--version', '-v'])('prints the package version and exits 0 for %s', async (flag) => {
     const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { version: string }
 
-    const result = runEasy('--version')
+    const result = runEasy(flag)
 
-    expect(result.status, result.stderr).toBe(0)
-    expect(result.stdout.trim()).toBe(manifest.version)
+    expect(result.status, `${flag}: ${result.stderr}`).toBe(0)
+    expect(result.stdout.trim(), `${flag} stdout`).toBe(manifest.version)
   })
 
-  it('prints the same package version for -v', async () => {
-    const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { version: string }
+  it('prefers the packaging override and Auto-Test.build.json over package.json', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-easy-version-'))
+    temporaryDirectories.push(directory)
+    await writeFile(resolve(directory, 'Auto-Test.build.json'), JSON.stringify({
+      packageVersion: '9.8.7-fixture-build',
+      commit: 'fixture000',
+    }))
 
-    const result = runEasy('-v')
+    // Build metadata found in the working directory outranks the source package.json.
+    const fromMetadata = runEasyIn({ cwd: directory }, '--version')
+    expect(fromMetadata.status, fromMetadata.stderr).toBe(0)
+    expect(fromMetadata.stdout.trim()).toBe('9.8.7-fixture-build')
 
-    expect(result.status, result.stderr).toBe(0)
-    expect(result.stdout.trim()).toBe(manifest.version)
+    // The packaging environment override outranks the build metadata.
+    const fromOverride = runEasyIn(
+      { cwd: directory, env: { ...envWithoutVersionOverride(), AUTO_TEST_PACKAGE_VERSION: '9.9.9-fixture-override' } },
+      '--version',
+    )
+    expect(fromOverride.status, fromOverride.stderr).toBe(0)
+    expect(fromOverride.stdout.trim()).toBe('9.9.9-fixture-override')
   })
 
-  it('still rejects unknown commands after the version flag', () => {
+  it('still rejects unknown commands', () => {
     const result = runEasy('definitely-not-a-command')
 
     expect(result.status).toBe(1)

--- a/tests/easy-cli-version.test.ts
+++ b/tests/easy-cli-version.test.ts
@@ -1,0 +1,43 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '..')
+const tsxCli = resolve(root, 'node_modules/tsx/dist/cli.mjs')
+const easyCli = resolve(root, 'src/cli/easy.ts')
+
+function runEasy(...args: string[]): SpawnSyncReturns<string> {
+  // The package version can be overridden by the packaging environment; pin the
+  // test to what `package.json` declares so the assertion stays deterministic.
+  const env = { ...process.env }
+  delete env.AUTO_TEST_PACKAGE_VERSION
+  return spawnSync(process.execPath, [tsxCli, easyCli, ...args], { cwd: root, env, encoding: 'utf8' })
+}
+
+describe('easy CLI --version', () => {
+  it('prints the package version and exits 0 for --version', async () => {
+    const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { version: string }
+
+    const result = runEasy('--version')
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout.trim()).toBe(manifest.version)
+  })
+
+  it('prints the same package version for -v', async () => {
+    const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8')) as { version: string }
+
+    const result = runEasy('-v')
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout.trim()).toBe(manifest.version)
+  })
+
+  it('still rejects unknown commands after the version flag', () => {
+    const result = runEasy('definitely-not-a-command')
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('未知命令：definitely-not-a-command')
+  })
+})


### PR DESCRIPTION
## Summary

Merges `agent/issue-120-easy-version-flag` into `main` and delivers it. Direct push to `main` is blocked by the "Require pull requests" repository rule, so the merge commit is delivered through this PR.

Closes #120

## What's included

- **`easy --version` / `-v`** (`src/cli/easy.ts`): prints the resolved Auto-Test package version and exits `0` before the interactive menu, before any Run, and before the unknown-command fallthrough. No other CLI behaviour changes (`run`, `status`, `register`, `doctor`, `--help` untouched).
- **`readAutoTestPackageVersion()`** (`src/agent/build-info.ts`): new side-effect-free version resolver that never touches Git or run state, so entry points stay cheap. Precedence matches `readAgentBuildInfo`:
  1. `AUTO_TEST_PACKAGE_VERSION` packaging env override
  2. `Auto-Test.build.json` (`packageVersion`)
  3. nearest `package.json` (`version`)
- `readAgentBuildInfo()` was refactored onto the shared `readBuildMetadata()` / `readPackageJson()` / `packageVersionFrom()` helpers with unchanged output.
- **Tests** (`tests/easy-cli-version.test.ts`): pin exit code + stdout for both flags, the metadata/override precedence over `package.json`, and the unknown-command rejection path.
- **Docs**: `README.md`, `docs/quick-start.md`, `docs/windows-package-quick-start.md`.

## Verification

- `npm run check` green locally: typecheck + **383 tests in 53 files passing** + `tsc` build.
- `npm run easy -- --version` → `0.1.0` (exit 0); `npm run easy -- -v` → `0.1.0`.

Per acceptance criteria in #120: `--version`/`-v` print the `package.json` version and exit 0, the existing CLI surface is unchanged, a focused test covers both flags, and `npm run check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)