### PR TITLE
feat(afk): port label-driven GitHub Actions from course-video-manager

### DIFF
--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -1,0 +1,221 @@
+name: Agent Implement (PR)
+
+on:
+  # See agent-review.yml — pull_request_target fires reliably on labels
+  # even when the PR is out-of-date or conflicting.
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  implement-pr:
+    if: github.event.label.name == 'agent:implement'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    # Shared with agent-review.yml — both push to the PR branch.
+    concurrency:
+      group: agent-mutate-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_STATE: ${{ github.event.pull_request.state }}
+      PR_MERGED: ${{ github.event.pull_request.merged }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Pre-flight — refuse if PR is closed or merged
+        id: state
+        run: |
+          if [ "$PR_STATE" != "open" ] || [ "$PR_MERGED" = "true" ]; then
+            gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
+            gh pr comment "$PR_NUMBER" --body "Refused to run \`agent:implement\`: PR is not open."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pre-flight — refuse if there is nothing to act on
+        if: steps.state.outputs.proceed == 'true'
+        id: inputs
+        run: |
+          set -euo pipefail
+          top_level=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments | length')
+          review_summaries=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" --jq '[.[] | select(.body != null and .body != "")] | length')
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          unresolved=$(gh api graphql \
+            -F owner="$owner" -F repo="$repo" -F number="$PR_NUMBER" \
+            -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' \
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+          total=$((top_level + review_summaries + unresolved))
+          if [ "$total" -eq 0 ]; then
+            gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
+            gh pr comment "$PR_NUMBER" --body "Refused to run \`agent:implement\`: no unresolved review threads, review summaries, or top-level PR comments to act on."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Transition labels — remove trigger + blocked, add in-progress
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
+          gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
+          gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
+
+      - name: Checkout PR branch
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+      - name: Checkout PR branch with runner HOME and managed Git hooks
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "https://github.com/\${GH_REPO}.git"
+          else
+            git clone "https://github.com/\${GH_REPO}.git" .
+          fi
+          git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
+          git checkout -B "$BRANCH" FETCH_HEAD
+
+      - name: Ensure main is available for diffing
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          git fetch origin main:main || git fetch origin main
+          git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+
+      - name: Setup pnpm
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+
+      - name: Setup Node.js 22
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: npm ci
+
+      - name: Configure git identity
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          git config user.name "claude-code[bot]"
+          git config user.email "claude-code[bot]@users.noreply.github.com"
+
+      - name: Run implement-pr.ts
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        id: implement
+        env:
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/implement-pr/implement-pr.ts
+
+      - name: Push branch (abort cleanly if non-fast-forward)
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        id: push
+        run: |
+          has_commits=$(cat "${RUNNER_TEMP}/has_commits.txt")
+          if [ "$has_commits" != "true" ]; then
+            echo "No commits this run — skipping push."
+            exit 0
+          fi
+          set +e
+          git push --force-with-lease="refs/heads/$BRANCH:$BRANCH_HEAD_SHA" origin "$BRANCH" 2> push_err.txt
+          status=$?
+          set -e
+          if [ $status -ne 0 ]; then
+            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
+              echo "Branch advanced during implement run." > "${RUNNER_TEMP}/failure_reason.txt"
+              cat push_err.txt
+              exit 1
+            fi
+            cat push_err.txt
+            exit $status
+          fi
+
+      - name: Post thread replies
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        env:
+          REPLIES: ${{ runner.temp }}/implement_thread_replies.json
+        run: |
+          count=$(jq 'length' "$REPLIES")
+          for i in $(seq 0 $((count - 1))); do
+            commentId=$(jq -r ".[$i].commentId" "$REPLIES")
+            body=$(jq -r ".[$i].body" "$REPLIES")
+            rest_id=$(gh api graphql -f query="query(\$id:ID!){ node(id:\$id){ ... on PullRequestReviewComment { databaseId } } }" -F id="$commentId" --jq '.data.node.databaseId')
+            if [ -z "$rest_id" ] || [ "$rest_id" = "null" ]; then
+              echo "Could not resolve REST id for $commentId — skipping" >&2
+              continue
+            fi
+            gh api \
+              --method POST \
+              "repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments/${rest_id}/replies" \
+              -f body="$body"
+          done
+
+      - name: Post new inline comments
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        env:
+          INLINE: ${{ runner.temp }}/implement_new_inline_comments.json
+        run: |
+          commit_id=$(jq -r '.commit_id' "$INLINE")
+          count=$(jq '.comments | length' "$INLINE")
+          for i in $(seq 0 $((count - 1))); do
+            path=$(jq -r ".comments[$i].path" "$INLINE")
+            line=$(jq -r ".comments[$i].line" "$INLINE")
+            side=$(jq -r ".comments[$i].side" "$INLINE")
+            body=$(jq -r ".comments[$i].body" "$INLINE")
+            gh api \
+              --method POST \
+              "repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments" \
+              -f body="$body" \
+              -f commit_id="$commit_id" \
+              -f path="$path" \
+              -F line="$line" \
+              -f side="$side"
+          done
+
+      - name: Post top-level PR comments
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        env:
+          TOP: ${{ runner.temp }}/implement_top_level_comments.json
+        run: |
+          count=$(jq 'length' "$TOP")
+          for i in $(seq 0 $((count - 1))); do
+            body=$(jq -r ".[$i].body" "$TOP")
+            gh pr comment "$PR_NUMBER" --body "$body"
+          done
+
+      - name: Mark blocked on failure
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          reason="(no reason file written — check workflow logs)"
+          if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
+            reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "agent:blocked" || true
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          \`agent:implement\` run on this PR failed.
+
+          **Reason:** $reason
+
+          **Workflow run:** $RUN_URL
+
+          Re-add \`agent:implement\` to retry.
+          EOF
+          )"
+
+      - name: Always remove in-progress label
+        if: always() && steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -1,0 +1,234 @@
+name: Agent Implement
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'agent:implement'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    concurrency:
+      group: agent-implement-issue-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Detect — does this issue have sub-issues or a parent?
+        id: shape
+        run: |
+          set -euo pipefail
+          # Sub-issues: REST endpoint returns [] if none, list otherwise.
+          sub_count=$(gh api "repos/${GH_REPO}/issues/${ISSUE_NUMBER}/sub_issues" --jq 'length' 2>/dev/null || echo "0")
+          # Parent: queried via GraphQL since REST doesn't expose it on the issue object.
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          parent_number=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { parent { number } } } }' \
+            -f owner="$owner" -f repo="$repo" -F num="$ISSUE_NUMBER" \
+            --jq '.data.repository.issue.parent.number // empty' 2>/dev/null || echo "")
+          if [ "$sub_count" != "0" ]; then
+            # Issue is a PRD — agent-implement-prd.yml handles it. Silent skip here.
+            proceed="false"
+          elif [ -n "$parent_number" ]; then
+            # Issue is itself a sub-issue. We refuse below.
+            proceed="false"
+          else
+            proceed="true"
+          fi
+          echo "sub_count=$sub_count" >> "$GITHUB_OUTPUT"
+          echo "parent_number=$parent_number" >> "$GITHUB_OUTPUT"
+          echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse — issue is a sub-issue of another issue
+        if: steps.shape.outputs.sub_count == '0' && steps.shape.outputs.parent_number != ''
+        env:
+          PARENT_NUMBER: ${{ steps.shape.outputs.parent_number }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --remove-label "agent:implement" || true
+          gh issue edit "$ISSUE_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$ISSUE_NUMBER" --body "Refused to run: this issue is a sub-issue of #${PARENT_NUMBER}. Sub-issues are not labeled directly — add \`agent:implement\` to the parent PRD instead. Cleared \`agent:implement\` and added \`agent:blocked\`."
+
+      - name: Pre-flight — refuse if an open PR already exists for this issue
+        if: steps.shape.outputs.proceed == 'true'
+        id: preflight
+        run: |
+          set -euo pipefail
+          # Find open PRs whose body references "Closes #N" / "Fixes #N" / "Resolves #N".
+          existing=$(gh pr list \
+            --state open \
+            --search "in:body \"#${ISSUE_NUMBER}\"" \
+            --json number,url,body \
+            --jq "[.[] | select(.body | test(\"(?i)(closes|fixes|resolves)\\\\s+#${ISSUE_NUMBER}\\\\b\"))]")
+          count=$(echo "$existing" | jq 'length')
+          if [ "$count" -gt 0 ]; then
+            url=$(echo "$existing" | jq -r '.[0].url')
+            echo "existing_pr_url=$url" >> "$GITHUB_OUTPUT"
+            echo "refused=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "refused=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pre-flight refusal — comment + remove label, exit
+        if: steps.preflight.outputs.refused == 'true'
+        env:
+          EXISTING_PR_URL: ${{ steps.preflight.outputs.existing_pr_url }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --remove-label "agent:implement" || true
+          gh issue comment "$ISSUE_NUMBER" --body "Refused to run: PR $EXISTING_PR_URL already targets this issue. Close it first, then re-add \`agent:implement\`."
+          exit 0
+
+      - name: Transition labels — remove implement/blocked, add in-progress
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --remove-label "agent:implement" || true
+          gh issue edit "$ISSUE_NUMBER" --remove-label "agent:blocked" || true
+          gh issue edit "$ISSUE_NUMBER" --add-label "agent:in-progress"
+
+      - name: Checkout main with runner HOME and managed Git hooks
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git fetch --depth 1 origin main
+            git checkout -B main FETCH_HEAD
+          else
+            git clone --branch main --depth 1 "https://github.com/\${GH_REPO}.git" .
+          fi
+
+      - name: Compute branch name
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        id: branch
+        run: |
+          slug=$(echo "$ISSUE_TITLE" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+            | cut -c1-50)
+          branch="agent/issue-${ISSUE_NUMBER}-${slug}"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Create branch
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          git config user.name "claude-code[bot]"
+          git config user.email "claude-code[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+
+      - name: Setup Node.js 22
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        run: npm ci
+
+      - name: Run implement.ts
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        id: implement
+        env:
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/implement/implement.ts
+
+      - name: Push branch
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && success()
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        # Force-push so we recover from leftover branches whose PR has since
+        # closed/merged. Safe because the preflight step refuses when an open
+        # PR exists for this issue, and the branch name is deterministic from
+        # the issue number — any remote ref here is an orphan.
+        run: git push --force origin "$BRANCH"
+
+      - name: Write PR title and description
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && success()
+        env:
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/write-pr/write-pr.ts
+
+      - name: Open PR
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && success()
+        id: open_pr
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          PR_TITLE=$(cat "${RUNNER_TEMP}/pr_title.txt")
+          PR_TITLE="${PR_TITLE:0:256}"
+          pr_url=$(gh pr create \
+            --draft \
+            --base main \
+            --head "$BRANCH" \
+            --title "$PR_TITLE" \
+            --body-file "${RUNNER_TEMP}/pr_description.txt" | tail -n1)
+          pr_number=$(basename "$pr_url")
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Request automated review (add agent:review label)
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && success()
+        env:
+          PR_NUMBER: ${{ steps.open_pr.outputs.pr_number }}
+          # Prefer AGENT_PAT so the labeled event triggers agent-review.yml
+          # (GITHUB_TOKEN-driven label adds do not trigger downstream workflows).
+          # Fall back to GITHUB_TOKEN if AGENT_PAT is unset or lacks
+          # pull-requests permission; in that case a human will need to
+          # re-add `agent:review` manually to fire the review workflow.
+          AGENT_PAT: ${{ secrets.AGENT_PAT }}
+          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          if [ -n "$AGENT_PAT" ]; then
+            GH_TOKEN="$AGENT_PAT" gh pr edit "$PR_NUMBER" --add-label "agent:review"
+            status=$?
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            echo "AGENT_PAT label add failed (status $status); falling back to GITHUB_TOKEN."
+          fi
+          GH_TOKEN="$GITHUB_TOKEN_FALLBACK" gh pr edit "$PR_NUMBER" --add-label "agent:review"
+
+      - name: Mark blocked on failure
+        if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          reason="(no reason file written — check workflow logs)"
+          if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
+            reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
+          fi
+          gh issue edit "$ISSUE_NUMBER" --add-label "agent:blocked" || true
+          gh issue comment "$ISSUE_NUMBER" --body "$(cat <<EOF
+          \`agent:implement\` run failed.
+
+          **Reason:** $reason
+
+          **Workflow run:** $RUN_URL
+
+          Re-add \`agent:implement\` to retry.
+          EOF
+          )"
+
+      - name: Always remove in-progress
+        if: always() && steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
+        run: gh issue edit "$ISSUE_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-promote-queued.yml
+++ b/.github/workflows/agent-promote-queued.yml
@@ -1,0 +1,129 @@
+name: Agent Promote Queued
+
+# When an issue closes, find every `agent:queued` issue that declared it as a
+# blocker via the native GitHub issue dependency relation. If any of those
+# dependents have no remaining open blockers, flip `agent:queued` to
+# `agent:implement` so `agent-implement.yml` picks them up.
+#
+# Manual application only — humans apply `agent:queued`. This workflow is the
+# exit ramp, not the entrance.
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  promote:
+    # Wontfix closes don't unblock anything in a meaningful sense.
+    if: github.event.issue.state_reason != 'not_planned'
+    runs-on: self-hosted
+    timeout-minutes: 5
+    permissions:
+      issues: write
+
+    env:
+      CLOSED_NUMBER: ${{ github.event.issue.number }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      # AGENT_PAT is required for the promoted `agent:implement` label to
+      # fire `agent-implement.yml` — labels added via GITHUB_TOKEN do not
+      # trigger downstream workflows. Falls back to GITHUB_TOKEN, in which
+      # case promotion lands but the downstream run won't auto-trigger.
+      AGENT_PAT: ${{ secrets.AGENT_PAT }}
+
+    steps:
+      - name: Find dependents of the closed issue
+        id: dependents
+        run: |
+          set -euo pipefail
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          # `blocking` is the connection from the closed issue to issues that
+          # declared it as a blocker (i.e. our promotion candidates).
+          dependents=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { blocking(first: 100) { nodes { number state } } } } }' \
+            -f owner="$owner" -f repo="$repo" -F num="$CLOSED_NUMBER" \
+            --jq '[.data.repository.issue.blocking.nodes[] | select(.state == "OPEN") | .number]')
+          echo "list=$dependents" >> "$GITHUB_OUTPUT"
+          echo "Found dependents: $dependents"
+
+      - name: Evaluate and promote each dependent
+        if: steps.dependents.outputs.list != '[]'
+        env:
+          DEPENDENTS_JSON: ${{ steps.dependents.outputs.list }}
+        run: |
+          set -euo pipefail
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+
+          echo "$DEPENDENTS_JSON" | jq -r '.[]' | while read -r y; do
+            echo "::group::Evaluating #$y"
+
+            # Fetch labels + parent for Y in one shot.
+            y_data=$(gh api graphql \
+              -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { labels(first: 50) { nodes { name } } parent { number } blockedBy(first: 100) { nodes { number state } } } } }' \
+              -f owner="$owner" -f repo="$repo" -F num="$y")
+
+            has_queued=$(echo "$y_data" | jq '[.data.repository.issue.labels.nodes[].name] | index("agent:queued") != null')
+            has_in_progress=$(echo "$y_data" | jq '[.data.repository.issue.labels.nodes[].name] | index("agent:in-progress") != null')
+            parent_num=$(echo "$y_data" | jq -r '.data.repository.issue.parent.number // empty')
+            remaining_open=$(echo "$y_data" | jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length')
+
+            if [ "$has_queued" != "true" ]; then
+              echo "Skip: #$y is not agent:queued"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ "$has_in_progress" = "true" ]; then
+              echo "Skip: #$y is agent:in-progress"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -n "$parent_num" ]; then
+              echo "Refuse: #$y is a sub-issue of #$parent_num"
+              gh issue edit "$y" --remove-label "agent:queued" || true
+              gh issue edit "$y" --add-label "agent:blocked" || true
+              gh issue comment "$y" --body "Refused to promote: this is a sub-issue of #${parent_num}. \`agent:queued\` is not meaningful on sub-issues — label the parent PRD instead. Cleared \`agent:queued\` and added \`agent:blocked\`."
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ "$remaining_open" -gt 0 ]; then
+              echo "Skip: #$y still has $remaining_open open blocker(s)"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Idempotent flip: re-fetch labels right before mutating to lose
+            # races against a sibling run of this workflow.
+            still_queued=$(gh issue view "$y" --json labels --jq '[.labels[].name] | index("agent:queued") != null')
+            if [ "$still_queued" != "true" ]; then
+              echo "Skip: #$y no longer has agent:queued (lost race)"
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "Promote: #$y"
+            gh issue edit "$y" --remove-label "agent:queued"
+            gh issue comment "$y" --body "Unblocked by #${CLOSED_NUMBER} closing — promoting from \`agent:queued\` to \`agent:implement\`."
+
+            # Use AGENT_PAT for the agent:implement add so downstream
+            # agent-implement.yml fires. Fall back to GITHUB_TOKEN if PAT is
+            # absent; in that case the label lands but won't trigger.
+            set +e
+            if [ -n "$AGENT_PAT" ]; then
+              GH_TOKEN="$AGENT_PAT" gh issue edit "$y" --add-label "agent:implement"
+              status=$?
+              if [ "$status" -ne 0 ]; then
+                echo "AGENT_PAT add-label failed (status $status); falling back to GITHUB_TOKEN."
+                gh issue edit "$y" --add-label "agent:implement"
+              fi
+            else
+              gh issue edit "$y" --add-label "agent:implement"
+            fi
+            set -e
+
+            echo "::endgroup::"
+          done

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,170 @@
+name: Agent Review
+
+on:
+  # pull_request_target rather than pull_request: the standard pull_request
+  # trigger depends on a generated merge commit, which GitHub fails to
+  # produce when the PR is out-of-date or conflicting. pull_request_target
+  # runs in the base context and does not need the merge commit, so the
+  # labeled event fires reliably.
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  review:
+    if: github.event.label.name == 'agent:review'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    concurrency:
+      group: agent-mutate-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Transition labels — remove trigger + blocked, add in-progress
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "agent:review" || true
+          gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
+          gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
+
+      - name: Checkout PR branch
+      - name: Checkout PR branch with runner HOME and managed Git hooks
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "https://github.com/\${GH_REPO}.git"
+          else
+            git clone "https://github.com/\${GH_REPO}.git" .
+          fi
+          git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
+          git checkout -B "$BRANCH" FETCH_HEAD
+
+      - name: Ensure main is available for diffing
+        run: |
+          git fetch origin main:main || git fetch origin main
+          git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+
+      - name: Capture pre-run HEAD
+        id: pre
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # latest — every run exercises the current version of the skill. Global
+      # (not project) install keeps it outside the git work tree so the review
+      # agent's commit step can never sweep it into the PR branch. Scoped to the
+      # claude-code agent so the step exits 0 (other agents reject -g installs).
+      - name: Install code-review skill
+        run: pnpm dlx skills@latest add mattpocock/skills -g -s code-review -a claude-code -y --copy
+
+      - name: Configure git identity
+        run: |
+          git config user.name "claude-code[bot]"
+          git config user.email "claude-code[bot]@users.noreply.github.com"
+
+      - name: Run review.ts
+        id: review
+        env:
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/review/review.ts
+
+      - name: Push branch (abort cleanly if non-fast-forward)
+        id: push
+        if: success()
+        run: |
+          # Lease against the SHA we checked out — fails cleanly if anything
+          # pushed to the branch during our run.
+          set +e
+          git push --force-with-lease="refs/heads/$BRANCH:$BRANCH_HEAD_SHA" origin "$BRANCH" 2> push_err.txt
+          status=$?
+          set -e
+          if [ $status -ne 0 ]; then
+            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
+              echo "Branch advanced during review run." > "${RUNNER_TEMP}/failure_reason.txt"
+              echo "race=true" >> "$GITHUB_OUTPUT"
+              cat push_err.txt
+              exit 1
+            fi
+            cat push_err.txt
+            exit $status
+          fi
+
+      - name: Post PR review (inline comments + summary)
+        if: success()
+        env:
+          PAYLOAD: ${{ runner.temp }}/review_payload.json
+        run: |
+          gh api \
+            --method POST \
+            "repos/{owner}/{repo}/pulls/${PR_NUMBER}/reviews" \
+            --input "$PAYLOAD"
+
+      - name: Mark PR ready for review
+        if: success()
+        run: gh pr ready "$PR_NUMBER" || true
+
+      - name: Post thread replies
+        if: success()
+        env:
+          REPLIES: ${{ runner.temp }}/replies.json
+        run: |
+          count=$(jq 'length' "$REPLIES")
+          for i in $(seq 0 $((count - 1))); do
+            commentId=$(jq -r ".[$i].commentId" "$REPLIES")
+            body=$(jq -r ".[$i].body" "$REPLIES")
+            # GraphQL node ID → numeric REST id via the node lookup.
+            rest_id=$(gh api graphql -f query="query(\$id:ID!){ node(id:\$id){ ... on PullRequestReviewComment { databaseId } } }" -F id="$commentId" --jq '.data.node.databaseId')
+            if [ -z "$rest_id" ] || [ "$rest_id" = "null" ]; then
+              echo "Could not resolve REST id for $commentId — skipping" >&2
+              continue
+            fi
+            gh api \
+              --method POST \
+              "repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments/${rest_id}/replies" \
+              -f body="$body"
+          done
+
+      - name: Mark blocked on failure
+        if: failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          reason="(no reason file written — check workflow logs)"
+          if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
+            reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "agent:blocked" || true
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          \`agent:review\` run failed.
+
+          **Reason:** $reason
+
+          **Workflow run:** $RUN_URL
+
+          Re-add \`agent:review\` to retry.
+          EOF
+          )"
+
+      - name: Always remove in-progress label
+        if: always()
+        run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -1,0 +1,136 @@
+name: Agent Update Branch
+
+on:
+  # pull_request_target rather than pull_request: the standard pull_request
+  # trigger depends on a generated merge commit, which GitHub fails to
+  # produce when the PR is out-of-date or conflicting — exactly when this
+  # workflow needs to run. pull_request_target runs in the base context and
+  # does not need the merge commit, so the labeled event fires reliably.
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  update-branch:
+    if: github.event.label.name == 'agent:update-branch'
+    runs-on: self-hosted
+    timeout-minutes: 60
+    concurrency:
+      group: agent-mutate-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Transition labels — remove trigger + blocked, add in-progress
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "agent:update-branch" || true
+          gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
+          gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
+
+      - name: Checkout PR branch
+      - name: Checkout PR branch with runner HOME and managed Git hooks
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "https://github.com/\${GH_REPO}.git"
+          else
+            git clone "https://github.com/\${GH_REPO}.git" .
+          fi
+          git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
+          git checkout -B "$BRANCH" FETCH_HEAD
+
+      - name: Ensure branch is checked out by name
+        run: git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+
+      - name: Setup pnpm
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: npm ci
+
+        run: |
+          git config user.name "claude-code[bot]"
+          git config user.email "claude-code[bot]@users.noreply.github.com"
+
+      - name: Run update-branch.ts
+        id: run
+        env:
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/update-branch/update-branch.ts
+
+      - name: Push branch (abort cleanly if non-fast-forward)
+        if: success()
+        env:
+          SHOULD_PUSH_FILE: ${{ runner.temp }}/should_push.txt
+        run: |
+          if [ ! -f "$SHOULD_PUSH_FILE" ] || [ "$(cat "$SHOULD_PUSH_FILE")" != "true" ]; then
+            echo "Nothing to push."
+            exit 0
+          fi
+          # Lease against the SHA we checked out — fails if anything pushed
+          # to the branch during our run (race detection), and tolerates
+          # history-rewriting updates (rebase) when the remote is unchanged.
+          set +e
+          git push --force-with-lease="refs/heads/$BRANCH:$BRANCH_HEAD_SHA" origin "$BRANCH" 2> push_err.txt
+          status=$?
+          set -e
+          if [ $status -ne 0 ]; then
+            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
+              echo "Branch advanced during update-branch run." > "${RUNNER_TEMP}/failure_reason.txt"
+              cat push_err.txt
+              exit 1
+            fi
+            cat push_err.txt
+            exit $status
+          fi
+
+      - name: Post PR comment
+        if: success()
+        env:
+          COMMENT_FILE: ${{ runner.temp }}/comment.md
+        run: |
+          if [ -f "$COMMENT_FILE" ]; then
+            gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"
+          fi
+
+      - name: Mark blocked on failure
+        if: failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          reason="(no reason file written — check workflow logs)"
+          if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
+            reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "agent:blocked" || true
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          \`agent:update-branch\` run failed.
+
+          **Reason:** $reason
+
+          **Workflow run:** $RUN_URL
+
+          Re-add \`agent:update-branch\` to retry.
+          EOF
+          )"
+
+      - name: Always remove in-progress label
+        if: always()
+        run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -1,0 +1,140 @@
+name: Architecture Review
+
+on:
+  schedule:
+    # 09:00 UTC, Monday–Friday. GitHub may delay scheduled runs under load.
+    - cron: "0 9 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  check-backlog:
+    runs-on: self-hosted
+    timeout-minutes: 5
+    permissions:
+      issues: read
+    outputs:
+      proceed: ${{ steps.count.outputs.proceed }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Count open architecture-review issues
+        id: count
+        env:
+          LABEL: source:architecture-review
+        run: |
+          set -euo pipefail
+          # Only care whether the backlog is below 10, so a limit of 10 is enough
+          # to detect the threshold; the true count may be higher.
+          open=$(gh issue list --state open --label "$LABEL" --limit 10 --json number --jq 'length')
+          echo "Found $open open '$LABEL' issue(s) (counted up to 10)."
+          if [ "$open" -lt 10 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Backlog has 10+ open '$LABEL' issues — skipping this run." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  architecture-review:
+    needs: check-backlog
+    if: needs.check-backlog.outputs.proceed == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 20
+    concurrency:
+      group: architecture-review
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      issues: write
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Checkout main
+      - name: Checkout main with runner HOME and managed Git hooks
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          if [ -d .git ]; then
+            git remote remove origin 2>/dev/null || true
+            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git fetch --depth 1 origin main
+            git checkout -B main FETCH_HEAD
+          else
+            git clone --branch main --depth 1 "https://github.com/\${GH_REPO}.git" .
+          fi
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+        env:
+          AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npm exec tsx .sandcastle/architecture-review/architecture-review.ts
+
+      - name: Publish PRD issue
+        id: publish
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/architecture_review_output.json
+          TITLE_FILE: ${{ runner.temp }}/prd_title.txt
+          BODY_FILE: ${{ runner.temp }}/prd_body.md
+          LABEL: source:architecture-review
+        run: |
+          set -euo pipefail
+          status=$(jq -r '.status' "$OUTPUT_FILE")
+          if [ "$status" != "proposed" ]; then
+            echo "Status is '$status' — nothing to publish."
+            exit 0
+          fi
+          title=$(cat "$TITLE_FILE")
+          # Ensure the provenance label exists (idempotent — succeeds if already present).
+          gh label create "$LABEL" \
+            --color "5319E7" \
+            --description "PRDs proposed by the automated architecture-review workflow" \
+            >/dev/null 2>&1 || true
+          # gh issue create prints the URL on the last line.
+          issue_url=$(gh issue create \
+            --title "$title" \
+            --body-file "$BODY_FILE" \
+            --label "$LABEL" | tail -n1)
+          issue_number=$(basename "$issue_url")
+          echo "issue_url=$issue_url" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "Published #${issue_number}: ${issue_url}"
+
+      - name: Summarise run
+        if: always()
+        env:
+          OUTPUT_FILE: ${{ runner.temp }}/architecture_review_output.json
+        run: |
+          if [ ! -f "$OUTPUT_FILE" ]; then
+            echo "No output file produced — agent likely crashed before emitting a result."
+            exit 0
+          fi
+          status=$(jq -r '.status' "$OUTPUT_FILE")
+          {
+            echo "## Architecture review"
+            echo ""
+            if [ "$status" = "proposed" ]; then
+              issue_url="${{ steps.publish.outputs.issue_url }}"
+              title=$(jq -r '.title' "$OUTPUT_FILE")
+              summary=$(jq -r '.oneLineSummary' "$OUTPUT_FILE")
+              echo "**Created:** [$title]($issue_url)"
+              echo ""
+              echo "$summary"
+              echo ""
+              echo "### Candidates considered"
+              jq -r '.candidatesConsidered[] | "- \(.)"' "$OUTPUT_FILE"
+            elif [ "$status" = "skipped" ]; then
+              reason=$(jq -r '.reason' "$OUTPUT_FILE")
+              echo "**Skipped — no fresh candidates today.**"
+              echo ""
+              echo "$reason"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.sandcastle/architecture-review/architecture-review.ts
+++ b/.sandcastle/architecture-review/architecture-review.ts
@@ -1,0 +1,64 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import { runWithExtraction } from "../run-with-extraction";
+
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const PromptOutput = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("proposed"),
+    title: z.string().min(1).max(256),
+    body: z.string().min(1),
+    oneLineSummary: z.string().min(1),
+    candidatesConsidered: z.array(z.string().min(1)).min(1),
+  }),
+  z.object({
+    status: z.literal("skipped"),
+    reason: z.string().min(1),
+  }),
+]);
+
+const result = await runWithExtraction({
+  name: `architecture-review-${new Date().toISOString().slice(0, 10)}`,
+  ...claudeProfile(process.env.AFK_PROFILE),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: PromptOutput,
+  }),
+  extractionPrompt: fs.readFileSync(
+    path.join(import.meta.dirname, "extraction.md"),
+    "utf8"
+  ),
+});
+
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "architecture_review_output.json"),
+  JSON.stringify(result.output, null, 2)
+);
+
+if (result.output.status === "proposed") {
+  fs.writeFileSync(path.join(OUTPUT_DIR, "prd_title.txt"), result.output.title);
+  fs.writeFileSync(path.join(OUTPUT_DIR, "prd_body.md"), result.output.body);
+  console.log(`\nProposed PRD: ${result.output.title}`);
+  console.log(
+    `  candidates considered: ${result.output.candidatesConsidered.length}`
+  );
+  console.log(`  body written to ${OUTPUT_DIR}/prd_body.md`);
+} else {
+  console.log(`\nSkipped — no fresh candidates.`);
+  console.log(`  reason: ${result.output.reason}`);
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/.sandcastle/architecture-review/extraction.md
+++ b/.sandcastle/architecture-review/extraction.md
@@ -1,0 +1,37 @@
+# EMIT STRUCTURED OUTPUT
+
+You have finished the architecture-review pass. **Do not explore further or make any changes** — only report the outcome.
+
+End your response with a single `<output>` block, exactly as specified in the project skill `improve-codebase-architecture-project`. It has one of two shapes.
+
+## Proposed a PRD this run
+
+<output>
+{
+  "status": "proposed",
+  "title": "PRD title (matches the issue you created)",
+  "body": "The PRD body you published.",
+  "oneLineSummary": "One-line description of the deepening opportunity.",
+  "candidatesConsidered": ["candidate 1", "candidate 2"]
+}
+</output>
+
+## Skipped — everything fresh is already covered
+
+<output>
+{
+  "status": "skipped",
+  "reason": "Why no new PRD was proposed (e.g. every candidate is already covered by a prior source:architecture-review proposal)."
+}
+</output>
+
+Field rules:
+
+- `status` — `"proposed"` or `"skipped"`. Required.
+- `title` — required when proposed; ≤256 characters.
+- `body` — required when proposed; the full PRD body.
+- `oneLineSummary` — required when proposed.
+- `candidatesConsidered` — required when proposed; non-empty array of strings.
+- `reason` — required when skipped.
+
+Do not add fields beyond those listed. The JSON is machine-parsed.

--- a/.sandcastle/architecture-review/prompt.md
+++ b/.sandcastle/architecture-review/prompt.md
@@ -1,0 +1,35 @@
+# TASK
+
+You are running the daily architecture-review pass. Find one fresh deepening
+opportunity in this codebase and publish it as a PRD.
+
+This is an unattended CI run. There is no user to grill, no HTML report to
+write. Your job is:
+
+1. List prior proposals labelled `source:architecture-review` (open and
+   closed) so you don't re-propose them.
+2. Explore the codebase.
+3. Pick **one** top candidate.
+4. Publish it via `/to-prd-project`.
+5. Apply the `source:architecture-review` label to the new issue.
+
+The full process — including the methodology (deletion test, deepening,
+glossary), the loose-duplicate rule, the PRD shape, and the exact `<output>`
+schema — is documented in the project skill
+`improve-codebase-architecture-project`. Follow it.
+
+# CONTEXT
+
+Read `docs/` and any relevant ADRs under `docs/adr/` before proposing
+anything. Treat ADRs as binding — do not propose changes that contradict a
+recorded decision.
+
+# RULES
+
+- Read-only on the repo. No commits. No edits to `docs/`, ADRs, or
+  source files. The only mutations allowed are creating the PRD issue (via
+  `/to-prd-project`) and applying the `source:architecture-review` label.
+- One PRD per run. If every reasonable candidate is already covered by a
+  prior `source:architecture-review` proposal, emit a `skipped` output and
+  stop.
+- No questions to a user — there is none. Make the call.

--- a/.sandcastle/implement-pr/extraction.md
+++ b/.sandcastle/implement-pr/extraction.md
@@ -1,0 +1,60 @@
+# EMIT STRUCTURED OUTPUT
+
+You have finished addressing the feedback. **Do not make any further code changes** — only report the replies and any new inline comments you want posted, based on what you already did.
+
+Emit a single `<output>` block as the **last thing** in your response. Valid JSON, field names exact.
+
+## Example
+
+<output>
+{
+  "threadReplies": [
+    {
+      "commentId": "PRRC_kwDOPSEf9c8AAAABX1234",
+      "body": "Good catch — fixed in the latest commit by adding the early-return guard."
+    },
+    {
+      "commentId": "PRRC_kwDOPSEf9c8AAAABX5678",
+      "body": "I'd push back on this one — renaming `calcVal` to `calculateDiscount` would conflict with the `calcVal` convention used elsewhere in this file. Happy to do it as a follow-up across the whole file if you want."
+    }
+  ],
+  "newInlineComments": [
+    {
+      "path": "app/services/auth.ts",
+      "line": 87,
+      "body": "Heads up — while addressing the thread above I also tightened the guard on line 85. Flagging in case it affects the test you mentioned."
+    }
+  ],
+  "topLevelComments": [
+    {
+      "body": "Addressed 2 of 3 threads. Left the third (about the helper rename) for a separate PR — explained inline."
+    }
+  ]
+}
+</output>
+
+## Empty output (rare)
+
+If you made no code changes and have nothing to say, emit:
+
+<output>
+{ "threadReplies": [], "newInlineComments": [], "topLevelComments": [] }
+</output>
+
+The workflow will mark the run as blocked if both the diff and all reply arrays are empty — that's a degenerate run.
+
+## Field reference
+
+| Field                       | Type    | Required | Notes                                                                                                               |
+| --------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `threadReplies`             | array   | no       | Replies posted in an existing unresolved review thread.                                                             |
+| `threadReplies[].commentId` | string  | **yes**  | Must be a `commentId` from a `review_thread` you were shown. Do not invent IDs.                                     |
+| `threadReplies[].body`      | string  | **yes**  | Markdown reply.                                                                                                     |
+| `newInlineComments`         | array   | no       | New inline comments on lines in the diff (not replies). Use only when a thread reply isn't the right surface.       |
+| `newInlineComments[].path`  | string  | **yes**  | Relative file path.                                                                                                 |
+| `newInlineComments[].line`  | integer | **yes**  | Single line number in the current HEAD (the diff is unchanged). The workflow drops anchors that aren't in the diff. |
+| `newInlineComments[].body`  | string  | **yes**  | Markdown.                                                                                                           |
+| `topLevelComments`          | array   | no       | New top-level PR conversation comments. Use for cross-cutting summaries or comments not tied to a thread.           |
+| `topLevelComments[].body`   | string  | **yes**  | Markdown.                                                                                                           |
+
+Do not add fields not listed above.

--- a/.sandcastle/implement-pr/implement-pr-output.ts
+++ b/.sandcastle/implement-pr/implement-pr-output.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+export const ImplementPrOutput = z.object({
+  threadReplies: z
+    .array(
+      z.object({
+        commentId: z.string().min(1),
+        body: z.string().min(1),
+      })
+    )
+    .default([]),
+  newInlineComments: z
+    .array(
+      z
+        .object({
+          path: z.string().min(1).optional(),
+          file: z.string().min(1).optional(),
+          line: z.coerce.number().int().positive().optional(),
+          lineRange: z.string().optional(),
+          side: z.enum(["LEFT", "RIGHT"]).default("RIGHT"),
+          body: z.string().min(1).optional(),
+          comment: z.string().min(1).optional(),
+        })
+        .transform((c, ctx) => {
+          const path = c.path ?? c.file;
+          const body = c.body ?? c.comment;
+
+          let line = c.line;
+          if (line == null && c.lineRange != null) {
+            const match = c.lineRange.match(/^(\d+)/);
+            line = match ? parseInt(match[1]!, 10) : undefined;
+          }
+
+          if (!path) {
+            ctx.addIssue({
+              code: "custom",
+              message: "inline comment missing 'path' (or 'file')",
+            });
+            return z.NEVER;
+          }
+          if (line == null || line < 1) {
+            ctx.addIssue({
+              code: "custom",
+              message:
+                "inline comment missing 'line' (or 'lineRange' with a valid number)",
+            });
+            return z.NEVER;
+          }
+          if (!body) {
+            ctx.addIssue({
+              code: "custom",
+              message: "inline comment missing 'body' (or 'comment')",
+            });
+            return z.NEVER;
+          }
+          return { path, line, side: c.side, body };
+        })
+    )
+    .default([]),
+  topLevelComments: z
+    .array(
+      z.object({
+        body: z.string().min(1),
+      })
+    )
+    .default([]),
+});
+
+export type ImplementPrOutput = z.infer<typeof ImplementPrOutput>;

--- a/.sandcastle/implement-pr/implement-pr.ts
+++ b/.sandcastle/implement-pr/implement-pr.ts
@@ -1,0 +1,286 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync, execFileSync } from "node:child_process";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import { parseDiffLines } from "../review/parse-diff-lines";
+import { ImplementPrOutput } from "./implement-pr-output";
+import { runWithExtraction } from "../run-with-extraction";
+
+const PR_NUMBER = required("PR_NUMBER");
+const BRANCH = required("BRANCH");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const PrView = z.object({
+  title: z.string(),
+  body: z.string().nullable().default(""),
+  headRefOid: z.string(),
+  comments: z.array(
+    z.object({
+      id: z.string().optional(),
+      author: z.object({ login: z.string() }).nullable().optional(),
+      body: z.string(),
+      createdAt: z.string().optional(),
+    })
+  ),
+});
+
+const prViewJson = sh(
+  `gh pr view ${PR_NUMBER} --json title,body,headRefOid,comments`
+);
+const prView = PrView.parse(JSON.parse(prViewJson));
+
+const issueMatch = prView.body?.match(/(?:closes|fixes|resolves)\s+#(\d+)/i);
+const ISSUE_NUMBER = issueMatch?.[1] ?? "";
+const ISSUE_TITLE = ISSUE_NUMBER
+  ? safeSh(`gh issue view ${ISSUE_NUMBER} --json title --jq .title`).trim()
+  : "";
+
+const reviewsJson = sh(
+  `gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/reviews`
+);
+const reviews = z
+  .array(
+    z.object({
+      id: z.number(),
+      user: z.object({ login: z.string() }).nullable(),
+      body: z.string().nullable().default(""),
+      state: z.string(),
+      submitted_at: z.string().nullable().optional(),
+    })
+  )
+  .parse(JSON.parse(reviewsJson));
+
+const graphqlQuery = `
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:50) {
+            nodes {
+              id
+              path
+              line
+              originalLine
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const [owner, repo] = required("GH_REPO").split("/");
+const threadsJson = execFileSync(
+  "gh",
+  [
+    "api",
+    "graphql",
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `repo=${repo}`,
+    "-F",
+    `number=${PR_NUMBER}`,
+    "-f",
+    `query=${graphqlQuery}`,
+  ],
+  { encoding: "utf8" }
+);
+const threadsParsed = z
+  .object({
+    data: z.object({
+      repository: z.object({
+        pullRequest: z.object({
+          reviewThreads: z.object({
+            nodes: z.array(
+              z.object({
+                id: z.string(),
+                isResolved: z.boolean(),
+                isOutdated: z.boolean(),
+                comments: z.object({
+                  nodes: z.array(
+                    z.object({
+                      id: z.string(),
+                      path: z.string().nullable(),
+                      line: z.number().nullable(),
+                      originalLine: z.number().nullable(),
+                      body: z.string(),
+                      author: z.object({ login: z.string() }).nullable(),
+                    })
+                  ),
+                }),
+              })
+            ),
+          }),
+        }),
+      }),
+    }),
+  })
+  .parse(JSON.parse(threadsJson));
+
+const unresolvedThreads =
+  threadsParsed.data.repository.pullRequest.reviewThreads.nodes.filter(
+    (t) => !t.isResolved
+  );
+
+const prComments = {
+  issue_comments: prView.comments.map((c) => ({
+    author: c.author?.login ?? "unknown",
+    body: c.body,
+    createdAt: c.createdAt,
+  })),
+  review_summaries: reviews
+    .filter((r) => r.body && r.body.trim().length > 0)
+    .map((r) => ({
+      author: r.user?.login ?? "unknown",
+      state: r.state,
+      body: r.body,
+      submittedAt: r.submitted_at,
+    })),
+  review_threads: unresolvedThreads.flatMap((t) =>
+    t.comments.nodes.map((c) => ({
+      commentId: c.id,
+      threadId: t.id,
+      path: c.path,
+      line: c.line ?? c.originalLine,
+      author: c.author?.login ?? "unknown",
+      body: c.body,
+    }))
+  ),
+};
+
+const result = await runWithExtraction({
+  name: `implement-pr-${PR_NUMBER}`,
+  ...claudeProfile(process.env.AFK_PROFILE),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PR_NUMBER,
+    BRANCH,
+    ISSUE_NUMBER: ISSUE_NUMBER || "(none)",
+    ISSUE_TITLE: ISSUE_TITLE || "(no linked issue)",
+    PR_COMMENTS_JSON: JSON.stringify(prComments, null, 2),
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: ImplementPrOutput,
+  }),
+  extractionPrompt: fs.readFileSync(
+    path.join(import.meta.dirname, "extraction.md"),
+    "utf8"
+  ),
+});
+
+const commitsThisRun = result.commits.length;
+const replyCount =
+  result.output.threadReplies.length +
+  result.output.newInlineComments.length +
+  result.output.topLevelComments.length;
+
+if (commitsThisRun === 0 && replyCount === 0) {
+  fail(
+    "Agent produced no commits and no replies — nothing to do for the unresolved feedback."
+  );
+}
+
+const headSha = sh("git rev-parse HEAD").trim();
+const diffLines = parseDiffLines(safeSh("git diff main...HEAD"));
+const validInlineComments = result.output.newInlineComments.filter((c) => {
+  const fileLines = diffLines.get(c.path);
+  if (!fileLines) {
+    console.warn(
+      `Dropping inline comment for ${c.path}:${c.line} — file not in diff.`
+    );
+    return false;
+  }
+  if (!fileLines.has(c.line)) {
+    console.warn(
+      `Dropping inline comment for ${c.path}:${c.line} — line not in diff hunks.`
+    );
+    return false;
+  }
+  return true;
+});
+
+const validReplyIds = new Set(
+  prComments.review_threads.map((c) => c.commentId)
+);
+const validThreadReplies = result.output.threadReplies.filter((r) => {
+  if (!validReplyIds.has(r.commentId)) {
+    console.warn(
+      `Dropping reply for commentId=${r.commentId} — not in fetched threads.`
+    );
+    return false;
+  }
+  return true;
+});
+
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "implement_thread_replies.json"),
+  JSON.stringify(validThreadReplies, null, 2)
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "implement_new_inline_comments.json"),
+  JSON.stringify(
+    {
+      commit_id: headSha,
+      comments: validInlineComments.map((c) => ({
+        path: c.path,
+        line: c.line,
+        side: c.side,
+        body: c.body,
+      })),
+    },
+    null,
+    2
+  )
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "implement_top_level_comments.json"),
+  JSON.stringify(result.output.topLevelComments, null, 2)
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "has_commits.txt"),
+  commitsThisRun > 0 ? "true" : "false"
+);
+
+console.log(`\nImplement-PR complete.`);
+console.log(`  commits this run: ${commitsThisRun}`);
+console.log(`  thread replies: ${validThreadReplies.length}`);
+console.log(`  new inline comments: ${validInlineComments.length}`);
+console.log(`  top-level comments: ${result.output.topLevelComments.length}`);
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function safeSh(cmd: string): string {
+  try {
+    return sh(cmd);
+  } catch {
+    return "";
+  }
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function fail(message: string): never {
+  console.error(`\nFAILED: ${message}`);
+  fs.writeFileSync(path.join(OUTPUT_DIR, "failure_reason.txt"), message);
+  process.exit(1);
+}

--- a/.sandcastle/implement-pr/prompt.md
+++ b/.sandcastle/implement-pr/prompt.md
@@ -1,0 +1,47 @@
+# TASK
+
+You are addressing reviewer feedback on PR #{{PR_NUMBER}} (branch `{{BRANCH}}`).
+
+Unlike a review, your job is **not** to compare the code against a spec or coding standards. Your job is to read the unresolved conversation on this PR, decide what (if anything) to change in the code, make those changes, and explain yourself by commenting back where useful.
+
+# CONTEXT
+
+Read `docs/` and any relevant ADRs under `docs/adr/` if you need domain context for a comment. Don't go deeper than the comments demand.
+
+<linked-issue>
+
+!`gh issue view {{ISSUE_NUMBER}} --comments`
+
+</linked-issue>
+
+<diff-to-main>
+
+!`git diff main..HEAD --stat`
+
+</diff-to-main>
+
+<pr-comments>
+
+The unresolved conversation on this PR. Tagged by surface:
+
+- `issue_comment` — top-level PR conversation comment.
+- `review_thread` — inline thread anchored to a file + line. Only **unresolved** threads are included. Each comment has a `commentId` you can reply to in-thread.
+- `review_summary` — top-level body of a submitted review.
+
+Not everything in here is necessarily actionable — reviewers may leave context, questions, asides, or things they meant to resolve. Use your judgement. **Do not treat unresolved == must-action.**
+
+```json
+{{PR_COMMENTS_JSON}}
+```
+
+</pr-comments>
+
+# PROCESS
+
+1. Read the conversation. For each item, classify it in your head as: code change needed, reply needed (question / disagreement / clarification), or neither.
+2. Make the code changes you decided on. Run `npm run check` before committing. Use conventional-commit messages (`feat:`, `fix:`, `refactor:`, etc.). Do NOT use a `RALPH:` prefix.
+3. If you made no changes that's fine — only commit when there's a real diff.
+
+You do not have to reply to every thread. Reply only where a reply adds value: confirming what you changed, explaining why you chose not to make a requested change, answering a question, or pointing out something the reviewer should look at. Silence is fine for context-only comments.
+
+You cannot resolve threads. Resolution is the reviewer's job.

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -1,0 +1,49 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+
+const ISSUE_NUMBER = required("ISSUE_NUMBER");
+const ISSUE_TITLE = required("ISSUE_TITLE");
+const BRANCH = required("BRANCH");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const result = await sandcastle.run({
+  name: `implement-#${ISSUE_NUMBER}`,
+  ...claudeProfile(process.env.AFK_PROFILE),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    ISSUE_NUMBER,
+    ISSUE_TITLE,
+    BRANCH,
+  },
+});
+
+const commitsAhead = Number(
+  execSync("git rev-list --count main..HEAD", { encoding: "utf8" }).trim()
+);
+if (!Number.isFinite(commitsAhead) || commitsAhead === 0) {
+  fail("Agent finished but no commits were made on the branch.");
+}
+
+console.log(
+  `\nImplementation produced ${commitsAhead} commit(s) on ${BRANCH}.`
+);
+console.log(`  commits this run: ${result.commits.length}`);
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function fail(message: string): never {
+  console.error(`\nFAILED: ${message}`);
+  fs.writeFileSync(path.join(OUTPUT_DIR, "failure_reason.txt"), message);
+  process.exit(1);
+}

