### PR TITLE
docs: record AFK provider canary

### DIFF
--- a/docs/afk-provider-canary.md
+++ b/docs/afk-provider-canary.md
@@ -1,0 +1,13 @@
+# AFK provider canary
+
+Date: 2026-08-29
+
+This record confirms the repository's AFK delivery workflow was validated
+through the official planning boundary (`/grill-with-docs` -> `/to-spec` ->
+`/to-tickets`) and the harness-neutral Sandcastle Standards/Spec review
+orchestration.
+
+The validation was documentation-scoped only. No provider credentials, API
+keys, tenant data, device identifiers, or internal endpoints are recorded
+here. Existing AFK workflow documentation and application behavior remain
+unchanged.

--- a/tests/afk-provider-canary.test.ts
+++ b/tests/afk-provider-canary.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("AFK provider canary record", () => {
+  it("records the official planning boundary and Sandcastle review without private inputs", async () => {
+    const canary = await readFile("docs/afk-provider-canary.md", "utf8");
+
+    expect(canary).toContain("/grill-with-docs");
+    expect(canary).toContain("/to-spec");
+    expect(canary).toContain("/to-tickets");
+    expect(canary).toContain("Sandcastle");
+    expect(canary).toMatch(/\b2026-\d{2}-\d{2}\b/);
+    expect(canary).not.toMatch(/\b(sk-[A-Za-z0-9_-]{8,}|AIza[0-9A-Za-z_-]{10,}|AKIA[0-9A-Z]{16}|Bearer\s+[A-Za-z0-9._~+/-]+=*)\b/);
+    expect(canary).not.toMatch(/https?:\/\/[^\s`)]+/);
+  });
+});


### PR DESCRIPTION
Closes #146

## changes
- add a dated AFK provider canary record
- add focused contract test for the record

## tests
- typecheck and build passed
- focused canary and AFK runner tests passed
- full check attempted; unrelated pre-existing provider/runner failures remain

## checklist
- [x] documentation-only
- [x] no credentials or internal endpoints
- [x] no application behavior changes