### PR TITLE
docs(qa): record live canary provider block

### DIFF
--- a/docs/afk-provider-canary.md
+++ b/docs/afk-provider-canary.md
@@ -16,6 +16,13 @@ clean delivery checkout. Missing or unusable `AGENT_PAT` now fails closed with
 `agent:blocked`; it no longer falls back to `GITHUB_TOKEN`.
 
 The repository-local static and template regression checks are recorded in
-`qa-plan.md`. A new live `agent:review` canary remains pending until these
-workflows are merged. No provider credentials, API keys, tenant data, device
-identifiers, or internal endpoints are recorded here.
+`qa-plan.md`. The post-merge live canary was attempted on 2026-08-30 with
+workflow runs [33272059907](https://github.com/kilbertert/Auto_Test/actions/runs/33272059907),
+[33272577334](https://github.com/kilbertert/Auto_Test/actions/runs/33272577334),
+and [33273244207](https://github.com/kilbertert/Auto_Test/actions/runs/33273244207).
+Trusted checkout, candidate preparation, and isolation passed. The review
+provider stage was blocked: Aliyun timed out, Claude Ark rejected the account
+without a CodingPlan subscription, and Psydo timed out. The workflow therefore
+failed closed before delivery push or review publication; no provider
+credentials, API keys, tenant data, device identifiers, or internal endpoints
+are recorded here.

--- a/docs/afk-provider-canary.md
+++ b/docs/afk-provider-canary.md
@@ -17,9 +17,7 @@ clean delivery checkout. Missing or unusable `AGENT_PAT` now fails closed with
 
 The repository-local static and template regression checks are recorded in
 `qa-plan.md`. The post-merge live canary was attempted on 2026-08-30 with
-workflow runs [33272059907](https://github.com/kilbertert/Auto_Test/actions/runs/33272059907),
-[33272577334](https://github.com/kilbertert/Auto_Test/actions/runs/33272577334),
-and [33273244207](https://github.com/kilbertert/Auto_Test/actions/runs/33273244207).
+workflow run IDs `33272059907`, `33272577334`, and `33273244207`.
 Trusted checkout, candidate preparation, and isolation passed. The review
 provider stage was blocked: Aliyun timed out, Claude Ark rejected the account
 without a CodingPlan subscription, and Psydo timed out. The workflow therefore

--- a/qa-plan.md
+++ b/qa-plan.md
@@ -21,8 +21,13 @@ AFK-B11: passed at the same build identity; retained evidence is template
 commit `84e9537c661f676f68951eb3e7480472b91ff728` and its `bash
 test/trusted-pr-delivery.sh` report.
 
-AFK-B12 remains pending until the hardened workflow is merged and an
-owner-authored `agent:review` canary retains its workflow URL, review result,
-labels and cleanup evidence.
+AFK-B12: blocked on provider availability. The owner-authored disposable PR
+`#151` exercised the merged workflow three times. Runs 33272059907 and
+33272577334 verified trusted checkout, candidate preparation, and isolation;
+33273244207 reached both parallel review axes but the configured provider
+returned a subscription error. The workflow marked the PR `agent:blocked` and
+did not push or publish a review. PR #151 and issue #152 were closed, the
+canary branch and worktree were removed, and `AFK_PROFILE` was restored to
+`aliyun-deepseek`. Re-run AFK-B12 after a healthy provider is configured.
 
 Complexity and mutation tools are not applicable to workflow YAML. The template-owned shell state machine has focused stale-base, merge-preservation, and race-rejection coverage; this repository verifies the deployed policy and byte identity.


### PR DESCRIPTION
Record the post-merge AFK canary evidence. Trusted checkout and candidate isolation passed; all configured model providers were unavailable, so the fail-closed workflow correctly stopped before delivery push and review publication.