--- a/.sandcastle/implement/prompt.md
+++ b/.sandcastle/implement/prompt.md
@@ -1,0 +1,31 @@
+# TASK
+
+Implement issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}
+
+You are on branch `{{BRANCH}}`, already created from `main`. Pull in the
+issue with `gh issue view {{ISSUE_NUMBER}} --comments`. If it has a
+parent PRD, pull that in too.
+
+# CONTEXT
+
+Read `docs/` and any relevant ADRs under `docs/adr/` before
+starting. Explore the repo and fill your context with the parts
+relevant to this issue — especially test files that touch the area
+you'll change.
+
+# EXECUTION
+
+Use red-green-refactor where applicable.
+
+1. RED: write one failing test
+2. GREEN: implement to pass it
+3. REPEAT until the issue is done
+4. REFACTOR
+
+Before committing, run `npm run check`.
+
+# COMMIT
+
+Make one or more git commits on `{{BRANCH}}`. Use conventional-commit messages (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`). Do NOT use a `RALPH:` prefix — that prefix is reserved for the RALPH loop.
+
+Do not close the issue yourself.

--- a/.sandcastle/review/extraction.md
+++ b/.sandcastle/review/extraction.md
@@ -1,0 +1,56 @@
+# EMIT STRUCTURED OUTPUT
+
+You have finished the review. **Do not make any further code changes** — only report what you already did.
+
+Emit a single `<output>` block as the **last thing** in your response. The block must contain valid JSON matching one of the examples below — **copy the field names exactly**.
+
+## Example: review with inline comments and thread replies
+
+<output>
+{
+  "summary": "Fixed a null-dereference in `getUser` and added a guard clause. The original code assumed `ctx.user` was always present, but it can be `undefined` after token expiry. Also flagging an unrelated naming inconsistency in `helpers.ts`.",
+  "inlineComments": [
+    {
+      "path": "app/services/auth.ts",
+      "line": 87,
+      "body": "This user! non-null assertion is the root cause — `ctx.user` is `undefined` when the token has expired. The guard clause I added on line 85 handles this."
+    },
+    {
+      "path": "app/utils/helpers.ts",
+      "line": 14,
+      "body": "Nit: `calcVal` doesn't say what it calculates. Consider `calculateDiscount`."
+    }
+  ],
+  "replies": [
+    {
+      "commentId": "PRRC_kwDOPSEf9c8AAAABX1234",
+      "body": "Good catch — fixed in my commit. I added the early-return guard you suggested."
+    }
+  ]
+}
+</output>
+
+## Example: clean review, no changes needed
+
+<output>
+{
+  "summary": "Reviewed the full diff against the spec. All stated outcomes are covered, tests pass, no edge-case gaps found. No changes needed.",
+  "inlineComments": [],
+  "replies": []
+}
+</output>
+
+## Field reference
+
+| Field                   | Type    | Required | Notes                                                                                                                                                                                                                                              |
+| ----------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `summary`               | string  | **yes**  | 1–3 short markdown paragraphs. Even on a clean review, explain why no changes were needed.                                                                                                                                                         |
+| `inlineComments`        | array   | no       | Omit or `[]` if none.                                                                                                                                                                                                                              |
+| `inlineComments[].path` | string  | **yes**  | Relative file path, e.g. `"app/foo/bar.ts"`.                                                                                                                                                                                                       |
+| `inlineComments[].line` | integer | **yes**  | A **single line number** (e.g. `42`), not a range. Must be a number, not a string. Points to the current HEAD (the diff you reviewed is unchanged). The workflow validates path+line exist in the diff; hallucinated anchors are silently dropped. |
+| `inlineComments[].body` | string  | **yes**  | Markdown comment body.                                                                                                                                                                                                                             |
+| `replies`               | array   | no       | Omit or `[]` if none.                                                                                                                                                                                                                              |
+| `replies[].commentId`   | string  | **yes**  | Must be a `commentId` from a `review_thread` you were shown. Do not invent IDs.                                                                                                                                                                    |
+| `replies[].body`        | string  | **yes**  | Markdown reply posted in-thread.                                                                                                                                                                                                                   |
+
+Do **not** add fields that aren't listed above (no `verdict`, no `file`, no `lineRange`, no `comment`). The JSON is machine-parsed; extra or renamed fields cause a validation failure.

--- a/.sandcastle/review/parse-diff-lines.ts
+++ b/.sandcastle/review/parse-diff-lines.ts
@@ -1,0 +1,41 @@
+export function parseDiffLines(diff: string): Map<string, Set<number>> {
+  const result = new Map<string, Set<number>>();
+  const lines = diff.split("\n");
+
+  let currentPath: string | null = null;
+  let inHunk = false;
+  let rightLine = 0;
+
+  for (const line of lines) {
+    const fileMatch = line.match(/^diff --git a\/.+ b\/(.+)$/);
+    if (fileMatch) {
+      currentPath = fileMatch[1]!;
+      inHunk = false;
+      if (!result.has(currentPath)) {
+        result.set(currentPath, new Set());
+      }
+      continue;
+    }
+
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      rightLine = parseInt(hunkMatch[1]!, 10);
+      inHunk = true;
+      continue;
+    }
+
+    if (!currentPath || !inHunk) continue;
+
+    if (line.startsWith("+")) {
+      result.get(currentPath)!.add(rightLine);
+      rightLine++;
+    } else if (line.startsWith("-")) {
+      // Removed line — only on left side, don't increment right counter.
+    } else if (line.startsWith(" ")) {
+      result.get(currentPath)!.add(rightLine);
+      rightLine++;
+    }
+  }
+
+  return result;
+}

--- a/.sandcastle/review/prompt.md
+++ b/.sandcastle/review/prompt.md
@@ -1,0 +1,89 @@
+# TASK
+
+Review PR #{{PR_NUMBER}} on branch `{{BRANCH}}` for issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}
+
+You are an expert code reviewer. Your job is **not just to comment** — actively improve the code on this branch, and explain what you changed.
+
+# CONTEXT
+
+Read the relevant files under `docs/` and any ADRs under `docs/adr/` before
+starting.
+
+<linked-issue>
+
+!`gh issue view {{ISSUE_NUMBER}} --comments`
+
+</linked-issue>
+
+<diff-to-main>
+
+This is a **summary** of the diff — changed files with added/removed line counts, not the full patch:
+
+!`git diff main..HEAD --stat`
+
+The full patch is deliberately omitted here because it can be very long. Go deeper on the files that matter: run `git diff main..HEAD -- <path>` on the changed files above to read the actual changes before reviewing.
+
+</diff-to-main>
+
+<pr-comments>
+
+The following PR comments have been fetched by the workflow. They are tagged by surface:
+
+- `issue_comment` — top-level PR conversation comment, not anchored to code.
+- `review_thread` — inline thread anchored to a file + line. Only **unresolved** threads are included. Each has a `commentId` you can reply to in-thread.
+- `review_summary` — top-level body of a submitted review (with approve/request-changes/comment state).
+
+```json
+{{PR_COMMENTS_JSON}}
+```
+
+</pr-comments>
+
+# REVIEW PROCESS
+
+## 1. Analyse the diff yourself
+
+Read the diff on two axes and treat your findings as the worklist for the
+steps below:
+
+- **Standards** — code quality: fragile logic, unchecked assumptions, tricky
+  conditions, implicit coercions, missing guards, deep nesting, redundant
+  abstractions, unclear names. Apply the repo's own conventions from
+  `docs/` / `AGENTS.md`.
+- **Spec** — does the branch match issue #{{ISSUE_NUMBER}}? Missing coverage,
+  scope creep, or misinterpretation should be called out (in the summary /
+  inline comments) for the human reviewer, not silently "fixed" by adding
+  code yourself.
+
+For every changed code path, stress-test the edge cases: empty/zero/negative
+inputs, missing optional fields, null/undefined, off-by-one, races, and
+regressions in adjacent functionality.
+
+## 2. Act on your findings
+
+Work through the findings from step 1 and resolve each one on this branch:
+
+- For any **correctness/robustness** finding, write a test that exercises it and try to actually break it. If you can break it, fix it. Cover the edge cases the skill flagged (empty/zero/negative inputs, missing optional fields, null/undefined, off-by-one, races, regressions in adjacent code).
+- For any **quality/standards** finding, improve the code: reduce nesting, eliminate redundancy, improve names, consolidate related logic, drop comments that restate obvious code, avoid nested ternaries (prefer if/else or switch), choose clarity over brevity. 
+- For any **spec** finding (missing coverage, scope creep, misinterpretation), do **not** silently "fix" missing spec coverage by adding code yourself — call it out in the `summary` and (where line-anchored) the inline comments for the human reviewer to decide.
+
+**Preserve functionality.** When improving code, never change what it does — only how it does it. All original features, outputs, and behaviours must remain intact.
+
+# RESPONDING TO HUMAN COMMENTS
+
+For each unresolved `review_thread` and each `issue_comment` directed at the code, choose one:
+
+- **Address** — make a code change in your commit, then reply in-thread (or with an issue comment) explaining what you did. Use the comment's `commentId` for in-thread replies.
+- **Decline** — don't change the code, but reply explaining your reasoning. Use Decline when you have a substantive disagreement (the suggestion would break something, conflicts with project standards, is out of scope).
+- **Defer** — do nothing, no reply. Only valid when the comment isn't a code-review request (jokes, off-topic banter, stale comments about already-fixed code, side conversations between humans).
+
+Default to Address. Decline when you have a real reason. Defer only when a reply would be noise.
+
+# EXECUTION
+
+1. Run `npm run check` — confirm the current state passes.
+2. Make improvements + write any new edge-case tests. Stage and commit them as a **single squashed commit** on this branch with a Conventional Commit message (e.g. `refactor: review improvements for #{{ISSUE_NUMBER}}`).
+3. Run `npm run check` again. If either fails, fix it before continuing — do not leave the branch broken.
+4. Decide which inline review comments to leave (line-anchored notes about your changes or remaining findings) and which thread replies to make.
+
+If the code is already clean and there are no human comments to address, make no commits.

--- a/.sandcastle/review/review-output.ts
+++ b/.sandcastle/review/review-output.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+export const ReviewOutput = z.object({
+  summary: z.string().min(1),
+  inlineComments: z
+    .array(
+      z
+        .object({
+          path: z.string().min(1).optional(),
+          file: z.string().min(1).optional(),
+          line: z.coerce.number().int().positive().optional(),
+          lineRange: z.string().optional(),
+          body: z.string().min(1).optional(),
+          comment: z.string().min(1).optional(),
+        })
+        .transform((c, ctx) => {
+          const path = c.path ?? c.file;
+          const body = c.body ?? c.comment;
+
+          let line = c.line;
+          if (line == null && c.lineRange != null) {
+            const match = c.lineRange.match(/^(\d+)/);
+            line = match ? parseInt(match[1]!, 10) : undefined;
+          }
+
+          if (!path) {
+            ctx.addIssue({
+              code: "custom",
+              message: "inline comment missing 'path' (or 'file')",
+            });
+            return z.NEVER;
+          }
+          if (line == null || line < 1) {
+            ctx.addIssue({
+              code: "custom",
+              message:
+                "inline comment missing 'line' (or 'lineRange' with a valid number)",
+            });
+            return z.NEVER;
+          }
+          if (!body) {
+            ctx.addIssue({
+              code: "custom",
+              message: "inline comment missing 'body' (or 'comment')",
+            });
+            return z.NEVER;
+          }
+          return { path, line, body };
+        })
+    )
+    .default([]),
+  replies: z
+    .array(
+      z.object({
+        commentId: z.string().min(1),
+        body: z.string().min(1),
+      })
+    )
+    .default([]),
+});
+
+export type ReviewOutput = z.infer<typeof ReviewOutput>;

--- a/.sandcastle/review/review.ts
+++ b/.sandcastle/review/review.ts
@@ -1,0 +1,270 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync, execFileSync } from "node:child_process";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import { parseDiffLines } from "./parse-diff-lines";
+import { ReviewOutput } from "./review-output";
+import { runWithExtraction } from "../run-with-extraction";
+
+const PR_NUMBER = required("PR_NUMBER");
+const BRANCH = required("BRANCH");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const PrView = z.object({
+  title: z.string(),
+  body: z.string().nullable().default(""),
+  headRefOid: z.string(),
+  comments: z.array(
+    z.object({
+      id: z.string().optional(),
+      author: z.object({ login: z.string() }).nullable().optional(),
+      body: z.string(),
+      createdAt: z.string().optional(),
+    })
+  ),
+});
+
+const prViewJson = sh(
+  `gh pr view ${PR_NUMBER} --json title,body,headRefOid,comments`
+);
+const prView = PrView.parse(JSON.parse(prViewJson));
+
+const issueMatch = prView.body?.match(/(?:closes|fixes|resolves)\s+#(\d+)/i);
+const ISSUE_NUMBER = issueMatch?.[1] ?? "";
+const ISSUE_TITLE = ISSUE_NUMBER
+  ? safeSh(`gh issue view ${ISSUE_NUMBER} --json title --jq .title`).trim()
+  : "";
+
+const reviewsJson = sh(
+  `gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/reviews`
+);
+const reviews = z
+  .array(
+    z.object({
+      id: z.number(),
+      user: z.object({ login: z.string() }).nullable(),
+      body: z.string().nullable().default(""),
+      state: z.string(),
+      submitted_at: z.string().nullable().optional(),
+    })
+  )
+  .parse(JSON.parse(reviewsJson));
+
+const graphqlQuery = `
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:50) {
+            nodes {
+              id
+              path
+              line
+              originalLine
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const [owner, repo] = required("GH_REPO").split("/");
+const threadsJson = execFileSync(
+  "gh",
+  [
+    "api",
+    "graphql",
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `repo=${repo}`,
+    "-F",
+    `number=${PR_NUMBER}`,
+    "-f",
+    `query=${graphqlQuery}`,
+  ],
+  { encoding: "utf8" }
+);
+const threadsParsed = z
+  .object({
+    data: z.object({
+      repository: z.object({
+        pullRequest: z.object({
+          reviewThreads: z.object({
+            nodes: z.array(
+              z.object({
+                id: z.string(),
+                isResolved: z.boolean(),
+                isOutdated: z.boolean(),
+                comments: z.object({
+                  nodes: z.array(
+                    z.object({
+                      id: z.string(),
+                      path: z.string().nullable(),
+                      line: z.number().nullable(),
+                      originalLine: z.number().nullable(),
+                      body: z.string(),
+                      author: z.object({ login: z.string() }).nullable(),
+                    })
+                  ),
+                }),
+              })
+            ),
+          }),
+        }),
+      }),
+    }),
+  })
+  .parse(JSON.parse(threadsJson));
+
+const unresolvedThreads =
+  threadsParsed.data.repository.pullRequest.reviewThreads.nodes.filter(
+    (t) => !t.isResolved
+  );
+
+const prComments = {
+  issue_comments: prView.comments.map((c) => ({
+    author: c.author?.login ?? "unknown",
+    body: c.body,
+    createdAt: c.createdAt,
+  })),
+  review_summaries: reviews
+    .filter((r) => r.body && r.body.trim().length > 0)
+    .map((r) => ({
+      author: r.user?.login ?? "unknown",
+      state: r.state,
+      body: r.body,
+      submittedAt: r.submitted_at,
+    })),
+  review_threads: unresolvedThreads.flatMap((t) =>
+    t.comments.nodes.map((c) => ({
+      commentId: c.id,
+      threadId: t.id,
+      path: c.path,
+      line: c.line ?? c.originalLine,
+      author: c.author?.login ?? "unknown",
+      body: c.body,
+    }))
+  ),
+};
+
+const result = await runWithExtraction({
+  name: `review-pr-${PR_NUMBER}`,
+  ...claudeProfile(process.env.AFK_PROFILE),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PR_NUMBER,
+    BRANCH,
+    ISSUE_NUMBER: ISSUE_NUMBER || "(none)",
+    ISSUE_TITLE: ISSUE_TITLE || "(no linked issue)",
+    PR_COMMENTS_JSON: JSON.stringify(prComments, null, 2),
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: ReviewOutput,
+  }),
+  extractionPrompt: fs.readFileSync(
+    path.join(import.meta.dirname, "extraction.md"),
+    "utf8"
+  ),
+});
+
+const verdict = result.commits.length > 0 ? "improved" : "clean";
+
+const headSha = sh("git rev-parse HEAD").trim();
+const diffLines = parseDiffLines(safeSh("git diff main...HEAD"));
+const validInlineComments = result.output.inlineComments.filter((c) => {
+  const fileLines = diffLines.get(c.path);
+  if (!fileLines) {
+    console.warn(
+      `Dropping inline comment for ${c.path}:${c.line} — file not in diff.`
+    );
+    return false;
+  }
+  if (!fileLines.has(c.line)) {
+    console.warn(
+      `Dropping inline comment for ${c.path}:${c.line} — line not in diff hunks.`
+    );
+    return false;
+  }
+  return true;
+});
+
+const validReplyIds = new Set(
+  prComments.review_threads.map((c) => c.commentId)
+);
+const validReplies = result.output.replies.filter((r) => {
+  if (!validReplyIds.has(r.commentId)) {
+    console.warn(
+      `Dropping reply for commentId=${r.commentId} — not in fetched threads.`
+    );
+    return false;
+  }
+  return true;
+});
+
+const reviewPayload = {
+  commit_id: headSha,
+  event: "COMMENT" as const,
+  body: result.output.summary,
+  comments: validInlineComments.map((c) => ({
+    path: c.path,
+    line: c.line,
+    side: "RIGHT" as const,
+    body: c.body,
+  })),
+};
+
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "review_payload.json"),
+  JSON.stringify(reviewPayload, null, 2)
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "replies.json"),
+  JSON.stringify(validReplies, null, 2)
+);
+fs.writeFileSync(path.join(OUTPUT_DIR, "summary.md"), result.output.summary);
+fs.writeFileSync(path.join(OUTPUT_DIR, "verdict.txt"), verdict);
+
+console.log(`\nReview complete.`);
+console.log(`  verdict: ${verdict}`);
+console.log(`  commits: ${result.commits.length}`);
+console.log(`  inline comments: ${validInlineComments.length}`);
+console.log(`  replies: ${validReplies.length}`);
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function safeSh(cmd: string): string {
+  try {
+    return sh(cmd);
+  } catch {
+    return "";
+  }
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function fail(message: string): never {
+  console.error(`\nFAILED: ${message}`);
+  fs.writeFileSync(path.join(OUTPUT_DIR, "failure_reason.txt"), message);
+  process.exit(1);
+}

--- a/.sandcastle/run-with-extraction.ts
+++ b/.sandcastle/run-with-extraction.ts
@@ -1,0 +1,97 @@
+import {
+  run,
+  type OutputObjectDefinition,
+  type RunOptions,
+  type RunResult,
+} from "@ai-hero/sandcastle";
+import { runWithRetry } from "./run-with-retry";
+
+/**
+ * Options for {@link runWithExtraction} — the standard `run()` options, but with
+ * `output` separated out and an `extractionPrompt` added.
+ *
+ * The `output` definition is NOT applied to the produce run (see the module
+ * docs); it is applied to the extraction run(s) instead.
+ */
+export interface RunWithExtractionOptions<T> extends Omit<
+  RunOptions,
+  "output"
+> {
+  /** Structured output to extract during the extraction pass. */
+  readonly output: OutputObjectDefinition<T>;
+  /**
+   * Prompt for the extraction pass, sent after resuming the produce session.
+   * Must contain the configured opening tag literal (e.g. `<output>`), since
+   * Sandcastle requires the resolved prompt to contain it.
+   */
+  readonly extractionPrompt: string;
+  /** Maximum number of extraction attempts before giving up. Default: 3. */
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Run an agent in two phases to make structured output reliable.
+ *
+ * The brittle part of structured output is asking the agent to both *do the
+ * work* and *emit rigid JSON* in a single turn — it frequently returns
+ * malformed JSON or omits the `<output>` tag, and a single failure aborts the
+ * whole run. This wrapper splits the two concerns, which matters when the
+ * produce phase has side effects we must not repeat (commits, issue creation):
+ *
+ * 1. **Produce.** Run the agent on `prompt`/`promptFile` with NO `output`
+ *    definition, so `run()` never throws on extraction and we keep the
+ *    resumable `sessionId`. The produce prompt should contain no JSON-emission
+ *    instructions — it just does the work and reasons in prose.
+ * 2. **Extract.** Resume that session with `extractionPrompt` and the `output`
+ *    definition, retrying via {@link runWithRetry}: the first attempt resumes
+ *    the produce session; any retry resumes the *failed extraction's* own
+ *    session with feedback, so the correction happens in-context without
+ *    re-doing the work or re-sending the prompt.
+ *
+ * Returns the produce run's result (commits, branch, stdout) with the
+ * extraction run's `output` — extraction must not commit, so the produce
+ * commits are the source of truth for callers that inspect `commits`.
+ *
+ * Throws the final `StructuredOutputError` if every attempt fails, which
+ * mirrors the pre-wrapper failure path (the workflow marks the PR/issue
+ * blocked).
+ *
+ * For side-effect-free scripts where the output *is* the work, prefer
+ * {@link runWithRetry} directly — there's no work to preserve, so the produce
+ * pass is pure overhead.
+ */
+export async function runWithExtraction<T>(
+  options: RunWithExtractionOptions<T>
+): Promise<RunResult & { output: T }> {
+  const { output, extractionPrompt, maxAttempts, ...produceOptions } = options;
+
+  const produce = await run(produceOptions);
+
+  const sessionId = produce.iterations.at(-1)?.sessionId;
+  if (!sessionId) {
+    throw new Error(
+      "runWithExtraction: produce run returned no sessionId, so the extraction " +
+        "pass cannot resume it. Session capture must be enabled (Claude Code " +
+        "provider with sessions written to the host)."
+    );
+  }
+
+  // The extraction pass uses an inline `prompt` (extractionPrompt), so drop the
+  // produce phase's `promptArgs` — Sandcastle only allows promptArgs alongside
+  // a promptFile, and the extraction prompt needs no substitution.
+  const { promptArgs: _produceArgs, ...extractionOptions } = produceOptions;
+
+  const extraction = await runWithRetry({
+    ...extractionOptions,
+    name: produceOptions.name ? `${produceOptions.name} (extract)` : undefined,
+    promptFile: undefined,
+    prompt: extractionPrompt,
+    resumeSession: sessionId,
+    output,
+    maxAttempts,
+  });
+
+  // Commits/branch come from the produce run (extraction does no work); only
+  // the structured output comes from the extraction pass.
+  return { ...produce, output: extraction.output };
+}

--- a/.sandcastle/update-branch/extraction.md
+++ b/.sandcastle/update-branch/extraction.md
@@ -1,0 +1,13 @@
+# EMIT STRUCTURED OUTPUT
+
+You have resolved the conflicts and committed the merge. **Do not make any further changes** — only report what you did.
+
+Emit a single block as the last thing in your response:
+
+<output>
+{
+  "comment": "Markdown body posted as a PR comment. Free-form prose. Describe which conflicts existed, how you resolved each, and flag any uncertainty or remaining problems (e.g. typecheck failures, ambiguous intent). Reference commit SHAs or file paths where useful."
+}
+</output>
+
+The comment is the only safety net for the human author. Write it like you're handing the branch back to them and want them to be able to spot any bad call you made in 30 seconds.

--- a/.sandcastle/update-branch/prompt.md
+++ b/.sandcastle/update-branch/prompt.md
@@ -1,0 +1,41 @@
+# TASK
+
+PR #{{PR_NUMBER}} (branch `{{BRANCH}}`) has merge conflicts against its base `{{BASE_REF}}`. A `git merge origin/{{BASE_REF}} --no-edit` has already been attempted and left the working tree in a conflicted state. Your job is to resolve every conflict, finish the merge, and write a PR comment describing what you did.
+
+# CONTEXT
+
+Read `docs/` and any relevant ADRs under `docs/adr/` before resolving anything substantive.
+
+<pr-view>
+
+!`gh pr view {{PR_NUMBER}}`
+
+</pr-view>
+
+<merge-status>
+
+!`git status`
+
+</merge-status>
+
+<conflicting-files>
+
+!`git diff --name-only --diff-filter=U`
+
+</conflicting-files>
+
+# RESOLUTION POLICY
+
+Always resolve. Do not abort the merge. Do not leave the branch in a half-finished state.
+
+For each conflicting hunk:
+
+1. **Investigate intent on both sides** before choosing a resolution. Use `git log -p --follow -- <path>` on both `origin/{{BASE_REF}}` and `{{BRANCH}}` to see how each side reached this state. Read the commit messages. If a commit references an issue, pull it with `gh issue view <n>`.
+2. **Pick the resolution that preserves both intents** wherever possible. Where the intents are incompatible, pick the one that best matches the PR's stated goal (in `<pr-view>` above) and note the trade-off in your comment.
+3. **Do not invent new behaviour.** Your job is reconciliation, not feature work. If a sensible resolution requires writing new logic that wasn't on either side, that's a signal to flag uncertainty rather than to be creative.
+
+After resolving, run whatever checks you think are warranted — `npm run check` is fast and catches most resolution mistakes; `npm run check` if you want stronger confidence. You decide. If something is broken, fix what you can; if you can't, push what you have and flag it clearly in the comment.
+
+# COMMIT
+
+Stage everything and finish the merge with a single commit. Conventional-commit style, e.g. `chore: merge origin/{{BASE_REF}} into {{BRANCH}}`. The wrapper will push whatever you commit.

--- a/.sandcastle/update-branch/update-branch.ts
+++ b/.sandcastle/update-branch/update-branch.ts
@@ -1,0 +1,131 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync, execFileSync } from "node:child_process";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import { runWithExtraction } from "../run-with-extraction";
+
+const PR_NUMBER = required("PR_NUMBER");
+const BRANCH = required("BRANCH");
+const BASE_REF = required("BASE_REF");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+execFileSync("git", ["fetch", "origin", BASE_REF], { stdio: "inherit" });
+
+const preMergeSha = sh("git rev-parse HEAD").trim();
+const baseSha = sh(`git rev-parse origin/${BASE_REF}`).trim();
+
+const mergeBase = sh(`git merge-base HEAD origin/${BASE_REF}`).trim();
+if (mergeBase === baseSha) {
+  writeComment(
+    `\`agent:update-branch\`: branch is already up to date with \`origin/${BASE_REF}\`. No merge needed.`
+  );
+  writeNoPush();
+  console.log("Already up to date — nothing to do.");
+  process.exit(0);
+}
+
+const mergeResult = tryMerge();
+
+if (mergeResult.status === "clean") {
+  writeComment(
+    `\`agent:update-branch\`: merged \`origin/${BASE_REF}\` (\`${baseSha.slice(0, 7)}\`) into \`${BRANCH}\` cleanly — no conflicts.`
+  );
+  writePush();
+  console.log("Clean merge — wrapper will push.");
+  process.exit(0);
+}
+
+console.log(
+  `Merge produced conflicts in ${mergeResult.conflicts.length} file(s) — invoking agent.`
+);
+
+const PromptOutput = z.object({
+  comment: z.string().min(1),
+});
+
+const result = await runWithExtraction({
+  name: `update-branch-pr-${PR_NUMBER}`,
+  ...claudeProfile(process.env.AFK_PROFILE),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PR_NUMBER,
+    BRANCH,
+    BASE_REF,
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: PromptOutput,
+  }),
+  extractionPrompt: fs.readFileSync(
+    path.join(import.meta.dirname, "extraction.md"),
+    "utf8"
+  ),
+});
+
+const postSha = sh("git rev-parse HEAD").trim();
+if (postSha === preMergeSha) {
+  fail("Agent produced no commits — branch still at pre-merge HEAD.");
+}
+
+const unresolved = sh("git diff --name-only --diff-filter=U").trim();
+if (unresolved) {
+  fail(`Agent left unresolved conflicts in:\n${unresolved}`);
+}
+
+writeComment(result.output.comment);
+writePush();
+console.log(`Agent resolved conflicts. Wrapper will push ${postSha}.`);
+
+function tryMerge():
+  | { status: "clean" }
+  | { status: "conflict"; conflicts: string[] } {
+  try {
+    execFileSync("git", ["merge", `origin/${BASE_REF}`, "--no-edit"], {
+      stdio: "inherit",
+    });
+    return { status: "clean" };
+  } catch {
+    const conflicts = sh("git diff --name-only --diff-filter=U")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (conflicts.length === 0) {
+      fail("git merge failed but no conflicts reported — aborting.");
+    }
+    return { status: "conflict", conflicts };
+  }
+}
+
+function writeComment(body: string): void {
+  fs.writeFileSync(path.join(OUTPUT_DIR, "comment.md"), body);
+}
+
+function writePush(): void {
+  fs.writeFileSync(path.join(OUTPUT_DIR, "should_push.txt"), "true");
+}
+
+function writeNoPush(): void {
+  fs.writeFileSync(path.join(OUTPUT_DIR, "should_push.txt"), "false");
+}
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function fail(message: string): never {
+  console.error(`\nFAILED: ${message}`);
+  fs.writeFileSync(path.join(OUTPUT_DIR, "failure_reason.txt"), message);
+  process.exit(1);
+}

