### PR TITLE
fix(workflow): deepen review checkout history

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -54,6 +54,11 @@ jobs:
 
       - name: Ensure main is available for diffing
         run: |
+          if [ "$(git rev-parse --is-shallow-repository)" = true ]; then
+            git fetch --prune --unshallow origin
+          else
+            git fetch --prune origin
+          fi
           git fetch --prune origin main
           git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
 


### PR DESCRIPTION
## changes\nHandle persistent shallow runner workspaces by unshallowing before computing the PR diff, then refresh origin/main. This keeps the managed pre-push guard able to find a merge-base.\n\n## tests\n- Workflow syntax checked\n- No application/API/database changes\n\n## checklist\n- [x] Minimal workflow-only change\n- [x] Preserves guarded push behavior