### PR TITLE
feat(afk): bake coding standards + code-review skill into the AFK loop

### DIFF
--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -1,0 +1,50 @@
+# Auto-Test Coding Standards
+
+Project-local engineering standards applied by the AFK implement and review
+prompts. Deviations need an explicit reason.
+
+## Correctness & safety
+
+- **Fail-closed contracts are sacred.** AgentHost, evidence, Mutation Ledger,
+  and result contracts must never be weakened, skipped, or silently bypassed.
+  Do not invent a parallel runtime contract.
+- Handle errors explicitly; never swallow them. Throw/surface with a clear
+  message; log useful context.
+- Validate all external input (files, URLs, env, API payloads) at boundaries.
+- Never put secrets (API keys, tokens, credentials) in code, prompts, logs, or
+  GitHub. Read them from env / server-local config.
+- Preserve functionality on refactor: change *how*, not *what*. Keep tests
+  passing.
+
+## TypeScript & structure
+
+- Strict TypeScript. Use the repo's `tsconfig` (exact optional property types
+  etc.) — write types that satisfy it, not `any` escapes.
+- Functions small and focused; files cohesive; prefer small modules over big
+  ones (the repo splits by feature/domain, e.g. `src/agent`, `src/workflow`).
+- Favor immutable patterns: return new objects instead of mutating inputs.
+- Early returns over deep nesting. Clear names: camelCase fns/vars,
+  PascalCase types, UPPER_SNAKE_CASE constants.
+- Reuse existing utilities (run-directory, model-profile, host-registry, etc.)
+  instead of re-deriving the same logic.
+
+## Tests
+
+- Add/update focused tests for behavior you change (vitest, in `tests/`).
+- Preserve the deterministic check gate: `npm run check`
+  (typecheck + tests + build) must stay green.
+- No skipping or weakening tests to make CI pass.
+
+## CLI & contracts
+
+- The `easy` CLI surface and its help text are user-visible contracts: don't
+  remove or rename documented commands/flags without updating help + tests.
+- Public schemas and state files (`codex-agent.state.json`, build-info, etc.)
+  are contracts: changing shape requires updating readers + tests.
+
+## Deliverables
+
+- Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`,
+  `chore:`). No `RALPH:` prefix.
+- `git diff --check` clean; no dead code, commented-out blocks, or debug
+  leftovers.

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -45,6 +45,12 @@ RUN npm install --global @anthropic-ai/claude-code \
   && chmod 755 /usr/local/bin/claude \
   && npm cache clean --force
 
+# code-review skill (two-axis Standards/Spec review via parallel sub-agents),
+# used by the review prompts. Source lives in .sandcastle/skills/code-review.
+COPY skills/code-review /opt/code-review
+RUN mkdir -p /home/agent/.claude/skills && cp -r /opt/code-review /home/agent/.claude/skills/code-review \
+  && chown -R ${AGENT_UID}:${AGENT_GID} /home/agent/.claude
+
 USER ${AGENT_UID}:${AGENT_GID}
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 WORKDIR /home/agent

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -8,9 +8,9 @@ PRD, pull that in too. Only work on the issue specified.
 # CONTEXT
 
 Read the relevant files under `docs/` and any ADRs under `docs/adr/` before
-starting. Explore the repo and fill your context window with the parts
-relevant to this issue — especially test files that touch the area you'll
-change.
+starting. Apply the project's `.sandcastle/CODING_STANDARDS.md`. Explore the
+repo and fill your context window with the parts relevant to this issue —
+especially test files that touch the area you'll change.
 
 # EXPLORATION
 

--- a/.sandcastle/implement/prompt.md
+++ b/.sandcastle/implement/prompt.md
@@ -8,8 +8,8 @@ parent PRD, pull that in too.
 
 # CONTEXT
 
-Read `docs/` and any relevant ADRs under `docs/adr/` before
-starting. Explore the repo and fill your context with the parts
+Read `docs/`, `.sandcastle/CODING_STANDARDS.md`, and any relevant ADRs under
+`docs/adr/` before starting. Explore the repo and fill your context with the parts
 relevant to this issue — especially test files that touch the area
 you'll change.
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -44,6 +44,9 @@ Write tests for anything that isn't already covered.
 
 ## 3. Analyze for code quality improvements
 
+Apply the project's `.sandcastle/CODING_STANDARDS.md` alongside these
+opportunities:
+
 Look for opportunities to:
 
 - Reduce unnecessary complexity and nesting

--- a/.sandcastle/review/prompt.md
+++ b/.sandcastle/review/prompt.md
@@ -6,8 +6,7 @@ You are an expert code reviewer. Your job is **not just to comment** — activel
 
 # CONTEXT
 
-Read the relevant files under `docs/` and any ADRs under `docs/adr/` before
-starting.
+Read `docs/`, `.sandcastle/CODING_STANDARDS.md`, and any relevant ADRs under `docs/adr/` before starting.
 
 <linked-issue>
 
@@ -41,30 +40,24 @@ The following PR comments have been fetched by the workflow. They are tagged by 
 
 # REVIEW PROCESS
 
-## 1. Analyse the diff yourself
+## 1. Analyse with the `code-review` skill
 
-Read the diff on two axes and treat your findings as the worklist for the
-steps below:
+Use the **`code-review` skill** (installed globally at `~/.claude/skills/code-review`) to produce the review. It analyses the diff along two axes — **Standards** and **Spec** — using parallel sub-agents. Its findings are the **single source of truth** for what's wrong with this branch: act only on what it reports, not on a separate ad-hoc pass of your own.
 
-- **Standards** — code quality: fragile logic, unchecked assumptions, tricky
-  conditions, implicit coercions, missing guards, deep nesting, redundant
-  abstractions, unclear names. Apply the repo's own conventions from
-  `docs/` / `AGENTS.md`.
-- **Spec** — does the branch match issue #{{ISSUE_NUMBER}}? Missing coverage,
-  scope creep, or misinterpretation should be called out (in the summary /
-  inline comments) for the human reviewer, not silently "fixed" by adding
-  code yourself.
+Invoke it with everything it needs, so it does **not** run its own discovery and does **not** prompt or pause:
 
-For every changed code path, stress-test the edge cases: empty/zero/negative
-inputs, missing optional fields, null/undefined, off-by-one, races, and
-regressions in adjacent functionality.
+- **Fixed point:** `main`. The diff to review is `git diff main...HEAD`. Do not ask for a fixed point — it is `main`.
+- **Spec:** issue #{{ISSUE_NUMBER}} — already fetched above in `<linked-issue>`. Pass this as the spec. Do **not** look for `docs/agents/issue-tracker.md` and do **not** run `/setup-matt-pocock-skills`; the spec is provided. If the linked issue is a **PRD** (it has sub-issues), pull them with `gh api repos/$GH_REPO/issues/{{ISSUE_NUMBER}}/sub_issues` and treat each closed sub-issue as a sub-requirement; code for an _open_ sub-issue is a scope violation.
+- **Standards:** `.sandcastle/CODING_STANDARDS.md` is this repo's documented standard — feed it as the standards source. The skill's built-in smell baseline applies on top, but a documented repo standard always wins.
 
-## 2. Act on your findings
+The skill is read-only and produces a report; it does not edit code. That report — its Standards findings and its Spec findings — is your worklist for the steps below.
 
-Work through the findings from step 1 and resolve each one on this branch:
+## 2. Act on the skill's findings
+
+Work through the skill's findings and resolve each one on this branch:
 
 - For any **correctness/robustness** finding, write a test that exercises it and try to actually break it. If you can break it, fix it. Cover the edge cases the skill flagged (empty/zero/negative inputs, missing optional fields, null/undefined, off-by-one, races, regressions in adjacent code).
-- For any **quality/standards** finding, improve the code: reduce nesting, eliminate redundancy, improve names, consolidate related logic, drop comments that restate obvious code, avoid nested ternaries (prefer if/else or switch), choose clarity over brevity. 
+- For any **quality/standards** finding, improve the code: reduce nesting, eliminate redundancy, improve names, consolidate related logic, drop comments that restate obvious code, avoid nested ternaries (prefer if/else or switch), choose clarity over brevity. Apply `.sandcastle/CODING_STANDARDS.md`.
 - For any **spec** finding (missing coverage, scope creep, misinterpretation), do **not** silently "fix" missing spec coverage by adding code yourself — call it out in the `summary` and (where line-anchored) the inline comments for the human reviewer to decide.
 
 **Preserve functionality.** When improving code, never change what it does — only how it does it. All original features, outputs, and behaviours must remain intact.
@@ -82,7 +75,7 @@ Default to Address. Decline when you have a real reason. Defer only when a reply
 # EXECUTION
 
 1. Run `npm run check` — confirm the current state passes.
-2. Make improvements + write any new edge-case tests. Stage and commit them as a **single squashed commit** on this branch with a Conventional Commit message (e.g. `refactor: review improvements for #{{ISSUE_NUMBER}}`).
+2. Make improvements + write any new edge-case tests. Stage and commit them as a **single squashed commit** on this branch with a message starting with `refactor: review improvements`.
 3. Run `npm run check` again. If either fails, fix it before continuing — do not leave the branch broken.
 4. Decide which inline review comments to leave (line-anchored notes about your changes or remaining findings) and which thread replies to make.
 