--- a/.sandcastle/write-pr/prompt.md
+++ b/.sandcastle/write-pr/prompt.md
@@ -1,0 +1,43 @@
+# TASK
+
+Write the title and description for a pull request that closes issue #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}.
+
+The implementation is already done — commits sit on branch
+`{{BRANCH}}`. You are NOT implementing anything. You are NOT running
+tests. You are summarising work that already exists.
+
+# CONTEXT
+
+Read the issue:
+
+```
+gh issue view {{ISSUE_NUMBER}} --comments
+```
+
+Read what changed on the branch:
+
+```
+git log main..{{BRANCH}} --reverse
+git diff main..{{BRANCH}} --stat
+git diff main..{{BRANCH}}
+```
+
+If the diff is large, focus on the commit messages and the `--stat`
+summary; only `git diff` specific files when a commit message is
+unclear.
+
+Draft the title and description from what you read.
+
+# OUTPUT
+
+Once you've read everything, emit a single `<output>` block as the **last thing** in your response:
+
+<output>
+{
+  "prTitle": "feat: short imperative summary",
+  "prDescription": "## Summary\n\n- bullet 1\n- bullet 2\n\nCloses #{{ISSUE_NUMBER}}"
+}
+</output>
+
+- `prTitle` must be a single line, under 70 characters, conventional-commit style (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`).
+- `prDescription` must include `Closes #{{ISSUE_NUMBER}}` so the PR closes the issue on merge.

--- a/.sandcastle/write-pr/write-pr.ts
+++ b/.sandcastle/write-pr/write-pr.ts
@@ -1,0 +1,50 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { claudeProfile } from "../profile.js";
+import { runWithRetry } from "../run-with-retry";
+
+const ISSUE_NUMBER = required("ISSUE_NUMBER");
+const ISSUE_TITLE = required("ISSUE_TITLE");
+const BRANCH = required("BRANCH");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const PromptOutput = z.object({
+  prTitle: z.string().min(1).max(256),
+  prDescription: z.string().min(1),
+});
+
+const result = await runWithRetry({
+  name: `write-pr-#${ISSUE_NUMBER}`,
+  ...claudeProfile(process.env.AFK_PROFILE),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    ISSUE_NUMBER,
+    ISSUE_TITLE,
+    BRANCH,
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: PromptOutput,
+  }),
+});
+
+fs.writeFileSync(path.join(OUTPUT_DIR, "pr_title.txt"), result.output.prTitle);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "pr_description.txt"),
+  result.output.prDescription
+);
+
+console.log(`\nWrote PR metadata to ${OUTPUT_DIR}`);
+console.log(`  title: ${result.output.prTitle}`);
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}

