### PR TITLE
chore(afk): baseline 同步 merge-prompt 分支清理 + worktrees ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ evals/
 # pnpm lockfiles (repo uses npm)
 pnpm-lock.yaml
 pnpm-workspace.yaml
+
+# AFK runner runtime dirs (not source)
+.sandcastle/worktrees/

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -32,6 +32,18 @@ You are authorized to push to `main` from inside this environment:
    git push origin main
    ```
 
+3. **After pushing main, clean up merged local branch refs.** The planner
+   creates `agent/*` worktree branches that persist as *local* refs even after
+   their worktrees are destroyed; since we deliver via direct push to `main`
+   (not a PR flow), those refs are never auto-deleted. Delete them so they do
+   not accumulate between runs:
+   ```bash
+   git branch --list 'agent/*' 'sandcastle/*' | xargs -r git branch -D
+   ```
+   Only delete branches that were merged (they are — every branch in
+   `{{BRANCHES}}` was just merged). If deletion fails (a branch is still
+   checked out), ignore and continue — it will be cleaned up on a later run.
+
 # CLOSE ISSUES
 
 For each branch that was merged, close its issue with a comment. If there are


### PR DESCRIPTION
## Changes
从 AI-Ops(e80b7c0)同步 baseline 到模板仓库:

1. `.sandcastle/merge-prompt.md`:delivery 走 direct-push main,planner 创建的 `agent/*` worktree 分支 ref 从不自动删 → 在 DELIVERY(push main 后)加 cleanup:
   ```bash
   git branch --list 'agent/*' 'sandcastle/*' | xargs -r git branch -D
   ```
2. `.gitignore`:忽略 `.sandcastle/worktrees/`(运行时残留目录不再 `??`)

这是 `bootstrap-afk.sh` 拷贝 verbatim 的 baseline,未来新 scaffold 的 repo 都会带上清理逻辑。

## Tests
- 纯模板 prompt 与配置改动,无应用逻辑
- diff vs AI-Ops 确认只含这 12 行 cleanup

## Checklist
- [x] baseline = `/home/claude/Projects/Auto-Test`(bootstrap-afk 默认 BASELINE)
- [x] 只删已 merge 的 ref;删除失败忽略
- [x] 不动 Java/tsdata/production.env