### PR TITLE
feat(afk): plan A — no auto-claim on agent:implement label

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -1,12 +1,20 @@
 name: Agent Implement
 
 on:
-  issues:
-    types: [labeled]
+  # Plan A: no auto-claim on label. The single-issue implement is now driven
+  # explicitly (workflow_dispatch or the planner). This removes the confusion
+  # where labeling an issue `agent:implement` instantly claimed + ran it.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to implement
+        required: true
+      issue_title:
+        description: Issue title (optional)
+        required: false
 
 jobs:
   implement:
-    if: github.event.label.name == 'agent:implement'
     runs-on: self-hosted
     timeout-minutes: 60
     concurrency:
@@ -18,8 +26,8 @@ jobs:
       issues: write
 
     env:
-      ISSUE_NUMBER: ${{ github.event.issue.number }}
-      ISSUE_TITLE: ${{ github.event.issue.title }}
+      ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
+      ISSUE_TITLE: ${{ inputs.issue_title || github.event.issue.title }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
 

--- a/docs/afk-workflow.md
+++ b/docs/afk-workflow.md
@@ -60,6 +60,28 @@ Label the PR `agent:review`: `review.ts` runs the two-axis `code-review` skill
 replies to threads. Address feedback via `agent:implement` on the PR; resolve
 conflicts via `agent:update-branch`.
 
+## Labels & engines (one queue, two explicit runners)
+
+**Plan A: no auto-claim.** An issue label is a *queue* marker, never a
+self-running trigger — nothing implements your issues until you run an engine.
+
+| Label | Means | Who acts |
+|---|---|---|
+| `ready-for-agent` | issue is queued for the planner | **`pnpm ralph`** (dependency graph → parallel → merge/push/close) |
+| `agent:implement` | legacy single-issue trigger — **no longer auto-runs** (dispatch-only now) | `gh workflow run agent-implement.yml -f issue_number=N` if you want the PR flow explicitly |
+| `agent:review` / `agent:update-branch` | PR review / conflict-resolve (dispatch or PR-driven) | review / update-branch workflows |
+
+Rules:
+
+- **One issue, one engine.** Label `ready-for-agent` if you want the planner to
+  handle it; run `pnpm ralph` to execute. For a single controlled issue, run
+  `pnpm afk -- <issue>` directly — no label needed.
+- **Splitting a PRD** (parent #N): label the parent `agent:to-issues` to split
+  into native sub-issues; then add `ready-for-agent` to the sub-issues you want
+  the planner to implement (it respects the "Blocked by" dependency graph).
+- **Never** label an issue `agent:implement` expecting it to run — it won't
+  auto-start; you must dispatch or use the planner.
+
 ## Rules
 
 - **Profiles are server-global** (`claude`, `claude-ark`, `psydo`,


### PR DESCRIPTION
Removes the auto-claim: labeling an issue agent:implement no longer runs it. One queue (ready-for-agent) + two explicit runners (pnpm ralph / pnpm afk). Docs updated.