--- a/tests/parse-diff-lines.test.ts
+++ b/tests/parse-diff-lines.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { parseDiffLines } from "../.sandcastle/review/parse-diff-lines.js";
+
+const simpleDiff = `diff --git a/app/foo.ts b/app/foo.ts
+index abc1234..def5678 100644
+--- a/app/foo.ts
++++ b/app/foo.ts
+@@ -10,6 +10,8 @@ some context
+ context line 10
+ context line 11
++added line 12
++added line 13
+ context line 14
+ context line 15
+ context line 16
+ context line 17
+`;
+
+const multiFileDiff = `diff --git a/app/alpha.ts b/app/alpha.ts
+index 1111111..2222222 100644
+--- a/app/alpha.ts
++++ b/app/alpha.ts
+@@ -1,3 +1,4 @@
+ line 1
++inserted line 2
+ line 3
+ line 4
+diff --git a/app/beta.ts b/app/beta.ts
+index 3333333..4444444 100644
+--- a/app/beta.ts
++++ b/app/beta.ts
+@@ -5,4 +5,3 @@ header
+ context 5
+-removed 6
+ context 6
+ context 7
+`;
+
+const deletionOnlyDiff = `diff --git a/app/del.ts b/app/del.ts
+index aaa..bbb 100644
+--- a/app/del.ts
++++ b/app/del.ts
+@@ -1,4 +1,3 @@
+ keep 1
+-remove 2
+ keep 2
+ keep 3
+`;
+
+const multiHunkDiff = `diff --git a/app/multi.ts b/app/multi.ts
+index aaa..bbb 100644
+--- a/app/multi.ts
++++ b/app/multi.ts
+@@ -2,3 +2,4 @@ header
+ ctx 2
++add 3
+ ctx 4
+@@ -20,3 +21,4 @@ header2
+ ctx 21
++add 22
+ ctx 23
+`;
+
+const newFileDiff = `diff --git a/app/new.ts b/app/new.ts
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/app/new.ts
+@@ -0,0 +1,3 @@
++line 1
++line 2
++line 3
+`;
+
+const noNewlineDiff = `diff --git a/app/trail.ts b/app/trail.ts
+index abc..def 100644
+--- a/app/trail.ts
++++ b/app/trail.ts
+@@ -1,3 +1,3 @@
+ line 1
+-old line 2
++new line 2
+ line 3
+\\ No newline at end of file
+`;
+
+const modeOnlyDiff = `diff --git a/app/script.sh b/app/script.sh
+old mode 100644
+new mode 100755
+`;
+
+const renamedFileDiff = `diff --git a/app/old-name.ts b/app/new-name.ts
+similarity index 80%
+rename from app/old-name.ts
+rename to app/new-name.ts
+index abc..def 100644
+--- a/app/old-name.ts
++++ b/app/new-name.ts
+@@ -1,3 +1,4 @@
+ line 1
++added line 2
+ line 3
+ line 4
+`;
+
+const binaryFileDiff = `diff --git a/assets/logo.png b/assets/logo.png
+new file mode 100644
+index 0000000..abc1234
+Binary files /dev/null and b/assets/logo.png differ
+`;
+
+const contentStartingWithPlusDiff = `diff --git a/app/plus.ts b/app/plus.ts
+index abc..def 100644
+--- a/app/plus.ts
++++ b/app/plus.ts
+@@ -1,2 +1,3 @@
+ line 1
++++ added content starting with double plus
+ line 2
+`;
+
+describe("parseDiffLines", () => {
+  it("returns valid right-side line numbers from a simple diff", () => {
+    const result = parseDiffLines(simpleDiff);
+    const fooLines = result.get("app/foo.ts");
+    expect(fooLines).toBeDefined();
+    // context lines 10, 11 + added 12, 13 + context 14, 15, 16, 17
+    expect(fooLines).toEqual(new Set([10, 11, 12, 13, 14, 15, 16, 17]));
+  });
+
+  it("handles multiple files", () => {
+    const result = parseDiffLines(multiFileDiff);
+    expect(result.get("app/alpha.ts")).toEqual(new Set([1, 2, 3, 4]));
+    // beta: context 5, context 6 (was 7), context 7 (was 8). Removed line doesn't appear.
+    expect(result.get("app/beta.ts")).toEqual(new Set([5, 6, 7]));
+  });
+
+  it("handles deletion-only hunks (only context lines on right side)", () => {
+    const result = parseDiffLines(deletionOnlyDiff);
+    expect(result.get("app/del.ts")).toEqual(new Set([1, 2, 3]));
+  });
+
+  it("handles multiple hunks in one file", () => {
+    const result = parseDiffLines(multiHunkDiff);
+    const lines = result.get("app/multi.ts");
+    expect(lines).toEqual(new Set([2, 3, 4, 21, 22, 23]));
+  });
+
+  it("returns empty map for empty diff", () => {
+    expect(parseDiffLines("")).toEqual(new Map());
+  });
+
+  it("returns empty map for whitespace-only diff", () => {
+    expect(parseDiffLines("   \n\n  ")).toEqual(new Map());
+  });
+
+  it("handles new file diffs", () => {
+    const result = parseDiffLines(newFileDiff);
+    expect(result.get("app/new.ts")).toEqual(new Set([1, 2, 3]));
+  });
+
+  it("skips the no-newline-at-end-of-file marker without breaking line counts", () => {
+    const result = parseDiffLines(noNewlineDiff);
+    expect(result.get("app/trail.ts")).toEqual(new Set([1, 2, 3]));
+  });
+
+  it("handles mode-only changes with no hunks", () => {
+    const result = parseDiffLines(modeOnlyDiff);
+    expect(result.get("app/script.sh")).toEqual(new Set());
+  });
+
+  it("handles renamed files using the new path", () => {
+    const result = parseDiffLines(renamedFileDiff);
+    expect(result.has("app/old-name.ts")).toBe(false);
+    expect(result.get("app/new-name.ts")).toEqual(new Set([1, 2, 3, 4]));
+  });
+
+  it("handles binary files with no line content", () => {
+    const result = parseDiffLines(binaryFileDiff);
+    expect(result.get("assets/logo.png")).toEqual(new Set());
+  });
+
+  it("handles added lines whose content starts with ++", () => {
+    const result = parseDiffLines(contentStartingWithPlusDiff);
+    expect(result.get("app/plus.ts")).toEqual(new Set([1, 2, 3]));
+  });
+});