--- a/.sandcastle/run-with-extraction.ts
+++ b/.sandcastle/run-with-extraction.ts
@@ -4,7 +4,7 @@ import {
   type RunOptions,
   type RunResult,
 } from "@ai-hero/sandcastle";
-import { runWithRetry } from "./run-with-retry";
+import { runWithRetry } from "./run-with-retry.js";
 
 /**
  * Options for {@link runWithExtraction} — the standard `run()` options, but with
@@ -77,18 +77,18 @@ export async function runWithExtraction<T>(
   }
 
   // The extraction pass uses an inline `prompt` (extractionPrompt), so drop the
-  // produce phase's `promptArgs` — Sandcastle only allows promptArgs alongside
-  // a promptFile, and the extraction prompt needs no substitution.
-  const { promptArgs: _produceArgs, ...extractionOptions } = produceOptions;
+  // produce phase's `promptArgs` and `promptFile` — Sandcastle only allows
+  // promptArgs alongside a promptFile, and the extraction prompt needs no
+  // substitution.
+  const { promptArgs: _produceArgs, promptFile: _produceFile, ...extractionOptions } = produceOptions;
 
   const extraction = await runWithRetry({
     ...extractionOptions,
-    name: produceOptions.name ? `${produceOptions.name} (extract)` : undefined,
-    promptFile: undefined,
+    ...(produceOptions.name ? { name: `${produceOptions.name} (extract)` } : {}),
     prompt: extractionPrompt,
     resumeSession: sessionId,
     output,
-    maxAttempts,
+    ...(maxAttempts !== undefined ? { maxAttempts } : {}),
   });
 
   // Commits/branch come from the produce run (extraction does no work); only

--- a/.sandcastle/skills/code-review/SKILL.md
+++ b/.sandcastle/skills/code-review/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: code-review
+description: "Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes: Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/spec asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to \"review since X\"."
+---
+
+Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+- **Standards**: does the code conform to this repo's documented coding standards?
+- **Spec**: does the code faithfully implement the originating issue / spec?
+
+Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+The issue tracker should have been provided to you. If `docs/agents/issue-tracker.md` is missing, tell the user to run `/setup-matt-pocock-skills`.
+
+## Process
+
+### 1. Pin the fixed point
+
+Whatever the user said is the fixed point (a commit SHA, branch name, tag, `main`, `HEAD~5`, etc.). If they didn't specify one, ask for it.
+
+Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here, not inside two parallel sub-agents.
+
+### 2. Identify the spec source
+
+Look for the originating spec, in this order:
+
+1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.), fetched via the workflow in `docs/agents/issue-tracker.md`.
+2. A path the user passed as an argument.
+3. A spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
+
+### 3. Identify the standards sources
+
+Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+On top of whatever the repo documents, the Standards axis always carries the **smell baseline** below: a fixed set of Fowler code smells (_Refactoring_, ch.3) that applies even when a repo documents nothing. Two rules bind it:
+
+- **The repo overrides.** A documented repo standard always wins; where it endorses something the baseline would flag, suppress the smell.
+- **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation. Like any standard here, skip anything tooling already enforces.
+
+Each smell reads *what it is* → *how to fix*; match it against the diff:
+
+- **Mysterious Name**: a function, variable, or type whose name doesn't reveal what it does or holds. → rename it; if no honest name comes, the design's murky.
+- **Duplicated Code**: the same logic shape appears in more than one hunk or file in the change. → extract the shared shape, call it from both.
+- **Feature Envy**: a method that reaches into another object's data more than its own. → move the method onto the data it envies.
+- **Data Clumps**: the same few fields or params keep travelling together (a type wanting to be born). → bundle them into one type, pass that.
+- **Primitive Obsession**: a primitive or string standing in for a domain concept that deserves its own type. → give the concept its own small type.
+- **Repeated Switches**: the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, or one map both sites share.
+- **Shotgun Surgery**: one logical change forces scattered edits across many files in the diff. → gather what changes together into one module.
+- **Divergent Change**: one file or module is edited for several unrelated reasons. → split so each module changes for one reason.
+- **Speculative Generality**: abstraction, parameters, or hooks added for needs the spec doesn't have. → delete it; inline back until a real need shows.
+- **Message Chains**: long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+- **Middle Man**: a class or function that mostly just delegates onward. → cut it, call the real target direct.
+- **Refused Bequest**: a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
+
+### 4. Spawn both sub-agents in parallel
+
+**Standards sub-agent prompt** should include:
+
+- The full diff command and commit list.
+- The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full (the sub-agent has no other access to it).
+- The brief: "Report, per file/hunk where relevant, (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls: documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words."
+
+**Spec sub-agent prompt** should include:
+
+- The diff command and commit list.
+- The path or fetched contents of the spec.
+- The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+
+If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+### 5. Aggregate
+
+Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings, because the two axes are deliberately separate (see _Why two axes_).
+
+End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes: that's the reranking the separation exists to prevent.
+
+## Why two axes
+
+A change can pass one axis and fail the other:
+
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+Reporting them separately stops one axis from masking the other.

--- a/.sandcastle/skills/code-review/agents/openai.yaml
+++ b/.sandcastle/skills/code-review/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Code Review"
+  short_description: "Review a diff on standards and spec"

--- a/tests/no-recent-commits.test.ts
+++ b/tests/no-recent-commits.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const SANDCASTLE_DIR = resolve(import.meta.dirname, "../.sandcastle");
+
+const promptFiles = readdirSync(SANDCASTLE_DIR, { recursive: true })
+  .filter(
+    (f): f is string =>
+      typeof f === "string" &&
+      f.endsWith(".md") &&
+      // worktrees/ holds throwaway repo checkouts with stale prompt copies —
+      // not part of this repo's prompts. (Also excluded from vitest collection
+      // in vite.config.ts, but that doesn't govern files a test reads itself.)
+      !f.split(/[/\\]/).includes("worktrees")
+  )
+  .map((rel) => [rel, join(SANDCASTLE_DIR, rel)] as const);
+
+describe("sandcastle prompts", () => {
+  it.each(promptFiles)(
+    "%s must not contain a <recent-commits> section",
+    (_rel, abs) => {
+      const content = readFileSync(abs, "utf-8");
+      expect(content).not.toMatch(/<recent-commits>/);
+    }
+  );
+});

--- a/tests/run-with-extraction.test.ts
+++ b/tests/run-with-extraction.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { run, StructuredOutputError, Output } from "@ai-hero/sandcastle";
+import { z } from "zod";
+import { runWithExtraction } from "../.sandcastle/run-with-extraction.js";
+
+vi.mock("@ai-hero/sandcastle", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@ai-hero/sandcastle")>();
+  return { ...actual, run: vi.fn() };
+});
+
+const mockRun = vi.mocked(run);
+
+const schema = z.object({ value: z.string() });
+const output = Output.object({ tag: "output", schema });
+
+function baseOptions() {
+  return {
+    name: "test-run",
+    agent: {} as never,
+    sandbox: {} as never,
+    promptFile: "/repo/prompt.md",
+    output,
+    extractionPrompt: "Emit the <output> block.",
+  };
+}
+
+function produceResult(sessionId: string = "sess-1") {
+  return {
+    iterations: [{ sessionId }],
+    stdout: "produce stdout",
+    commits: [{ sha: "abc123" }],
+    branch: "feat/x",
+  } as never;
+}
+
+function produceResultWithoutSession() {
+  return {
+    iterations: [{}],
+    stdout: "produce stdout",
+    commits: [{ sha: "abc123" }],
+    branch: "feat/x",
+  } as never;
+}
+
+function extractionResult(value: string) {
+  return {
+    iterations: [{ sessionId: "sess-extract" }],
+    stdout: "extract stdout",
+    commits: [],
+    branch: "feat/x",
+    output: { value },
+  } as never;
+}
+
+function structuredError(
+  rawMatched: string | undefined,
+  cause: unknown = new Error("Unexpected end of JSON input"),
+  sessionId: string = "sess-extract"
+) {
+  return new StructuredOutputError("extraction failed", {
+    tag: "output",
+    rawMatched,
+    cause,
+    commits: [],
+    branch: "feat/x",
+    sessionId,
+  });
+}
+
+beforeEach(() => {
+  mockRun.mockReset();
+});
+
+describe("runWithExtraction", () => {
+  it("runs produce without output, then a resumed extraction pass", async () => {
+    mockRun
+      .mockResolvedValueOnce(produceResult())
+      .mockResolvedValueOnce(extractionResult("ok"));
+
+    const result = await runWithExtraction(baseOptions());
+
+    expect(result.output).toEqual({ value: "ok" });
+    // commits/branch come from the produce run, not the extraction run.
+    expect(result.commits).toEqual([{ sha: "abc123" }]);
+    expect(mockRun).toHaveBeenCalledTimes(2);
+
+    const produceCall = mockRun.mock.calls[0]![0];
+    expect(produceCall).not.toHaveProperty("output");
+    expect(produceCall).not.toHaveProperty("resumeSession");
+
+    const extractCall = mockRun.mock.calls[1]![0];
+    expect(extractCall.resumeSession).toBe("sess-1");
+    expect(extractCall.output).toBe(output);
+    expect(extractCall.promptFile).toBeUndefined();
+    expect(extractCall.prompt).toBe("Emit the <output> block.");
+  });
+
+  it("keeps promptArgs on the produce call but drops it from the inline extraction", async () => {
+    mockRun
+      .mockResolvedValueOnce(produceResult())
+      .mockResolvedValueOnce(extractionResult("ok"));
+
+    const promptArgs = { PR_NUMBER: "878" };
+    await runWithExtraction({ ...baseOptions(), promptArgs });
+
+    // The produce call uses promptFile, so promptArgs is valid there.
+    const produceCall = mockRun.mock.calls[0]![0];
+    expect(produceCall.promptArgs).toBe(promptArgs);
+    expect(produceCall.promptFile).toBe("/repo/prompt.md");
+
+    // The extraction call swaps to an inline prompt; Sandcastle rejects
+    // promptArgs alongside an inline prompt, so it must be dropped.
+    const extractCall = mockRun.mock.calls[1]![0];
+    expect(extractCall.prompt).toBe("Emit the <output> block.");
+    expect(extractCall.promptFile).toBeUndefined();
+    expect(extractCall).not.toHaveProperty("promptArgs");
+  });
+
+  it("retries on StructuredOutputError, feeding back the bad output and cause", async () => {
+    mockRun
+      .mockResolvedValueOnce(produceResult())
+      .mockRejectedValueOnce(
+        structuredError('{"value":}', new Error("Unexpected token }"))
+      )
+      .mockResolvedValueOnce(extractionResult("recovered"));
+
+    const result = await runWithExtraction(baseOptions());
+
+    expect(result.output).toEqual({ value: "recovered" });
+    expect(mockRun).toHaveBeenCalledTimes(3);
+
+    // First extraction attempt resumes the produce session; the retry resumes
+    // the *failed extraction's* own session (via error.sessionId) so the fix
+    // happens in-context.
+    expect(mockRun.mock.calls[1]![0].resumeSession).toBe("sess-1");
+    expect(mockRun.mock.calls[2]![0].resumeSession).toBe("sess-extract");
+
+    const retryPrompt = mockRun.mock.calls[2]![0].prompt as string;
+    expect(retryPrompt).toContain("Previous attempt failed");
+    expect(retryPrompt).toContain('{"value":}');
+    expect(retryPrompt).toContain("Unexpected token }");
+  });
+
+  it("describes a missing tag distinctly from a validation failure", async () => {
+    mockRun
+      .mockResolvedValueOnce(produceResult())
+      .mockRejectedValueOnce(structuredError(undefined))
+      .mockResolvedValueOnce(extractionResult("ok"));
+
+    await runWithExtraction(baseOptions());
+
+    const retryPrompt = mockRun.mock.calls[2]![0].prompt as string;
+    expect(retryPrompt).toContain("did not contain a `<output>` block");
+  });
+
+  it("rethrows the final StructuredOutputError after exhausting attempts", async () => {
+    const finalError = structuredError('{"nope":1}');
+    mockRun
+      .mockResolvedValueOnce(produceResult())
+      .mockRejectedValueOnce(structuredError('{"a":1}'))
+      .mockRejectedValueOnce(structuredError('{"b":2}'))
+      .mockRejectedValueOnce(finalError);
+
+    await expect(runWithExtraction(baseOptions())).rejects.toBe(finalError);
+    // 1 produce + 3 extraction attempts (default maxAttempts).
+    expect(mockRun).toHaveBeenCalledTimes(4);
+  });
+
+  it("honours a custom maxAttempts", async () => {
+    mockRun
+      .mockResolvedValueOnce(produceResult())
+      .mockRejectedValueOnce(structuredError('{"a":1}'))
+      .mockRejectedValueOnce(structuredError('{"b":2}'));
+
+    await expect(
+      runWithExtraction({ ...baseOptions(), maxAttempts: 2 })
+    ).rejects.toBeInstanceOf(StructuredOutputError);
+    expect(mockRun).toHaveBeenCalledTimes(3); // 1 produce + 2 extraction
+  });
+
+  it("does not retry on a non-StructuredOutputError", async () => {
+    const boom = new Error("network down");
+    mockRun.mockResolvedValueOnce(produceResult()).mockRejectedValueOnce(boom);
+
+    await expect(runWithExtraction(baseOptions())).rejects.toBe(boom);
+    expect(mockRun).toHaveBeenCalledTimes(2); // produce + 1 failed extraction, no retry
+  });
+
+  it("throws a clear error when the produce run yields no sessionId", async () => {
+    mockRun.mockResolvedValueOnce(produceResultWithoutSession());
+
+    await expect(runWithExtraction(baseOptions())).rejects.toThrow(
+      /no sessionId/
+    );
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes the remaining gaps vs course-video-manager:\n- `.sandcastle/CODING_STANDARDS.md` (project standards) wired into the planner + label-Action implement/review prompts\n- code-review skill baked into the sandbox image; the label-Action review prompt restored to the reference's two-axis (Standards/Spec via parallel sub-agents) review\n- ported run-with-extraction.test.ts + no-recent-commits.test.ts\n- run-with-extraction.ts: .js import + exactOptionalPropertyTypes fix\n\nVerified: `npm run check` green (56 files / 423 tests).