### PR TITLE
chore(canary): exercise AFK review delivery

### DIFF
--- a/docs/afk-provider-canary.md
+++ b/docs/afk-provider-canary.md
@@ -19,3 +19,5 @@ The repository-local static and template regression checks are recorded in
 `qa-plan.md`. A new live `agent:review` canary remains pending until these
 workflows are merged. No provider credentials, API keys, tenant data, device
 identifiers, or internal endpoints are recorded here.
+
+Disposable live-canary marker: hardened review delivery validation.


### PR DESCRIPTION
Disposable live canary for the merged AFK review workflow.

This PR is intentionally not for merge; it verifies controller/candidate/delivery isolation and review publication.

Closes #152