### PR TITLE
fix(ci): clean stale agent branches in runner checkout

### DIFF
--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -142,6 +142,7 @@ jobs:
             git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --prune origin
             git checkout -B main origin/main
+            git branch --list 'agent/*' 'sandcastle/*' | xargs -r git branch -D 2>/dev/null || true
           else
             git clone "https://github.com/${GH_REPO}.git" .
             git checkout main

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -105,6 +105,7 @@ jobs:
             git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --depth 1 origin main
             git checkout -B main FETCH_HEAD
+            git branch --list 'agent/*' 'sandcastle/*' | xargs -r git branch -D 2>/dev/null || true
           else
             git clone --branch main --depth 1 "https://github.com/${GH_REPO}.git" .
           fi

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -82,6 +82,7 @@ jobs:
             git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --depth 1 origin main
             git checkout -B main FETCH_HEAD
+            git branch --list 'agent/*' 'sandcastle/*' | xargs -r git branch -D 2>/dev/null || true
           else
             git clone --branch main --depth 1 "https://github.com/${GH_REPO}.git" .
           fi

--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -62,6 +62,7 @@ jobs:
             git remote add origin "https://github.com/${GH_REPO}.git"
             git fetch --depth 1 origin main
             git checkout -B main FETCH_HEAD
+            git branch --list 'agent/*' 'sandcastle/*' | xargs -r git branch -D 2>/dev/null || true
           else
             git clone --branch main --depth 1 "https://github.com/${GH_REPO}.git" .
           fi


### PR DESCRIPTION
Fixes retries on self-hosted runners failing with 'branch already exists'.