### PR TITLE
fix(ci): grant issues permission to PR-label workflows

### DIFF
--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
 
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
GITHUB_TOKEN needs issues read/write for gh issue view in the review chain.