### PR TITLE
chore(gitignore): add pnpm lockfiles (repo uses npm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ evals/
 .DS_Store
 .idea/
 .vscode/
+
+# pnpm lockfiles (repo uses npm)
+pnpm-lock.yaml
+pnpm-workspace.yaml


### PR DESCRIPTION
Adds pnpm-lock.yaml / pnpm-workspace.yaml to .gitignore (the repo commits npm locks).