### PR DESCRIPTION
## Summary

Port the reference's 6 label-driven development Actions, adapted to the server's self-hosted runner + profile-backed docker sandboxes:

| workflow | trigger | entrypoint |
|---|---|---|
| agent-implement | issue `agent:implement` | implement.ts + write-pr.ts |
| agent-review | PR `agent:review` | review.ts |
| agent-implement-pr | PR `agent:implement` | implement-pr.ts |
| agent-update-branch | PR `agent:update-branch` | update-branch.ts |
| agent-promote-queued | issue closed | label promotion |
| architecture-review | cron daily | architecture-review.ts |

**Adaptations** (vs the upstream):
- `runs-on: self-hosted`; manual checkout that keeps runner `HOME` stable so the managed git hooks work (same pattern as the existing agent-implement-prd.yml).
- Agents use `claudeProfile(AFK_PROFILE)` (server profiles: claude-ark/psydo/aliyun) instead of `CLAUDE_CODE_OAUTH_TOKEN`.
- `npm ci` / `npm exec tsx` instead of pnpm; verification `npm run check`.
- review prompt made self-contained (no `code-review` skill / CODING_STANDARDS dependency — not present in the container); `RALPH:` prefixes replaced with Conventional Commits.
- Ported `run-with-extraction.ts`; moved `parse-diff-lines.test.ts` into `tests/`.

## Verification
- `npm run typecheck` clean; full `npm run check` green (54 files / 395 tests).
- All 6 workflow YAMLs parse.
- Self-hosted runner + `AGENT_PAT` secret needed for the Actions to fire (repo-level; the Auto_Test runner is already registered).