### PR TITLE
chore(gitignore): ignore per-run redacted event and state logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ screenshots/
 *.pid
 *.tmp
 .cache/
+# Redacted run event/state logs are generated per run (in the run dir).
+*.jsonl
+codex-agent.state.json
 
 # Credentials and browser state
 .env


### PR DESCRIPTION
The branch's original intent: ignore redacted run event/state logs (*.jsonl, codex-agent.state.json) so repo-root run artifacts don't dirty git status / break the private-package builder. Main currently DOESN'T ignore them. A stray working-tree edit in the worktree had reverted this; discarded. This lands the fix cleanly.