### PR TITLE
fix(afk): harden trusted PR delivery

### DIFF
--- a/.afk-bootstrap.json
+++ b/.afk-bootstrap.json
@@ -2,7 +2,7 @@
   "templateVersion": 1,
   "language": "node",
   "repository": "kilbertert/Auto_Test",
-  "afk_template_version": "1.1.0",
+  "afk_template_version": "1.1.1",
   "consensus_version": "1.0.0",
   "consensus_compatibility": ">=1.0.0 <2.0.0"
 }

--- a/.github/workflows/afk-policy.yml
+++ b/.github/workflows/afk-policy.yml
@@ -1,0 +1,27 @@
+name: AFK Policy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  workflows:
+    name: Workflow policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Verify AFK workflow boundaries
+        run: node .sandcastle/policy-check.mjs workflows

--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -156,7 +156,10 @@ jobs:
       - name: Import result into clean delivery workspace
         if: steps.result.outputs.changed == 'true'
         working-directory: delivery
+        env:
+          AFK_READ_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
         run: |
+          test -n "$AFK_READ_TOKEN"
           bash ../controller/.sandcastle/trusted-pr-delivery.sh \
             import . "$BRANCH_HEAD_SHA" "$BRANCH" "${RUNNER_TEMP}/implement-result.bundle"
           AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery

--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -16,7 +16,7 @@ jobs:
       group: agent-mutate-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
 

--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -1,8 +1,6 @@
 name: Agent Implement (PR)
 
 on:
-  # See agent-review.yml — pull_request_target fires reliably on labels
-  # even when the PR is out-of-date or conflicting.
   pull_request_target:
     types: [labeled]
 
@@ -10,10 +8,10 @@ jobs:
   implement-pr:
     if: >-
       github.event.label.name == 'agent:implement' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == github.repository_owner
     runs-on: self-hosted
     timeout-minutes: 60
