### PR TITLE
feat(afk): add AgentRouter profile

### DIFF
--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -39,7 +39,7 @@ RUN npm install --global @anthropic-ai/claude-code \
     'set -eu' \
     'case "${AFK_PROFILE:-claude}" in' \
     '  claude) exec /usr/local/bin/claude-real "$@" ;;' \
-    '  claude-ark|psydo) args=(); while [ "$#" -gt 0 ]; do if [ "$1" = "--model" ]; then shift 2; else args+=("$1"); shift; fi; done; exec env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_REASONING_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT=1 /usr/local/bin/claude-real --settings /home/agent/.afk-profile-settings.json "${args[@]}" ;;' \
+    '  claude-ark|agentrouter|psydo) args=(); while [ "$#" -gt 0 ]; do if [ "$1" = "--model" ]; then shift 2; else args+=("$1"); shift; fi; done; exec env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_REASONING_MODEL -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT=1 /usr/local/bin/claude-real --settings /home/agent/.afk-profile-settings.json "${args[@]}" ;;' \
     '  *) echo "unsupported AFK_PROFILE" >&2; exit 2 ;;' \
     'esac' > /usr/local/bin/claude \
   && chmod 755 /usr/local/bin/claude \

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -10,7 +10,7 @@ const issue = process.argv.slice(2).find((arg, index) =>
   /^\d+$/.test(arg) && (profileIndex < 0 || index + 2 !== profileIndex + 1),
 );
 if (!issue || !/^\d+$/.test(issue)) {
-  throw new Error("Usage: npm run afk -- [--profile claude|claude-ark|psydo|aliyun-deepseek] <issue-number>");
+  throw new Error("Usage: npm run afk -- [--profile claude|claude-ark|agentrouter|psydo|aliyun-deepseek] <issue-number>");
 }
 
 const root = resolve(import.meta.dirname, "..");

--- a/.sandcastle/profile.ts
+++ b/.sandcastle/profile.ts
@@ -6,6 +6,7 @@ import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 const profiles = {
   claude: undefined,
   "claude-ark": process.env.AFK_CLAUDE_ARK_SETTINGS ?? "/home/claude/cliproxyapi/settings.ark.json",
+  agentrouter: process.env.AFK_AGENTROUTER_SETTINGS ?? "/home/claude/cliproxyapi/settings.airouter2.json",
   psydo: undefined,
   "aliyun-deepseek": undefined,
 } as const;
@@ -61,7 +62,7 @@ export function claudeProfile(
   profile = process.env.AFK_PROFILE,
   env?: Record<string, string>,
 ): { agent: AgentProvider; sandbox: SandboxProvider } {
-  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude, claude-ark, psydo, or aliyun-deepseek.");
+  if (profile && !(profile in profiles)) throw new Error("Unsupported profile; use claude, claude-ark, agentrouter, psydo, or aliyun-deepseek.");
   const settingsPath = profile ? profiles[profile as keyof typeof profiles] : undefined;
   if (settingsPath && !existsSync(settingsPath)) throw new Error(`Profile settings not found: ${settingsPath}`);
   const usePsydo = profile === "psydo";

--- a/docs/afk-workflow.md
+++ b/docs/afk-workflow.md
@@ -84,9 +84,10 @@ Rules:
 
 ## Rules
 
-- **Profiles are server-global** (`claude`, `claude-ark`, `psydo`,
-  `aliyun-deepseek`). Pick one per repo: `AFK_PROFILE` variable. No repo-side
-  credentials.
+- **Profiles are server-global** (`claude`, `claude-ark`, `agentrouter`,
+  `psydo`, `aliyun-deepseek`). Pick one per repo: `AFK_PROFILE` variable.
+  `agentrouter` uses server-managed Claude settings and supports
+  `AFK_AGENTROUTER_SETTINGS` as an operator override. No repo-side credentials.
 - **The agent owns delivery on the planner loop** (push main + close issues);
   on GitHub branch-protected repos it degrades to a PR. Single-issue `pnpm afk`
   never touches GitHub.

--- a/tests/afk-runner.test.ts
+++ b/tests/afk-runner.test.ts
@@ -10,7 +10,7 @@ describe("AFK runner", () => {
     expect(prompt).toContain("Do not merge, push, close issues");
     expect(runner).toContain('branchStrategy: { type: "branch", branch, baseBranch: "origin/main" }');
     expect(runner).toContain('maxIterations: Number(process.env.AFK_ITERATIONS ?? 3)');
-    expect(runner).toContain('claude|claude-ark|psydo|aliyun-deepseek');
+    expect(runner).toContain('claude|claude-ark|agentrouter|psydo|aliyun-deepseek');
   });
 
   it("keeps the copied PRD workflow wired to native sub-issues and server profiles", async () => {


### PR DESCRIPTION
## Changes

- register the server-managed AgentRouter settings profile
- expose the profile in AFK CLI help and Docker dispatch
- document the operator override and cover the profile list in tests

## Tests

- `pnpm check` (423 tests, typecheck, build)
- `bash test/smoke.sh /home/claude/Projects/.auto-test-agentrouter-afk-profile` from afk-bootstrap

## Checklist

- [x] no repository credentials added
- [x] missing settings fail closed
- [x] default bootstrap baseline covered