### PR TITLE
fix(ci): unescape GH_REPO in manual checkout steps

### DIFF
--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -78,9 +78,9 @@ jobs:
           gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
           else
-            git clone "https://github.com/\${GH_REPO}.git" .
+            git clone "https://github.com/${GH_REPO}.git" .
           fi
           git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
           git checkout -B "$BRANCH" FETCH_HEAD

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -102,11 +102,11 @@ jobs:
           gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --depth 1 origin main
             git checkout -B main FETCH_HEAD
           else
-            git clone --branch main --depth 1 "https://github.com/\${GH_REPO}.git" .
+            git clone --branch main --depth 1 "https://github.com/${GH_REPO}.git" .
           fi
 
       - name: Compute branch name

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -42,9 +42,9 @@ jobs:
           gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
           else
-            git clone "https://github.com/\${GH_REPO}.git" .
+            git clone "https://github.com/${GH_REPO}.git" .
           fi
           git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
           git checkout -B "$BRANCH" FETCH_HEAD

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -43,9 +43,9 @@ jobs:
           gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
           else
-            git clone "https://github.com/\${GH_REPO}.git" .
+            git clone "https://github.com/${GH_REPO}.git" .
           fi
           git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
           git checkout -B "$BRANCH" FETCH_HEAD

--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -59,11 +59,11 @@ jobs:
           gh auth setup-git
           if [ -d .git ]; then
             git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/\${GH_REPO}.git"
+            git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --depth 1 origin main
             git checkout -B main FETCH_HEAD
           else
-            git clone --branch main --depth 1 "https://github.com/\${GH_REPO}.git" .
+            git clone --branch main --depth 1 "https://github.com/${GH_REPO}.git" .
           fi
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Fixes the self-hosted runner checkout: `\${GH_REPO}` was written literally, breaking `git remote add origin`. Live validation on genesis-evidence surfaced it.