-    # Shared with agent-review.yml — both push to the PR branch.
     concurrency:
       group: agent-mutate-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -28,13 +26,13 @@ jobs:
       BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_STATE: ${{ github.event.pull_request.state }}
       PR_MERGED: ${{ github.event.pull_request.merged }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AFK_AGENT_GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
       GH_REPO: ${{ github.repository }}
 
     steps:
-      - name: Pre-flight — refuse if PR is closed or merged
+      - name: Pre-flight - refuse if PR is closed or merged
         id: state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$PR_STATE" != "open" ] || [ "$PR_MERGED" = "true" ]; then
             gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
@@ -44,9 +42,11 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Pre-flight — refuse if there is nothing to act on
+      - name: Pre-flight - refuse if there is nothing to act on
         if: steps.state.outputs.proceed == 'true'
         id: inputs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # shellcheck disable=SC2016
           set -euo pipefail
@@ -67,32 +67,42 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Transition labels — remove trigger + blocked, add in-progress
+      - name: Transition labels - remove trigger and blocked, add in-progress
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
           gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
           gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
 
-      - name: Checkout PR branch with runner HOME and managed Git hooks
+      - name: Checkout trusted controller
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
-        run: |
-          set -euo pipefail
-          gh auth setup-git
-          if [ -d .git ]; then
-            git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/${GH_REPO}.git"
-          else
-            git clone "https://github.com/${GH_REPO}.git" .
-          fi
-          git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
-          git checkout -B "$BRANCH" FETCH_HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: controller
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
 
-      - name: Ensure main is available for diffing
+      - name: Checkout candidate PR head
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+
+      - name: Prepare candidate against current main
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        working-directory: candidate
         run: |
-          git fetch origin main:main || git fetch origin main
-          git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+          base_sha=$(git -C ../controller rev-parse HEAD)
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            prepare . "$BRANCH_HEAD_SHA" "$base_sha" "$BRANCH"
 
       - name: Setup Node.js 22
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
@@ -100,55 +110,78 @@ jobs:
         with:
           node-version: "22"
           cache: npm
+          cache-dependency-path: controller/package-lock.json
 
-      - name: Install dependencies
+      - name: Install trusted controller dependencies
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        working-directory: controller
         run: npm ci
 
-      - name: Configure git identity
-        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
-        run: |
-          git config user.name "claude-code[bot]"
-          git config user.email "claude-code[bot]@users.noreply.github.com"
-
-      - name: Run implement-pr.ts
+      - name: Run trusted implement controller against candidate
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
         id: implement
+        working-directory: candidate
         env:
+          GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+          AFK_AGENT_GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
           AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
           OUTPUT_DIR: ${{ runner.temp }}
-        run: npm exec tsx .sandcastle/implement-pr/implement-pr.ts
+        run: ../controller/node_modules/.bin/tsx ../controller/.sandcastle/implement-pr/implement-pr.ts
 
-      - name: Verify AFK policy before push
-        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
-        run: node .sandcastle/policy-check.mjs delivery
+      - name: Verify candidate policy
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        working-directory: candidate
+        run: AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery
 
-      - name: Push branch (abort cleanly if non-fast-forward)
-        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
-        id: push
+      - name: Capture trusted result bundle
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        id: result
+        working-directory: candidate
         run: |
-          has_commits=$(cat "${RUNNER_TEMP}/has_commits.txt")
-          if [ "$has_commits" != "true" ]; then
-            echo "No commits this run — skipping push."
-            exit 0
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            capture . "$BRANCH_HEAD_SHA" "$BRANCH" \
+            "${RUNNER_TEMP}/implement-result.bundle" "${RUNNER_TEMP}/has_changes.txt"
+          echo "changed=$(cat "${RUNNER_TEMP}/has_changes.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: delivery
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+
+      - name: Import result into clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        working-directory: delivery
+        run: |
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            import . "$BRANCH_HEAD_SHA" "$BRANCH" "${RUNNER_TEMP}/implement-result.bundle"
+          AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery
+
+      - name: Push result from clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        working-directory: delivery
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "AGENT_PAT is required to push the implementation result." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
-          set +e
-          git push origin "$BRANCH" 2> push_err.txt
-          status=$?
-          set -e
-          if [ $status -ne 0 ]; then
-            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
-              echo "Branch advanced during implement run." > "${RUNNER_TEMP}/failure_reason.txt"
-              cat push_err.txt
-              exit 1
-            fi
-            cat push_err.txt
-            exit $status
+          gh auth setup-git
+          if ! bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            push . "$BRANCH_HEAD_SHA" "$BRANCH"; then
+            echo "AGENT_PAT could not push the implementation result." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
 
       - name: Post thread replies
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPLIES: ${{ runner.temp }}/implement_thread_replies.json
         run: |
           count=$(jq 'length' "$REPLIES")
@@ -157,7 +190,7 @@ jobs:
             body=$(jq -r ".[$i].body" "$REPLIES")
             rest_id=$(gh api graphql -f query="query(\$id:ID!){ node(id:\$id){ ... on PullRequestReviewComment { databaseId } } }" -F id="$commentId" --jq '.data.node.databaseId')
             if [ -z "$rest_id" ] || [ "$rest_id" = "null" ]; then
-              echo "Could not resolve REST id for $commentId — skipping" >&2
+              echo "Could not resolve REST id for $commentId - skipping" >&2
               continue
             fi
             gh api \
@@ -169,6 +202,7 @@ jobs:
       - name: Post new inline comments
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INLINE: ${{ runner.temp }}/implement_new_inline_comments.json
         run: |
           commit_id=$(jq -r '.commit_id' "$INLINE")
@@ -191,6 +225,7 @@ jobs:
       - name: Post top-level PR comments
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TOP: ${{ runner.temp }}/implement_top_level_comments.json
         run: |
           count=$(jq 'length' "$TOP")
@@ -202,9 +237,10 @@ jobs:
       - name: Mark blocked on failure
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && failure()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          reason="(no reason file written — check workflow logs)"
+          reason="(no reason file written - check workflow logs)"
           if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
             reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
           fi
@@ -222,4 +258,6 @@ jobs:
 
       - name: Always remove in-progress label
         if: always() && steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -276,30 +276,26 @@ jobs:
           # repository Actions policy. AGENT_PAT is the host-side delivery
           # credential and never enters the Docker agent.
           AGENT_PAT: ${{ secrets.AGENT_PAT }}
-          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [ -n "$EXISTING_PR" ]; then
             echo "pr_number=$EXISTING_PR" >> "$GITHUB_OUTPUT"
             echo "created=false" >> "$GITHUB_OUTPUT"
           else
+            if [ -z "$AGENT_PAT" ]; then
+              echo "AGENT_PAT is required to create the delivery pull request." > "${RUNNER_TEMP}/failure_reason.txt"
+              exit 1
+            fi
             PR_TITLE=$(cat "${RUNNER_TEMP}/pr_title.txt")
             PR_TITLE="${PR_TITLE:0:256}"
-            create_pr() {
-              GH_TOKEN="$1" gh pr create \
+            if ! pr_url=$(GH_TOKEN="$AGENT_PAT" gh pr create \
               --draft \
               --base main \
               --head "$BRANCH" \
               --title "$PR_TITLE" \
-              --body-file "${RUNNER_TEMP}/pr_description.txt"
-            }
-            if [ -n "$AGENT_PAT" ]; then
-              pr_url=$(create_pr "$AGENT_PAT" | tail -n1) || {
-                echo "AGENT_PAT PR creation failed; falling back to GITHUB_TOKEN." >&2
-                pr_url=$(create_pr "$GITHUB_TOKEN_FALLBACK" | tail -n1)
-              }
-            else
-              pr_url=$(create_pr "$GITHUB_TOKEN_FALLBACK" | tail -n1)
+              --body-file "${RUNNER_TEMP}/pr_description.txt" | tail -n1); then
+              echo "AGENT_PAT could not create the delivery pull request." > "${RUNNER_TEMP}/failure_reason.txt"
+              exit 1
             fi
             pr_number=$(basename "$pr_url")
             echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
@@ -319,39 +315,32 @@ jobs:
         if: steps.shape.outputs.mode == 'run' && success() && steps.remaining.outputs.count != '0'
         env:
           AGENT_PAT: ${{ secrets.AGENT_PAT }}
-          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
-        # Need AGENT_PAT to fire the next workflow run — GITHUB_TOKEN-driven
-        # label adds don't trigger downstream workflows. Without AGENT_PAT,
-        # the chain stops here and a human will need to re-add the label.
         run: |
-          set +e
-          if [ -n "$AGENT_PAT" ]; then
-            GH_TOKEN="$AGENT_PAT" gh issue edit "$PRD_NUMBER" --add-label "agent:implement"
-            status=$?
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            echo "AGENT_PAT label add failed (status $status); falling back to GITHUB_TOKEN."
+          set -euo pipefail
+          if [ -z "$AGENT_PAT" ]; then
+            echo "AGENT_PAT is required to trigger the next PRD implementation run." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
-          GH_TOKEN="$GITHUB_TOKEN_FALLBACK" gh issue edit "$PRD_NUMBER" --add-label "agent:implement"
+          if ! GH_TOKEN="$AGENT_PAT" gh issue edit "$PRD_NUMBER" --add-label "agent:implement"; then
+            echo "AGENT_PAT could not add the agent:implement trigger label." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
 
       - name: Hand off — request review on the PR
         if: steps.shape.outputs.mode == 'run' && success() && steps.remaining.outputs.count == '0'
         env:
           PR_NUMBER: ${{ steps.open_pr.outputs.pr_number }}
           AGENT_PAT: ${{ secrets.AGENT_PAT }}
-          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set +e
-          if [ -n "$AGENT_PAT" ]; then
-            GH_TOKEN="$AGENT_PAT" gh pr edit "$PR_NUMBER" --add-label "agent:review"
-            status=$?
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            echo "AGENT_PAT label add failed (status $status); falling back to GITHUB_TOKEN."
+          set -euo pipefail
+          if [ -z "$AGENT_PAT" ]; then
+            echo "AGENT_PAT is required to trigger the review workflow." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
-          GH_TOKEN="$GITHUB_TOKEN_FALLBACK" gh pr edit "$PR_NUMBER" --add-label "agent:review"
+          if ! GH_TOKEN="$AGENT_PAT" gh pr edit "$PR_NUMBER" --add-label "agent:review"; then
+            echo "AGENT_PAT could not add the agent:review trigger label." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
 
       - name: Mark blocked on failure
         if: steps.shape.outputs.mode == 'run' && failure()

--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -236,16 +236,19 @@ jobs:
         if: steps.shape.outputs.mode == 'run' && success()
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
+          GH_TOKEN: ${{ secrets.AGENT_PAT }}
         # NOT force-push: the branch accumulates commits across sub-issue runs.
-        run: git push origin "$BRANCH"
-
-      - name: Close completed sub-issue
-        if: steps.shape.outputs.mode == 'run' && success()
-        env:
-          SUB_ISSUE_NUMBER: ${{ steps.shape.outputs.next_open_number }}
         run: |
-          commit_sha=$(git rev-parse HEAD)
-          gh issue close "$SUB_ISSUE_NUMBER" --comment "Implemented in ${commit_sha}. Part of #${PRD_NUMBER}."
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "AGENT_PAT is required to push the PRD implementation branch." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
+          gh auth setup-git
+          if ! git push origin "$BRANCH"; then
+            echo "AGENT_PAT could not push the PRD implementation branch." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
 
       - name: Check whether a PR already exists for this branch
         if: steps.shape.outputs.mode == 'run' && success()
@@ -301,6 +304,14 @@ jobs:
             echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
             echo "created=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Close completed sub-issue
+        if: steps.shape.outputs.mode == 'run' && success()
+        env:
+          SUB_ISSUE_NUMBER: ${{ steps.shape.outputs.next_open_number }}
+        run: |
+          commit_sha=$(git rev-parse HEAD)
+          gh issue close "$SUB_ISSUE_NUMBER" --comment "Implemented in ${commit_sha}. Part of #${PRD_NUMBER}."
 
       - name: Re-check remaining open sub-issues
         if: steps.shape.outputs.mode == 'run' && success()

--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -23,7 +23,7 @@ jobs:
       group: agent-implement-prd-issue-${{ inputs.prd_number || github.event.issue.number }}
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
 

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -23,7 +23,7 @@ jobs:
       group: agent-implement-issue-${{ inputs.issue_number || github.event.issue.number }}
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
 
@@ -201,7 +201,18 @@ jobs:
         if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && success()
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
-        run: git push origin "$BRANCH"
+          GH_TOKEN: ${{ secrets.AGENT_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "AGENT_PAT is required to push the implementation branch." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
+          gh auth setup-git
+          if ! git push origin "$BRANCH"; then
+            echo "AGENT_PAT could not push the implementation branch." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
 
       - name: Write PR title and description
         if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && success()

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -220,26 +220,22 @@ jobs:
           # repository Actions policy. AGENT_PAT is the host-side delivery
           # credential and never enters the Docker agent.
           AGENT_PAT: ${{ secrets.AGENT_PAT }}
-          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -z "$AGENT_PAT" ]; then
+            echo "AGENT_PAT is required to create the delivery pull request." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
           PR_TITLE=$(cat "${RUNNER_TEMP}/pr_title.txt")
           PR_TITLE="${PR_TITLE:0:256}"
-          create_pr() {
-            GH_TOKEN="$1" gh pr create \
+          if ! pr_url=$(GH_TOKEN="$AGENT_PAT" gh pr create \
             --draft \
             --base main \
             --head "$BRANCH" \
             --title "$PR_TITLE" \
-            --body-file "${RUNNER_TEMP}/pr_description.txt"
-          }
-          if [ -n "$AGENT_PAT" ]; then
-            pr_url=$(create_pr "$AGENT_PAT" | tail -n1) || {
-              echo "AGENT_PAT PR creation failed; falling back to GITHUB_TOKEN." >&2
-              pr_url=$(create_pr "$GITHUB_TOKEN_FALLBACK" | tail -n1)
-            }
-          else
-            pr_url=$(create_pr "$GITHUB_TOKEN_FALLBACK" | tail -n1)
+            --body-file "${RUNNER_TEMP}/pr_description.txt" | tail -n1); then
+            echo "AGENT_PAT could not create the delivery pull request." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
           pr_number=$(basename "$pr_url")
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
@@ -250,22 +246,17 @@ jobs:
           PR_NUMBER: ${{ steps.open_pr.outputs.pr_number }}
           # Prefer AGENT_PAT so the labeled event triggers agent-review.yml
           # (GITHUB_TOKEN-driven label adds do not trigger downstream workflows).
-          # Fall back to GITHUB_TOKEN if AGENT_PAT is unset or lacks
-          # pull-requests permission; in that case a human will need to
-          # re-add `agent:review` manually to fire the review workflow.
           AGENT_PAT: ${{ secrets.AGENT_PAT }}
-          GITHUB_TOKEN_FALLBACK: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set +e
-          if [ -n "$AGENT_PAT" ]; then
-            GH_TOKEN="$AGENT_PAT" gh pr edit "$PR_NUMBER" --add-label "agent:review"
-            status=$?
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            echo "AGENT_PAT label add failed (status $status); falling back to GITHUB_TOKEN."
+          set -euo pipefail
+          if [ -z "$AGENT_PAT" ]; then
+            echo "AGENT_PAT is required to trigger the review workflow." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
-          GH_TOKEN="$GITHUB_TOKEN_FALLBACK" gh pr edit "$PR_NUMBER" --add-label "agent:review"
+          if ! GH_TOKEN="$AGENT_PAT" gh pr edit "$PR_NUMBER" --add-label "agent:review"; then
+            echo "AGENT_PAT could not add the agent:review trigger label." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
 
       - name: Mark blocked on failure
         if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true' && failure()

--- a/.github/workflows/agent-promote-queued.yml
+++ b/.github/workflows/agent-promote-queued.yml
@@ -27,8 +27,7 @@ jobs:
       GH_REPO: ${{ github.repository }}
       # AGENT_PAT is required for the promoted `agent:implement` label to
       # fire `agent-implement.yml` — labels added via GITHUB_TOKEN do not
-      # trigger downstream workflows. Falls back to GITHUB_TOKEN, in which
-      # case promotion lands but the downstream run won't auto-trigger.
+      # trigger downstream workflows.
       AGENT_PAT: ${{ secrets.AGENT_PAT }}
 
     steps:
@@ -58,7 +57,8 @@ jobs:
           owner="${GH_REPO%/*}"
           repo="${GH_REPO#*/}"
 
-          echo "$DEPENDENTS_JSON" | jq -r '.[]' | while read -r y; do
+          failed=0
+          while read -r y; do
             echo "::group::Evaluating #$y"
 
             # Fetch labels + parent for Y in one shot.
@@ -109,23 +109,15 @@ jobs:
 
             echo "Promote: #$y"
             gh issue edit "$y" --remove-label "agent:queued"
-            gh issue comment "$y" --body "Unblocked by #${CLOSED_NUMBER} closing — promoting from \`agent:queued\` to \`agent:implement\`."
-
-            # Use AGENT_PAT for the agent:implement add so downstream
-            # agent-implement.yml fires. Fall back to GITHUB_TOKEN if PAT is
-            # absent; in that case the label lands but won't trigger.
-            set +e
-            if [ -n "$AGENT_PAT" ]; then
-              GH_TOKEN="$AGENT_PAT" gh issue edit "$y" --add-label "agent:implement"
-              status=$?
-              if [ "$status" -ne 0 ]; then
-                echo "AGENT_PAT add-label failed (status $status); falling back to GITHUB_TOKEN."
-                gh issue edit "$y" --add-label "agent:implement"
-              fi
-            else
-              gh issue edit "$y" --add-label "agent:implement"
+            if [ -z "$AGENT_PAT" ] || ! GH_TOKEN="$AGENT_PAT" gh issue edit "$y" --add-label "agent:implement"; then
+              gh issue edit "$y" --add-label "agent:blocked" || true
+              gh issue comment "$y" --body "Promotion stopped: AGENT_PAT is missing or could not add the workflow-triggering \`agent:implement\` label. Added \`agent:blocked\`; restore the delivery credential before retrying."
+              failed=1
+              echo "::endgroup::"
+              continue
             fi
-            set -e
+            gh issue comment "$y" --body "Unblocked by #${CLOSED_NUMBER} closing — promoted from \`agent:queued\` to \`agent:implement\`."
 
             echo "::endgroup::"
-          done
+          done < <(echo "$DEPENDENTS_JSON" | jq -r '.[]')
+          [ "$failed" -eq 0 ]

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -19,7 +19,7 @@ jobs:
       group: agent-mutate-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
 

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,11 +1,9 @@
 name: Agent Review
 
 on:
-  # pull_request_target rather than pull_request: the standard pull_request
-  # trigger depends on a generated merge commit, which GitHub fails to
-  # produce when the PR is out-of-date or conflicting. pull_request_target
-  # runs in the base context and does not need the merge commit, so the
-  # labeled event fires reliably.
+  # pull_request_target keeps the controller on trusted default-branch code.
+  # Candidate code is checked out separately and runs only inside Sandcastle's
+  # Docker sandbox with the read token.
   pull_request_target:
     types: [labeled]
 
@@ -13,7 +11,8 @@ jobs:
   review:
     if: >-
       github.event.label.name == 'agent:review' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == github.repository_owner
     runs-on: self-hosted
     timeout-minutes: 60
     concurrency:
@@ -28,100 +27,115 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       BRANCH: ${{ github.event.pull_request.head.ref }}
       BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AFK_AGENT_GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
       GH_REPO: ${{ github.repository }}
 
     steps:
-      - name: Transition labels — remove trigger + blocked, add in-progress
+      - name: Transition labels - remove trigger and blocked, add in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$PR_NUMBER" --remove-label "agent:review" || true
           gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
           gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
 
-      - name: Checkout PR branch with runner HOME and managed Git hooks
-        run: |
-          set -euo pipefail
-          gh auth setup-git
-          if [ -d .git ]; then
-            git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/${GH_REPO}.git"
-          else
-            git clone "https://github.com/${GH_REPO}.git" .
-          fi
-          git fetch origin "${{ github.event.pull_request.head.sha }}"
-          git checkout -B "$BRANCH" FETCH_HEAD
+      - name: Checkout trusted controller
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: controller
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
 
-      - name: Ensure main is available for diffing
-        run: |
-          if [ "$(git rev-parse --is-shallow-repository)" = true ]; then
-            git fetch --prune --unshallow origin
-          else
-            git fetch --prune origin
-          fi
-          git fetch --prune origin main
-          git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+      - name: Checkout candidate PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
 
-      - name: Capture pre-run HEAD
-        id: pre
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Prepare candidate against current main
+        working-directory: candidate
+        run: |
+          base_sha=$(git -C ../controller rev-parse HEAD)
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            prepare . "$BRANCH_HEAD_SHA" "$base_sha" "$BRANCH"
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: npm
+          cache-dependency-path: controller/package-lock.json
 
-      - name: Install dependencies
+      - name: Install trusted controller dependencies
+        working-directory: controller
         run: npm ci
 
-      # latest — every run exercises the current version of the skill. Global
-      # (not project) install keeps it outside the git work tree so the review
-      # agent's commit step can never sweep it into the PR branch. Scoped to the
-      # claude-code agent so the step exits 0 (other agents reject -g installs).
-      - name: Install code-review skill
-        run: pnpm dlx skills@latest add mattpocock/skills -g -s code-review -a claude-code -y --copy
-
-      - name: Configure git identity
-        run: |
-          git config user.name "claude-code[bot]"
-          git config user.email "claude-code[bot]@users.noreply.github.com"
-
-      - name: Run review.ts
+      - name: Run trusted review controller against candidate
         id: review
+        working-directory: candidate
         env:
+          GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+          AFK_AGENT_GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
           AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
           OUTPUT_DIR: ${{ runner.temp }}
-        run: npm exec tsx .sandcastle/review/review.ts
+        run: ../controller/node_modules/.bin/tsx ../controller/.sandcastle/review/review.ts
 
-      - name: Verify AFK policy before push
-        if: success()
-        run: node .sandcastle/policy-check.mjs delivery
+      - name: Verify candidate policy
+        working-directory: candidate
+        run: AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery
 
-      - name: Push branch (abort cleanly if non-fast-forward)
-        id: push
-        if: success()
+      - name: Capture trusted result bundle
+        id: result
+        working-directory: candidate
         run: |
-          # A normal push is enough because this run starts from the recorded
-          # PR head. It fails cleanly if anything advanced the branch.
-          set +e
-          git push origin "$BRANCH" 2> push_err.txt
-          status=$?
-          set -e
-          if [ $status -ne 0 ]; then
-            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
-              echo "Branch advanced during review run." > "${RUNNER_TEMP}/failure_reason.txt"
-              echo "race=true" >> "$GITHUB_OUTPUT"
-              cat push_err.txt
-              exit 1
-            fi
-            cat push_err.txt
-            exit $status
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            capture . "$BRANCH_HEAD_SHA" "$BRANCH" \
+            "${RUNNER_TEMP}/review-result.bundle" "${RUNNER_TEMP}/has_changes.txt"
+          echo "changed=$(cat "${RUNNER_TEMP}/has_changes.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: delivery
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+
+      - name: Import result into clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        working-directory: delivery
+        run: |
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            import . "$BRANCH_HEAD_SHA" "$BRANCH" "${RUNNER_TEMP}/review-result.bundle"
+          AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery
+
+      - name: Push result from clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        working-directory: delivery
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "AGENT_PAT is required to push the review result." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
+          fi
+          gh auth setup-git
+          if ! bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            push . "$BRANCH_HEAD_SHA" "$BRANCH"; then
+            echo "AGENT_PAT could not push the review result." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
 
-      - name: Post PR review (inline comments + summary)
+      - name: Post PR review
         if: success()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PAYLOAD: ${{ runner.temp }}/review_payload.json
         run: |
           gh api \
@@ -131,21 +145,23 @@ jobs:
 
       - name: Mark PR ready for review
         if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr ready "$PR_NUMBER" || true
 
       - name: Post thread replies
         if: success()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPLIES: ${{ runner.temp }}/replies.json
         run: |
           count=$(jq 'length' "$REPLIES")
           for i in $(seq 0 $((count - 1))); do
             commentId=$(jq -r ".[$i].commentId" "$REPLIES")
             body=$(jq -r ".[$i].body" "$REPLIES")
-            # GraphQL node ID → numeric REST id via the node lookup.
             rest_id=$(gh api graphql -f query="query(\$id:ID!){ node(id:\$id){ ... on PullRequestReviewComment { databaseId } } }" -F id="$commentId" --jq '.data.node.databaseId')
             if [ -z "$rest_id" ] || [ "$rest_id" = "null" ]; then
-              echo "Could not resolve REST id for $commentId — skipping" >&2
+              echo "Could not resolve REST id for $commentId - skipping" >&2
               continue
             fi
             gh api \
@@ -157,9 +173,10 @@ jobs:
       - name: Mark blocked on failure
         if: failure()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          reason="(no reason file written — check workflow logs)"
+          reason="(no reason file written - check workflow logs)"
           if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
             reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
           fi
@@ -177,4 +194,6 @@ jobs:
 
       - name: Always remove in-progress label
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -110,7 +110,10 @@ jobs:
       - name: Import result into clean delivery workspace
         if: steps.result.outputs.changed == 'true'
         working-directory: delivery
+        env:
+          AFK_READ_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
         run: |
+          test -n "$AFK_READ_TOKEN"
           bash ../controller/.sandcastle/trusted-pr-delivery.sh \
             import . "$BRANCH_HEAD_SHA" "$BRANCH" "${RUNNER_TEMP}/review-result.bundle"
           AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -1,11 +1,6 @@
 name: Agent Update Branch
 
 on:
-  # pull_request_target rather than pull_request: the standard pull_request
-  # trigger depends on a generated merge commit, which GitHub fails to
-  # produce when the PR is out-of-date or conflicting — exactly when this
-  # workflow needs to run. pull_request_target runs in the base context and
-  # does not need the merge commit, so the labeled event fires reliably.
   pull_request_target:
     types: [labeled]
 
@@ -13,7 +8,8 @@ jobs:
   update-branch:
     if: >-
       github.event.label.name == 'agent:update-branch' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == github.repository_owner
     runs-on: self-hosted
     timeout-minutes: 60
     concurrency:
@@ -29,86 +25,115 @@ jobs:
       BRANCH: ${{ github.event.pull_request.head.ref }}
       BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.event.pull_request.base.ref }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      AFK_AGENT_GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
       GH_REPO: ${{ github.repository }}
 
     steps:
-      - name: Transition labels — remove trigger + blocked, add in-progress
+      - name: Transition labels - remove trigger and blocked, add in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit "$PR_NUMBER" --remove-label "agent:update-branch" || true
           gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
           gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
 
-      - name: Checkout PR branch with runner HOME and managed Git hooks
-        run: |
-          set -euo pipefail
-          gh auth setup-git
-          if [ -d .git ]; then
-            git remote remove origin 2>/dev/null || true
-            git remote add origin "https://github.com/${GH_REPO}.git"
-          else
-            git clone "https://github.com/${GH_REPO}.git" .
-          fi
-          git fetch --depth 1 origin "${{ github.event.pull_request.head.sha }}"
-          git checkout -B "$BRANCH" FETCH_HEAD
+      - name: Checkout trusted controller
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: controller
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
 
-      - name: Ensure branch is checked out by name
-        run: git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+      - name: Checkout candidate PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+
+      - name: Prepare candidate against current main
+        working-directory: candidate
+        run: |
+          base_sha=$(git -C ../controller rev-parse HEAD)
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            prepare . "$BRANCH_HEAD_SHA" "$base_sha" "$BRANCH"
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: npm
+          cache-dependency-path: controller/package-lock.json
 
-      - name: Install dependencies
+      - name: Install trusted controller dependencies
+        working-directory: controller
         run: npm ci
 
-      - name: Configure git identity
-        run: |
-          git config user.name "claude-code[bot]"
-          git config user.email "claude-code[bot]@users.noreply.github.com"
-
-      - name: Run update-branch.ts
+      - name: Run trusted update controller against candidate
         id: run
+        working-directory: candidate
         env:
+          GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+          AFK_AGENT_GH_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
           AFK_PROFILE: ${{ vars.AFK_PROFILE || 'psydo' }}
           OUTPUT_DIR: ${{ runner.temp }}
-        run: npm exec tsx .sandcastle/update-branch/update-branch.ts
+        run: ../controller/node_modules/.bin/tsx ../controller/.sandcastle/update-branch/update-branch.ts
 
-      - name: Verify AFK policy before push
-        if: success()
-        run: node .sandcastle/policy-check.mjs delivery
+      - name: Verify candidate policy
+        working-directory: candidate
+        run: AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery
 
-      - name: Push branch (abort cleanly if non-fast-forward)
-        if: success()
-        env:
-          SHOULD_PUSH_FILE: ${{ runner.temp }}/should_push.txt
+      - name: Capture trusted result bundle
+        id: result
+        working-directory: candidate
         run: |
-          if [ ! -f "$SHOULD_PUSH_FILE" ] || [ "$(cat "$SHOULD_PUSH_FILE")" != "true" ]; then
-            echo "Nothing to push."
-            exit 0
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            capture . "$BRANCH_HEAD_SHA" "$BRANCH" \
+            "${RUNNER_TEMP}/update-result.bundle" "${RUNNER_TEMP}/has_changes.txt"
+          echo "changed=$(cat "${RUNNER_TEMP}/has_changes.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: delivery
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.AFK_AGENT_READ_TOKEN }}
+
+      - name: Import result into clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        working-directory: delivery
+        run: |
+          bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            import . "$BRANCH_HEAD_SHA" "$BRANCH" "${RUNNER_TEMP}/update-result.bundle"
+          AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery
+
+      - name: Push result from clean delivery workspace
+        if: steps.result.outputs.changed == 'true'
+        working-directory: delivery
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "AGENT_PAT is required to push the updated branch." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
-          # The updater creates a merge commit from the recorded PR head, so a
-          # normal push is sufficient and fails if the branch advanced.
-          set +e
-          git push origin "$BRANCH" 2> push_err.txt
-          status=$?
-          set -e
-          if [ $status -ne 0 ]; then
-            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
-              echo "Branch advanced during update-branch run." > "${RUNNER_TEMP}/failure_reason.txt"
-              cat push_err.txt
-              exit 1
-            fi
-            cat push_err.txt
-            exit $status
+          gh auth setup-git
+          if ! bash ../controller/.sandcastle/trusted-pr-delivery.sh \
+            push . "$BRANCH_HEAD_SHA" "$BRANCH"; then
+            echo "AGENT_PAT could not push the updated branch." > "${RUNNER_TEMP}/failure_reason.txt"
+            exit 1
           fi
 
       - name: Post PR comment
         if: success()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_FILE: ${{ runner.temp }}/comment.md
         run: |
           if [ -f "$COMMENT_FILE" ]; then
