### PR TITLE
fix(ci): remove orphan step stubs from label workflows

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -35,7 +35,6 @@ jobs:
           gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
           gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
 
-      - name: Checkout PR branch
       - name: Checkout PR branch with runner HOME and managed Git hooks
         run: |
           set -euo pipefail
@@ -57,8 +56,6 @@ jobs:
       - name: Capture pre-run HEAD
         id: pre
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Setup pnpm
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -36,7 +36,6 @@ jobs:
           gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
           gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
 
-      - name: Checkout PR branch
       - name: Checkout PR branch with runner HOME and managed Git hooks
         run: |
           set -euo pipefail
@@ -52,8 +51,6 @@ jobs:
 
       - name: Ensure branch is checked out by name
         run: git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
-
-      - name: Setup pnpm
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4

--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -52,7 +52,6 @@ jobs:
       GH_REPO: ${{ github.repository }}
 
     steps:
-      - name: Checkout main
       - name: Checkout main with runner HOME and managed Git hooks
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes unparseable workflows (orphan step names) that prevented agent-review/update-branch/architecture-review from dispatching.