@@ -118,9 +143,10 @@ jobs:
       - name: Mark blocked on failure
         if: failure()
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          reason="(no reason file written — check workflow logs)"
+          reason="(no reason file written - check workflow logs)"
           if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
             reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
           fi
@@ -138,4 +164,6 @@ jobs:
 
       - name: Always remove in-progress label
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -16,7 +16,7 @@ jobs:
       group: agent-mutate-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
 

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -108,7 +108,10 @@ jobs:
       - name: Import result into clean delivery workspace
         if: steps.result.outputs.changed == 'true'
         working-directory: delivery
+        env:
+          AFK_READ_TOKEN: ${{ secrets.AFK_AGENT_READ_TOKEN }}
         run: |
+          test -n "$AFK_READ_TOKEN"
           bash ../controller/.sandcastle/trusted-pr-delivery.sh \
             import . "$BRANCH_HEAD_SHA" "$BRANCH" "${RUNNER_TEMP}/update-result.bundle"
           AFK_ROOT="$PWD" node ../controller/.sandcastle/policy-check.mjs delivery

--- a/.sandcastle/policy-check.mjs
+++ b/.sandcastle/policy-check.mjs
@@ -79,6 +79,7 @@ function checkWorkflows() {
       "../controller/node_modules/.bin/tsx",
       "trusted-pr-delivery.sh",
       "AFK_AGENT_READ_TOKEN",
+      "AFK_READ_TOKEN",
       "GH_TOKEN: ${{ secrets.AGENT_PAT }}",
       "agent:blocked",
     ]) {
@@ -104,12 +105,12 @@ function checkWorkflows() {
     for (const required of ["AGENT_PAT", "agent:blocked"]) {
       if (!source.includes(required)) fail(`${name} is missing fail-closed delivery control: ${required}`);
     }
-    if (name === "agent-implement-prd.yml") {
+    if (name === "agent-implement-prd.yml" || name === "agent-implement.yml") {
       const pushStep = source.split(/\n(?= {6}- name:)/).find((step) => step.includes("- name: Push branch"));
       if (!pushStep || !pushStep.match(/^ {10}GH_TOKEN:\s*\$\{\{\s*secrets\.AGENT_PAT\s*\}\}\s*$/m)) {
-        fail(`${name} does not use AGENT_PAT for ticket branch pushes`);
+        fail(`${name} does not use AGENT_PAT for branch pushes`);
       }
-      if (source.indexOf("- name: Close completed sub-issue") < source.indexOf("- name: Open draft PR if one doesn't exist for this branch")) {
+      if (name === "agent-implement-prd.yml" && source.indexOf("- name: Close completed sub-issue") < source.indexOf("- name: Open draft PR if one doesn't exist for this branch")) {
         fail(`${name} closes the ticket before PR delivery succeeds`);
       }
     }

--- a/.sandcastle/policy-check.mjs
+++ b/.sandcastle/policy-check.mjs
@@ -75,6 +75,7 @@ function checkWorkflows() {
       "path: controller",
       "path: candidate",
       "path: delivery",
+      "contents: read",
       "../controller/node_modules/.bin/tsx",
       "trusted-pr-delivery.sh",
       "AFK_AGENT_READ_TOKEN",
@@ -102,6 +103,15 @@ function checkWorkflows() {
     const source = readText(join(directory, name), name);
     for (const required of ["AGENT_PAT", "agent:blocked"]) {
       if (!source.includes(required)) fail(`${name} is missing fail-closed delivery control: ${required}`);
+    }
+    if (name === "agent-implement-prd.yml") {
+      const pushStep = source.split(/\n(?= {6}- name:)/).find((step) => step.includes("- name: Push branch"));
+      if (!pushStep || !pushStep.match(/^ {10}GH_TOKEN:\s*\$\{\{\s*secrets\.AGENT_PAT\s*\}\}\s*$/m)) {
+        fail(`${name} does not use AGENT_PAT for ticket branch pushes`);
+      }
+      if (source.indexOf("- name: Close completed sub-issue") < source.indexOf("- name: Open draft PR if one doesn't exist for this branch")) {
+        fail(`${name} closes the ticket before PR delivery succeeds`);
+      }
     }
     rejectUnsafeWorkflowText(name, source);
   }

--- a/.sandcastle/policy-check.mjs
+++ b/.sandcastle/policy-check.mjs
@@ -8,12 +8,13 @@ const command = process.argv[2] ?? "all";
 const metadata = readJson(join(root, ".afk-bootstrap.json"), "metadata");
 const contract = readJson(join(root, ".sandcastle/consensus-contract.json"), "consensus contract");
 
-if (!["version", "exceptions", "commit", "delivery", "all"].includes(command)) {
-  fail(`Usage: node .sandcastle/policy-check.mjs [version|exceptions|commit|delivery|all]`);
+if (!["version", "exceptions", "workflows", "commit", "delivery", "all"].includes(command)) {
+  fail(`Usage: node .sandcastle/policy-check.mjs [version|exceptions|workflows|commit|delivery|all]`);
 }
 
 if (command === "version" || command === "delivery" || command === "all") checkVersions();
 if (command === "exceptions" || command === "delivery" || command === "all") checkExceptions();
+if (command === "workflows" || command === "delivery" || command === "all") checkWorkflows();
 if (command === "commit" || command === "delivery" || command === "all") checkBranch();
 if (command === "commit" || command === "delivery" || command === "all") checkDiff();
 
@@ -61,6 +62,57 @@ function checkExceptions() {
   }
 }
 
+function checkWorkflows() {
+  const directory = join(root, ".github/workflows");
+  const pullRequestWorkflows = ["agent-implement-pr.yml", "agent-review.yml", "agent-update-branch.yml"];
+  const deliveryWorkflows = ["agent-implement.yml", "agent-implement-prd.yml", "agent-promote-queued.yml"];
+
+  for (const name of pullRequestWorkflows) {
+    const source = readText(join(directory, name), name);
+    for (const required of [
+      "github.event.pull_request.head.repo.full_name == github.repository",
+      "github.event.pull_request.user.login == github.repository_owner",
+      "path: controller",
+      "path: candidate",
+      "path: delivery",
+      "../controller/node_modules/.bin/tsx",
+      "trusted-pr-delivery.sh",
+      "AFK_AGENT_READ_TOKEN",
+      "GH_TOKEN: ${{ secrets.AGENT_PAT }}",
+      "agent:blocked",
+    ]) {
+      if (!source.includes(required)) fail(`${name} is missing trusted PR control: ${required}`);
+    }
+    if (source.match(/^    env:\n(?: {6}.*\n)* {6}GH_TOKEN:/m)) fail(`${name} exposes GH_TOKEN to the whole job`);
+    for (const step of source.split(/\n(?= {6}- name:)/)) {
+      if (step.includes("run: npm ci") && !step.includes("working-directory: controller")) {
+        fail(`${name} installs untrusted host dependencies`);
+      }
+      if (step.includes("working-directory: candidate") && step.includes("GH_TOKEN:") && !step.includes("AFK_AGENT_READ_TOKEN")) {
+        fail(`${name} exposes a write token to the candidate checkout`);
+      }
+      if (step.includes("Push result from clean delivery workspace") && !step.includes("secrets.AGENT_PAT")) {
+        fail(`${name} does not use AGENT_PAT for the final push`);
+      }
+    }
+    rejectUnsafeWorkflowText(name, source);
+  }
+
+  for (const name of deliveryWorkflows) {
+    const source = readText(join(directory, name), name);
+    for (const required of ["AGENT_PAT", "agent:blocked"]) {
+      if (!source.includes(required)) fail(`${name} is missing fail-closed delivery control: ${required}`);
+    }
+    rejectUnsafeWorkflowText(name, source);
+  }
+}
+
+function rejectUnsafeWorkflowText(name, source) {
+  if (source.includes("skills@latest")) fail(`${name} installs a provider-specific skill at runtime`);
+  if (source.includes("GITHUB_TOKEN_FALLBACK")) fail(`${name} falls back to a token that cannot trigger workflows`);
+  if (/git\s+push[^\n]*--force(?:-with-lease)?/.test(source)) fail(`${name} force-pushes`);
+}
+
 function checkBranch() {
   let branch;
   try {
@@ -92,6 +144,14 @@ function git(args) {
 function readJson(path, label) {
   try {
     return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    fail(`cannot read ${label}: ${error.message}`);
+  }
+}
+
+function readText(path, label) {
+  try {
+    return readFileSync(path, "utf8");
   } catch (error) {
     fail(`cannot read ${label}: ${error.message}`);
   }

--- a/.sandcastle/trusted-pr-delivery.sh
+++ b/.sandcastle/trusted-pr-delivery.sh
@@ -12,7 +12,12 @@ valid_branch() {
 }
 
 remote_head() {
-  git -C "$1" ls-remote origin "refs/heads/$2" | awk 'NR == 1 { print $1 }'
+  if [ -n "${AFK_READ_TOKEN:-}" ]; then
+    git -C "$1" -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${AFK_READ_TOKEN}" \
+      ls-remote origin "refs/heads/$2" | awk 'NR == 1 { print $1 }'
+  else
+    git -C "$1" ls-remote origin "refs/heads/$2" | awk 'NR == 1 { print $1 }'
+  fi
 }
 
 command="${1:-}"

--- a/.sandcastle/trusted-pr-delivery.sh
+++ b/.sandcastle/trusted-pr-delivery.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  echo "trusted PR delivery failed: $*" >&2
+  exit 1
+}
+
+valid_branch() {
+  git check-ref-format --branch "$1" >/dev/null || die "invalid branch: $1"
+  [ "$1" != main ] || die "the pull request branch cannot be main"
+}
+
+remote_head() {
+  git -C "$1" ls-remote origin "refs/heads/$2" | awk 'NR == 1 { print $1 }'
+}
+
+command="${1:-}"
+case "$command" in
+  prepare)
+    [ "$#" -eq 5 ] || die "usage: $0 prepare REPO EXPECTED_HEAD BASE_SHA BRANCH"
+    repo="$2" expected="$3" base="$4" branch="$5"
+    valid_branch "$branch"
+    [ "$(git -C "$repo" rev-parse HEAD)" = "$expected" ] || die "candidate HEAD changed before preparation"
+    git -C "$repo" cat-file -e "$base^{commit}" || die "trusted base commit is unavailable"
+    git -C "$repo" checkout -q -B "$branch" "$expected"
+    git -C "$repo" branch -f main "$base"
+    git -C "$repo" config user.name "claude-code[bot]"
+    git -C "$repo" config user.email "claude-code[bot]@users.noreply.github.com"
+    ;;
+
+  capture)
+    [ "$#" -eq 6 ] || die "usage: $0 capture REPO EXPECTED_HEAD BRANCH BUNDLE STATE_FILE"
+    repo="$2" expected="$3" branch="$4" bundle="$5" state_file="$6"
+    valid_branch "$branch"
+    current_branch="$(git -C "$repo" symbolic-ref --short HEAD)"
+    [ "$current_branch" = "$branch" ] || die "candidate branch changed to $current_branch"
+    result="$(git -C "$repo" rev-parse HEAD)"
+    git -C "$repo" merge-base --is-ancestor "$expected" "$result" || die "candidate rewrote the recorded PR head"
+    git -C "$repo" diff --check "$expected..$result"
+    if [ "$result" = "$expected" ]; then
+      rm -f "$bundle"
+      printf 'false\n' > "$state_file"
+      exit 0
+    fi
+    git -C "$repo" bundle create "$bundle" "refs/heads/$branch" "^$expected"
+    git -C "$repo" bundle verify "$bundle" >/dev/null
+    printf 'true\n' > "$state_file"
+    ;;
+
+  import)
+    [ "$#" -eq 5 ] || die "usage: $0 import REPO EXPECTED_HEAD BRANCH BUNDLE"
+    repo="$2" expected="$3" branch="$4" bundle="$5"
+    valid_branch "$branch"
+    [ -f "$bundle" ] || die "result bundle is missing"
+    actual="$(remote_head "$repo" "$branch")"
+    [ "$actual" = "$expected" ] || die "branch advanced during the agent run"
+    git -C "$repo" fetch -q "$bundle" "refs/heads/$branch"
+    result="$(git -C "$repo" rev-parse FETCH_HEAD)"
+    git -C "$repo" merge-base --is-ancestor "$expected" "$result" || die "bundle does not extend the recorded PR head"
+    git -C "$repo" checkout -q -B "$branch" "$result"
+    ;;
+
+  push)
+    [ "$#" -eq 4 ] || die "usage: $0 push REPO EXPECTED_HEAD BRANCH"
+    repo="$2" expected="$3" branch="$4"
+    valid_branch "$branch"
+    actual="$(remote_head "$repo" "$branch")"
+    [ "$actual" = "$expected" ] || die "branch advanced before delivery"
+    git -C "$repo" push origin "HEAD:refs/heads/$branch"
+    ;;
+
+  *)
+    die "usage: $0 prepare|capture|import|push ..."
+    ;;
+esac

--- a/.sandcastle/trusted-pr-delivery.sh
+++ b/.sandcastle/trusted-pr-delivery.sh
@@ -13,7 +13,8 @@ valid_branch() {
 
 remote_head() {
   if [ -n "${AFK_READ_TOKEN:-}" ]; then
-    git -C "$1" -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${AFK_READ_TOKEN}" \
+    auth="$(printf 'x-access-token:%s' "$AFK_READ_TOKEN" | base64 | tr -d '\n')"
+    git -C "$1" -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth}" \
       ls-remote origin "refs/heads/$2" | awk 'NR == 1 { print $1 }'
   else
     git -C "$1" ls-remote origin "refs/heads/$2" | awk 'NR == 1 { print $1 }'

--- a/.sandcastle/update-branch/update-branch.ts
+++ b/.sandcastle/update-branch/update-branch.ts
@@ -10,8 +10,13 @@ const PR_NUMBER = required("PR_NUMBER");
 const BRANCH = required("BRANCH");
 const BASE_REF = required("BASE_REF");
 const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
-
-execFileSync("git", ["fetch", "origin", BASE_REF], { stdio: "inherit" });
+const readToken = process.env.AFK_AGENT_GH_TOKEN ?? process.env.GH_TOKEN;
+if (!readToken) fail("AFK_AGENT_GH_TOKEN is required for the trusted base fetch.");
+execFileSync(
+  "git",
+  ["-c", "http.https://github.com/.extraheader=AUTHORIZATION: bearer " + readToken, "fetch", "origin", BASE_REF],
+  { stdio: "inherit" },
+);
 
 const preMergeSha = sh("git rev-parse HEAD").trim();
 const baseSha = sh(`git rev-parse origin/${BASE_REF}`).trim();

--- a/.sandcastle/update-branch/update-branch.ts
+++ b/.sandcastle/update-branch/update-branch.ts
@@ -12,9 +12,10 @@ const BASE_REF = required("BASE_REF");
 const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
 const readToken = process.env.AFK_AGENT_GH_TOKEN ?? process.env.GH_TOKEN;
 if (!readToken) fail("AFK_AGENT_GH_TOKEN is required for the trusted base fetch.");
+const auth = Buffer.from("x-access-token:" + readToken).toString("base64");
 execFileSync(
   "git",
-  ["-c", "http.https://github.com/.extraheader=AUTHORIZATION: bearer " + readToken, "fetch", "origin", BASE_REF],
+  ["-c", "http.https://github.com/.extraheader=AUTHORIZATION: basic " + auth, "fetch", "origin", BASE_REF],
   { stdio: "inherit" },
 );
 

--- a/acceptance.feature
+++ b/acceptance.feature
@@ -1,0 +1,24 @@
+Feature: Trusted AFK pull request automation
+  Auto-Test runs pull request agents without executing candidate-controlled host code with delivery credentials.
+
+  Rule: Pull request automation uses the current trusted controller
+
+    Scenario: Review starts from the current default branch
+      Given a persistent runner whose local main branch is stale
+      And origin main has advanced
+      When an owner-authored pull request receives the agent:review label
+      Then the trusted controller resets local main to the current origin main
+      And the review diff uses that current base
+
+    Scenario: Candidate code cannot receive delivery credentials
+      Given an owner-authored pull request from the Auto-Test repository
+      When an AFK pull request mutation workflow runs
+      Then host dependencies and orchestration load from the trusted controller
+      And candidate commands run only in the Docker sandbox with the read token
+      And a clean delivery checkout imports and pushes the verified result bundle
+
+    Scenario: Untrusted or unauthenticated delivery stops
+      Given a pull request is untrusted or AGENT_PAT cannot perform the requested mutation
+      When an AFK mutation label is added
+      Then the mutation does not report a successful handoff
+      And credential failure records agent:blocked

--- a/docs/adr/0002-trusted-pr-control-plane.md
+++ b/docs/adr/0002-trusted-pr-control-plane.md
@@ -1,0 +1,3 @@
+# Trusted control plane for pull request mutation
+
+AFK pull request mutation workflows accept only repository-owner-authored branches from the same repository. Host orchestration and dependencies come from the default-branch controller, candidate commands receive only the read token inside Docker, and resulting commits cross into a clean delivery checkout through a verified Git bundle before the host injects `AGENT_PAT` for the final push; missing or failed delivery credentials stop the workflow. This preserves downstream CI triggers without executing candidate-controlled host code with delivery credentials.

--- a/docs/afk-provider-canary.md
+++ b/docs/afk-provider-canary.md
@@ -7,7 +7,15 @@ through the official planning boundary (`/grill-with-docs` -> `/to-spec` ->
 `/to-tickets`) and the harness-neutral Sandcastle Standards/Spec review
 orchestration.
 
-The validation was documentation-scoped only. No provider credentials, API
-keys, tenant data, device identifiers, or internal endpoints are recorded
-here. Existing AFK workflow documentation and application behavior remain
-unchanged.
+That canary predates template 1.1.1 and does not prove the hardened pull request
+delivery boundary. In 1.1.1, `pull_request_target` mutation workflows accept
+only owner-authored same-repository pull requests, load dependencies and
+orchestration from the current default-branch controller, expose only the read
+token to the candidate Docker sandbox, and import verified Git bundles into a
+clean delivery checkout. Missing or unusable `AGENT_PAT` now fails closed with
+`agent:blocked`; it no longer falls back to `GITHUB_TOKEN`.
+
+The repository-local static and template regression checks are recorded in
+`qa-plan.md`. A new live `agent:review` canary remains pending until these
+workflows are merged. No provider credentials, API keys, tenant data, device
+identifiers, or internal endpoints are recorded here.

--- a/docs/afk-workflow.md
+++ b/docs/afk-workflow.md
@@ -52,6 +52,13 @@ Agents commit on task branches and run deterministic checks. The host runner
 pushes branches, opens draft PRs, and merges only after CI and human review.
 No agent pushes the default branch directly.
 
+Pull request mutation jobs accept only repository-owner-authored branches from
+the same repository. The current `main` checkout supplies the trusted
+controller, candidate commands run in Docker with the read token, and verified
+Git bundles enter a clean delivery checkout before the host write token is used.
+Missing delivery credentials produce `agent:blocked`; there is no non-triggering
+`GITHUB_TOKEN` fallback.
+
 ## Providers
 
 The configured Sandcastle profile is server-global: `claude`, `claude-ark`,

--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
     "typescript": "^5.9.2",
     "vitest": "^3.2.6"
   },
-  "afk_template_version": "1.1.0"
+  "afk_template_version": "1.1.1"
 }

--- a/qa-plan.md
+++ b/qa-plan.md
@@ -10,15 +10,15 @@
 
 ## Results
 
-AFK-B10: passed on `2026-08-30T03:09:18+08:00`, build identity
-`7f1d64fd5a198043a012b29b33aea24c61b1b5ed`, Linux x86_64, Node v24.15.0,
+AFK-B10: passed on `2026-08-30T03:31:15+08:00`, build identity
+`2b42d80f10bc34e47125a8d8f302b4d06828b594`, Linux x86_64, Node v24.15.0,
 Python 3.13.13, actionlint 1.7.12 and ShellCheck 0.11.0. Evidence:
 `npm run check` (`423/423` tests plus typecheck/build), policy checker,
 actionlint, ShellCheck and `git diff --check` passed. Managed workflow, policy
 checker and bundle helper match the afk-bootstrap template byte-for-byte.
 
 AFK-B11: passed at the same build identity; retained evidence is template
-commit `7973f255059c4e71de67ae9375bc0fb28b584824` and its `bash
+commit `84e9537c661f676f68951eb3e7480472b91ff728` and its `bash
 test/trusted-pr-delivery.sh` report.
 
 AFK-B12 remains pending until the hardened workflow is merged and an

--- a/qa-plan.md
+++ b/qa-plan.md
@@ -1,0 +1,15 @@
+# AFK trusted delivery QA plan
+
+## Cases
+
+| ID | Environment | Preconditions | Test data | Actions | Expected observable result | Cleanup |
+|---|---|---|---|---|---|---|
+| AFK-B10 | Linux task branch | Template version 1.1.1 deployed | Six AFK mutation workflows | Run `node .sandcastle/policy-check.mjs workflows`, actionlint, and ShellCheck | Owner-only same-repository gates, trusted controller execution, read-only candidate token, clean delivery checkout, and fail-closed AGENT_PAT rules pass | None |
+| AFK-B11 | afk-bootstrap test checkout | Template source is available | Stale main, advanced origin, merge result, and raced remote | Run `test/trusted-pr-delivery.sh` in afk-bootstrap and compare deployed managed files byte-for-byte | The helper resets the base, preserves the result commit through a bundle, rejects the race, and deployed files match the tested template | Temporary repositories are removed by the test |
+| AFK-B12 | Auto-Test self-hosted runner | Hardened workflows merged; runner and required secrets online | Owner-authored disposable PR | Add `agent:review`; inspect the workflow, review, labels, and delivered branch | Review uses current main, completes through controller/candidate/delivery isolation, publishes the review, and leaves no blocked label | Close the disposable PR and remove its branch/labels |
+
+## Results
+
+AFK-B10 and AFK-B11 must record the tested commit, environment, timestamp, and command evidence before merge. AFK-B12 remains pending until the hardened template is merged and the live canary completes.
+
+Complexity and mutation tools are not applicable to workflow YAML. The template-owned shell state machine has focused stale-base, merge-preservation, and race-rejection coverage; this repository verifies the deployed policy and byte identity.

--- a/qa-plan.md
+++ b/qa-plan.md
@@ -10,6 +10,19 @@
 
 ## Results
 
-AFK-B10 and AFK-B11 must record the tested commit, environment, timestamp, and command evidence before merge. AFK-B12 remains pending until the hardened template is merged and the live canary completes.
+AFK-B10: passed on `2026-08-30T03:09:18+08:00`, build identity
+`7f1d64fd5a198043a012b29b33aea24c61b1b5ed`, Linux x86_64, Node v24.15.0,
+Python 3.13.13, actionlint 1.7.12 and ShellCheck 0.11.0. Evidence:
+`npm run check` (`423/423` tests plus typecheck/build), policy checker,
+actionlint, ShellCheck and `git diff --check` passed. Managed workflow, policy
+checker and bundle helper match the afk-bootstrap template byte-for-byte.
+
+AFK-B11: passed at the same build identity; retained evidence is template
+commit `7973f255059c4e71de67ae9375bc0fb28b584824` and its `bash
+test/trusted-pr-delivery.sh` report.
+
+AFK-B12 remains pending until the hardened workflow is merged and an
+owner-authored `agent:review` canary retains its workflow URL, review result,
+labels and cleanup evidence.
 
 Complexity and mutation tools are not applicable to workflow YAML. The template-owned shell state machine has focused stale-base, merge-preservation, and race-rejection coverage; this repository verifies the deployed policy and byte identity.


### PR DESCRIPTION
## changes\n- deploy AFK template 1.1.1 trusted controller/candidate/delivery workflows\n- require owner-authored same-repository PRs, AGENT_PAT, and authenticated private fetches\n- add policy workflow, acceptance feature, ADR, and QA evidence\n\n## tests\n- npm run check (423/423, typecheck, build)\n- node .sandcastle/policy-check.mjs workflows\n- actionlint, ShellCheck, git diff --check\n- managed payload byte comparison with afk-bootstrap\n\n## checklist\n- [x] B10/B11 evidence recorded\n- [ ] B12 live canary after merge