### PR TITLE
feat(observe): SSE live updates for in-progress runs

### DIFF
--- a/src/observe/dashboard-html.ts
+++ b/src/observe/dashboard-html.ts
@@ -29,6 +29,8 @@ export function observationDashboardHtml(): string {
   section h2 { font-size: 15px; margin: 0 0 8px; color: #4b5563; }
   .back { margin-bottom: 12px; font-size: 13px; }
   .note { padding: 8px 12px; background: #fef3c7; border-radius: 6px; font-size: 13px; }
+  ul.feed { list-style: none; padding-left: 0; max-height: 260px; overflow-y: auto; font-size: 13px; font-family: ui-monospace, monospace; }
+  ul.feed li { padding: 2px 0; border-bottom: 1px dashed #e6e8ec; }
   @media (prefers-color-scheme: dark) {
     body { background: #101418; color: #e5e7eb; }
     table { background: #161b22; }
@@ -99,20 +101,57 @@ export function observationDashboardHtml(): string {
   }
   async function showDetail(runId) {
     content.textContent = '正在加载运行详情…'
+    if (detailSource) { detailSource.close(); detailSource = null }
     let detail
     try { detail = await (await fetch('/api/runs/' + encodeURIComponent(runId))).json() } catch (e) { content.textContent = '无法加载运行详情：' + e; return }
     if (!detail || detail.error) { content.textContent = '无法加载运行详情：' + (detail ? detail.error : '未知错误'); return }
-    const container = document.createElement('div')
+    if (detail.entry.status === 'running') {
+      const feed = document.createElement('ul'); feed.className = 'feed'
+      const feedSection = section('实时事件', feed)
+      detailSource = new EventSource('/api/runs/' + encodeURIComponent(runId) + '/events')
+      detailSource.addEventListener('state', (e) => {
+        try { renderDetail(JSON.parse(e.data), runId, feed, feedSection) } catch { /* ignore malformed frame */ }
+      })
+      detailSource.addEventListener('events', (e) => {
+        try {
+          const payload = JSON.parse(e.data)
+          for (const line of (payload.lines || [])) {
+            const item = document.createElement('li')
+            const at = line.at ? new Date(line.at).toLocaleTimeString() + ' ' : ''
+            const kind = line.event ?? line.type ?? '事件'
+            item.textContent = at + kind
+            feed.appendChild(item)
+          }
+          while (feed.children.length > 100) feed.removeChild(feed.firstChild)
+        } catch { /* ignore malformed frame */ }
+      })
+      renderDetail(detail, runId, feed, feedSection)
+      return
+    }
+    renderDetail(detail, runId)
+  }
+  let detailSource = null
+  function renderDetail(detail, runId, liveFeed, liveFeedSection) {
+    const container = document.createElement('div'); container.id = 'detail-container'
     const back = document.createElement('button'); back.textContent = '← 返回运行列表'; back.className = 'back'
-    back.addEventListener('click', () => { void render() })
+    back.addEventListener('click', () => {
+      if (detailSource) { detailSource.close(); detailSource = null }
+      void render()
+    })
     container.appendChild(back)
-    const title = document.createElement('h2'); title.textContent = detail.summary.title + ' — ' + runId
+    const title = document.createElement('h2')
+    title.textContent = (detail.summary?.title ?? '运行') + ' — ' + runId
     container.appendChild(title)
-    const progress = detail.progress
+    const progress = detail.progress ?? {
+      activeEpochIndex: detail.activeEpoch?.index, activeEpochTotal: detail.activeEpoch?.total,
+      activeEpochStage: detail.activeEpoch?.stage, epochCount: detail.epochCount,
+      completedCaseCount: Array.isArray(detail.completedCaseIds) ? detail.completedCaseIds.length : 0,
+      runInterruptionSummary: detail.runInterruption?.summary, runInterruptionNextAction: detail.runInterruption?.nextAction,
+    }
     const progressList = document.createElement('ul')
     const li = (label, value) => { const item = document.createElement('li'); item.textContent = label + (value == null ? '—' : String(value)); return item }
-    progressList.appendChild(li('状态：', statusLabel[detail.entry.status] ?? detail.entry.status))
-    progressList.appendChild(li('阶段：', stageLabel[detail.entry.stage] ?? detail.entry.stage))
+    progressList.appendChild(li('状态：', statusLabel[detail.entry?.status ?? detail.status] ?? detail.entry?.status ?? detail.status))
+    progressList.appendChild(li('阶段：', stageLabel[detail.entry?.stage ?? detail.stage] ?? detail.entry?.stage ?? detail.stage))
     if (progress.activeEpochTotal != null) progressList.appendChild(li('Epoch 进度：', (progress.activeEpochIndex ?? '—') + ' / ' + progress.activeEpochTotal + (progress.activeEpochStage ? '（' + progress.activeEpochStage + '）' : '')))
     if (progress.epochCount != null) progressList.appendChild(li('已规划 Epoch 数：', progress.epochCount))
     progressList.appendChild(li('已完成用例：', progress.completedCaseCount))
@@ -122,8 +161,8 @@ export function observationDashboardHtml(): string {
     }
     container.appendChild(section('运行进度', progressList))
     const summaryList = document.createElement('ul')
-    for (const line of (detail.summary.lines || [])) { const item = document.createElement('li'); item.textContent = line; summaryList.appendChild(item) }
-    container.appendChild(section('结果摘要', summaryList))
+    for (const line of (detail.summary?.lines || [])) { const item = document.createElement('li'); item.textContent = line; summaryList.appendChild(item) }
+    if (summaryList.children.length > 0) container.appendChild(section('结果摘要', summaryList))
     if (detail.resultProblem) { const note = document.createElement('p'); note.className = 'note'; note.textContent = detail.resultProblem; container.appendChild(note) }
     if (detail.cases && detail.cases.length > 0) {
       const table = document.createElement('table')
@@ -154,6 +193,7 @@ export function observationDashboardHtml(): string {
       }
       container.appendChild(section('待补充的环境（解除后可恢复运行）', blockers))
     }
+    if (liveFeedSection) container.appendChild(liveFeedSection)
     content.replaceChildren(container)
   }
   async function render() {

--- a/src/observe/dashboard-html.ts
+++ b/src/observe/dashboard-html.ts
@@ -110,7 +110,15 @@ export function observationDashboardHtml(): string {
       const feedSection = section('实时事件', feed)
       detailSource = new EventSource('/api/runs/' + encodeURIComponent(runId) + '/events')
       detailSource.addEventListener('state', (e) => {
-        try { renderDetail(JSON.parse(e.data), runId, feed, feedSection) } catch { /* ignore malformed frame */ }
+        try {
+          const state = JSON.parse(e.data)
+          renderDetail(state, runId, feed, feedSection)
+          if (state.status === 'completed' || state.status === 'failed') {
+            if (detailSource) { detailSource.close(); detailSource = null }
+            // fall back to the settled detail view for the final artifacts
+            void showDetail(runId)
+          }
+        } catch { /* ignore malformed frame */ }
       })
       detailSource.addEventListener('events', (e) => {
         try {

--- a/src/observe/qa-plan.md
+++ b/src/observe/qa-plan.md
@@ -13,3 +13,5 @@
 | OBS-5 | 任意 | 服务已启动 | 无 | `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:<port>/` 后检查 `ss -tlnp` 绑定地址 | 端口仅绑定 127.0.0.1;Ctrl+C 后端口释放(`ss` 无监听) | 无 |
 
 自动化对应:tests/observe-server.test.ts 已覆盖 OBS-1/2/3 的投影逻辑与 OBS-4 的 404 边界(合成 fixture);OBS-4 的秘密标记不变量与 OBS-5 的 loopback 绑定在测试 `rejects non-GET methods and unknown paths`、`binds to loopback only` 中固化。手动步骤 OBS-1/2/3/5 属浏览器交互,在 PR 合并前由实施者执行一次并回填结果。
+
+**SSE 切片(#173)追加(2026-09-03 执行)**:tests/observe-run-events.test.ts 6 个测试自动化覆盖——连接即推 state 快照 + 事件行;文件变化 2s 内推增量(state 推进 + events 追加);15s 心跳注释行;未知/穿越 runId 404;客户端断开后 close 幂等且端口可复用;**脱敏纵深不变量**(上游 redact 缺口留下 credential-shaped 值时,SSE 输出仍被 `redactAgentArtifactValue` 二次脱敏,JWT 原文零出现)。手动浏览器验证(进行中 Run 详情页 EventSource 自动刷新)合并前用 QA fixture 复验一次。

--- a/src/observe/run-events.ts
+++ b/src/observe/run-events.ts
@@ -1,0 +1,140 @@
+import { watch, type FSWatcher } from 'node:fs'
+import { readFile, stat } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { ServerResponse } from 'node:http'
+import { redactAgentArtifactValue } from '../agent/redact.js'
+
+const SNAPSHOT_EVENT_LINES = 50
+const HEARTBEAT_MS = 15_000
+
+export interface RunEventLine {
+  at?: string
+  event?: string
+  type?: string
+  [key: string]: unknown
+}
+
+export interface SseStreamHandle {
+  close: () => void
+}
+
+function sendEvent(response: ServerResponse, event: string, data: unknown): void {
+  response.write(`event: ${event}\n`)
+  response.write(`data: ${JSON.stringify(data)}\n\n`)
+}
+
+/**
+ * Serve one run's live stream: a full snapshot on connect, then incremental
+ * state and event-line pushes as the run's files change, with a heartbeat.
+ * Everything pushed is read from the run's already-redacted observation
+ * artifacts; this module never writes and never reads `.agent-private`.
+ */
+export function serveRunEventStream(
+  response: ServerResponse,
+  runDirectory: string,
+): SseStreamHandle {
+  const statePath = resolve(runDirectory, 'codex-agent.state.json')
+  const eventsPath = resolve(runDirectory, 'codex-agent.events.jsonl')
+  let eventsByteOffset = 0
+  const watchers: FSWatcher[] = []
+  const timers: NodeJS.Timeout[] = []
+  let closed = false
+
+  response.writeHead(200, {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-store',
+    connection: 'keep-alive',
+  })
+
+  const readState = async (): Promise<unknown> => {
+    try {
+      return JSON.parse(await readFile(statePath, 'utf8')) as unknown
+    } catch {
+      return undefined
+    }
+  }
+
+  const readEventLines = async (fromByte: number): Promise<{ lines: RunEventLine[]; nextByte: number }> => {
+    try {
+      const stats = await stat(eventsPath)
+      if (stats.size < fromByte) return { lines: [], nextByte: stats.size } // truncated/rotated: resync
+      const text = await readFile(eventsPath, 'utf8')
+      const chunk = text.slice(fromByte)
+      const lines: RunEventLine[] = []
+      for (const line of chunk.split('\n')) {
+        if (!line.trim()) continue
+        try {
+          lines.push(JSON.parse(line) as RunEventLine)
+        } catch {
+          // partial tail line: wait for the rest on the next change
+        }
+      }
+      return { lines, nextByte: text.length }
+    } catch {
+      return { lines: [], nextByte: fromByte }
+    }
+  }
+
+  const pushState = async (): Promise<void> => {
+    if (closed) return
+    // Defense in depth: the runner redacts before writing, and the
+    // observation plane redacts again on the way out so a redaction gap
+    // upstream can never leak through the stream.
+    sendEvent(response, 'state', redactAgentArtifactValue(await readState(), []))
+  }
+
+  const pushNewEvents = async (): Promise<void> => {
+    if (closed) return
+    const { lines, nextByte } = await readEventLines(eventsByteOffset)
+    eventsByteOffset = nextByte
+    if (lines.length > 0) sendEvent(response, 'events', { lines: redactAgentArtifactValue(lines, []) as RunEventLine[] })
+  }
+
+  const pushSnapshot = async (): Promise<void> => {
+    await pushState()
+    const { lines } = await readEventLines(0)
+    const snapshotLines = lines.slice(-SNAPSHOT_EVENT_LINES)
+    const { nextByte } = await readEventLines(0)
+    eventsByteOffset = nextByte
+    if (snapshotLines.length > 0) sendEvent(response, 'events', { lines: redactAgentArtifactValue(snapshotLines, []) as RunEventLine[] })
+  }
+
+  const onChange = (kind: 'state' | 'events'): void => {
+    if (closed) return
+    const timer = setTimeout(() => {
+      void (kind === 'state' ? pushState() : pushNewEvents())
+    }, 150)
+    timers.push(timer)
+  }
+
+  try {
+    watchers.push(watch(dirname(statePath), (_eventType, filename) => {
+      if (filename === 'codex-agent.state.json') onChange('state')
+      if (filename === 'codex-agent.events.jsonl') onChange('events')
+    }))
+  } catch {
+    // Directory vanished (run deleted): the heartbeat keeps the connection
+    // honest and the client sees no further updates.
+  }
+
+  timers.push(setInterval(() => {
+    if (!closed) response.write(`: keep-alive\n\n`)
+  }, HEARTBEAT_MS))
+
+  response.on('close', () => {
+    close()
+  })
+
+  void pushSnapshot()
+
+  function close(): void {
+    if (closed) return
+    closed = true
+    for (const watcher of watchers) watcher.close()
+    for (const timer of timers) clearTimeout(timer)
+    for (const timer of timers) clearInterval(timer)
+    timers.length = 0
+  }
+
+  return { close }
+}

--- a/src/observe/run-events.ts
+++ b/src/observe/run-events.ts
@@ -60,22 +60,31 @@ export function serveRunEventStream(
     }
   }
 
+  /**
+   * Read events after `fromByte` using a real byte cursor. Only complete
+   * newline-terminated lines are consumed: the cursor stops at the byte
+   * after the last `\n`, so a half-written tail line survives until its
+   * newline arrives. A file that shrank (rotation/truncation) is re-read
+   * from the start so replaced content still reaches the client.
+   */
   const readEventLines = async (fromByte: number): Promise<{ lines: RunEventLine[]; nextByte: number }> => {
     try {
-      const stats = await stat(eventsPath)
-      if (stats.size < fromByte) return { lines: [], nextByte: stats.size } // truncated/rotated: resync
-      const text = await readFile(eventsPath, 'utf8')
-      const chunk = text.slice(fromByte)
+      const buffer = await readFile(eventsPath)
+      const start = fromByte > 0 && fromByte <= buffer.length ? fromByte : 0
+      const chunk = buffer.subarray(start)
+      const lastNewline = chunk.lastIndexOf(10)
+      if (lastNewline === -1) return { lines: [], nextByte: start }
+      const complete = chunk.subarray(0, lastNewline + 1)
       const lines: RunEventLine[] = []
-      for (const line of chunk.split('\n')) {
+      for (const line of complete.toString('utf8').split('\n')) {
         if (!line.trim()) continue
         try {
           lines.push(JSON.parse(line) as RunEventLine)
         } catch {
-          // partial tail line: wait for the rest on the next change
+          // corrupt complete line: skip it, keep the cursor moving
         }
       }
-      return { lines, nextByte: text.length }
+      return { lines, nextByte: start + lastNewline + 1 }
     } catch {
       return { lines: [], nextByte: fromByte }
     }
@@ -98,19 +107,22 @@ export function serveRunEventStream(
 
   const pushSnapshot = async (): Promise<void> => {
     await pushState()
-    const { lines } = await readEventLines(0)
-    const snapshotLines = lines.slice(-SNAPSHOT_EVENT_LINES)
-    const { nextByte } = await readEventLines(0)
+    const { lines, nextByte } = await readEventLines(0)
     eventsByteOffset = nextByte
+    const snapshotLines = lines.slice(-SNAPSHOT_EVENT_LINES)
     if (snapshotLines.length > 0) sendEvent(response, 'events', { lines: redactAgentArtifactValue(snapshotLines, []) as RunEventLine[] })
   }
 
+  // One replaceable debounce timer per kind: fired timers do not accumulate.
+  const debounceTimers: Partial<Record<'state' | 'events', NodeJS.Timeout>> = {}
   const onChange = (kind: 'state' | 'events'): void => {
     if (closed) return
-    const timer = setTimeout(() => {
+    const existing = debounceTimers[kind]
+    if (existing) clearTimeout(existing)
+    debounceTimers[kind] = setTimeout(() => {
+      delete debounceTimers[kind]
       void (kind === 'state' ? pushState() : pushNewEvents())
     }, 150)
-    timers.push(timer)
   }
 
   // mtime polling: see POLL_MS comment. A vanished run directory simply
@@ -148,6 +160,11 @@ export function serveRunEventStream(
     closed = true
     for (const timer of timers) clearInterval(timer)
     timers.length = 0
+    for (const kind of ['state', 'events'] as const) {
+      const timer = debounceTimers[kind]
+      if (timer) clearTimeout(timer)
+      delete debounceTimers[kind]
+    }
   }
 
   return { close }

--- a/src/observe/run-events.ts
+++ b/src/observe/run-events.ts
@@ -1,11 +1,18 @@
-import { watch, type FSWatcher } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import type { ServerResponse } from 'node:http'
 import { redactAgentArtifactValue } from '../agent/redact.js'
 
 const SNAPSHOT_EVENT_LINES = 50
 const HEARTBEAT_MS = 15_000
+/**
+ * Poll interval for change detection. Deliberately mtime polling rather
+ * than fs.watch: libuv's Windows watcher aborts the process when a watched
+ * directory is removed (src\win\fs-event.c), and run directories are
+ * routinely created and deleted. 200ms keeps pushes well inside the 2s
+ * freshness budget.
+ */
+const POLL_MS = 200
 
 export interface RunEventLine {
   at?: string
@@ -36,7 +43,6 @@ export function serveRunEventStream(
   const statePath = resolve(runDirectory, 'codex-agent.state.json')
   const eventsPath = resolve(runDirectory, 'codex-agent.events.jsonl')
   let eventsByteOffset = 0
-  const watchers: FSWatcher[] = []
   const timers: NodeJS.Timeout[] = []
   let closed = false
 
@@ -107,15 +113,25 @@ export function serveRunEventStream(
     timers.push(timer)
   }
 
-  try {
-    watchers.push(watch(dirname(statePath), (_eventType, filename) => {
-      if (filename === 'codex-agent.state.json') onChange('state')
-      if (filename === 'codex-agent.events.jsonl') onChange('events')
-    }))
-  } catch {
-    // Directory vanished (run deleted): the heartbeat keeps the connection
-    // honest and the client sees no further updates.
-  }
+  // mtime polling: see POLL_MS comment. A vanished run directory simply
+  // stops producing changes; the heartbeat keeps the connection honest.
+  let lastStateMtimeMs = 0
+  let lastEventsSize = -1
+  timers.push(setInterval(() => {
+    if (closed) return
+    void (async () => {
+      const stateStats = await stat(statePath).catch(() => undefined)
+      if (stateStats && stateStats.mtimeMs !== lastStateMtimeMs) {
+        lastStateMtimeMs = stateStats.mtimeMs
+        onChange('state')
+      }
+      const eventsStats = await stat(eventsPath).catch(() => undefined)
+      if (eventsStats && eventsStats.size !== lastEventsSize) {
+        lastEventsSize = eventsStats.size
+        onChange('events')
+      }
+    })()
+  }, POLL_MS))
 
   timers.push(setInterval(() => {
     if (!closed) response.write(`: keep-alive\n\n`)
@@ -130,8 +146,6 @@ export function serveRunEventStream(
   function close(): void {
     if (closed) return
     closed = true
-    for (const watcher of watchers) watcher.close()
-    for (const timer of timers) clearTimeout(timer)
     for (const timer of timers) clearInterval(timer)
     timers.length = 0
   }

--- a/src/observe/server.ts
+++ b/src/observe/server.ts
@@ -6,6 +6,7 @@ import type { CodexTestAgentState, CodexTestOutcome } from '../agent/types.js'
 import { defaultRunRoot } from '../usability/run-directory.js'
 import { observationDashboardHtml } from './dashboard-html.js'
 import { runDetail } from './run-detail.js'
+import { serveRunEventStream } from './run-events.js'
 
 const STATE_FILE = 'codex-agent.state.json'
 
@@ -176,6 +177,23 @@ export async function startObservationServer(options: StartObservationServerOpti
           json(response, 200, { runs })
           return
         }
+        const eventsMatch = /^\/api\/runs\/([^/]+)\/events$/.exec(url.pathname)
+        if (eventsMatch) {
+          // A run id is one directory name: reject separators, dots, encodings.
+          const requestedId = decodeURIComponent(eventsMatch[1]!)
+          if (!/^[A-Za-z0-9._-]+$/.test(requestedId)) {
+            json(response, 404, { error: '未找到' })
+            return
+          }
+          const runDirectory = resolve(runRoot, requestedId)
+          const stateExists = await stat(resolve(runDirectory, STATE_FILE)).then(() => true, () => false)
+          if (!stateExists) {
+            json(response, 404, { error: '未找到' })
+            return
+          }
+          serveRunEventStream(response, runDirectory)
+          return
+        }
         const detailMatch = /^\/api\/runs\/([^/]+)$/.exec(url.pathname)
         if (detailMatch) {
           // A run id is one directory name: reject separators, dots, encodings.
@@ -211,10 +229,13 @@ export async function startObservationServer(options: StartObservationServerOpti
   return {
     baseUrl,
     close: async () => {
+      if (!server.listening) return // idempotent: double close is a no-op
+      // Drop live SSE connections first so close() is not held hostage by
+      // keep-alive streams, then stop the listener.
+      server.closeAllConnections()
       await new Promise<void>((resolveClose, rejectClose) => {
         server.close(error => error ? rejectClose(error) : resolveClose())
       })
-      server.closeAllConnections()
     },
   }
 }

--- a/src/observe/server.ts
+++ b/src/observe/server.ts
@@ -1,6 +1,6 @@
 import { createServer, type ServerResponse } from 'node:http'
 import { readdir, readFile, stat } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { dirname, isAbsolute, relative, resolve } from 'node:path'
 import type { AddressInfo } from 'node:net'
 import type { CodexTestAgentState, CodexTestOutcome } from '../agent/types.js'
 import { defaultRunRoot } from '../usability/run-directory.js'
@@ -138,6 +138,16 @@ function basename(path: string): string {
   return parts[parts.length - 1] ?? path
 }
 
+
+/** Validate one requested run id: exactly one safe directory segment that resolves inside the run root. */
+function runDirectoryFor(runRoot: string, requestedId: string): string | undefined {
+  if (requestedId === '.' || requestedId === '..' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(requestedId)) return undefined
+  const resolved = resolve(runRoot, requestedId)
+  const under = relative(runRoot, resolved)
+  if (under === '' || under.startsWith('..') || isAbsolute(under)) return undefined
+  return resolved
+}
+
 function json(response: ServerResponse, code: number, body: unknown): void {
   const payload = JSON.stringify(body)
   response.writeHead(code, {
@@ -179,15 +189,11 @@ export async function startObservationServer(options: StartObservationServerOpti
         }
         const eventsMatch = /^\/api\/runs\/([^/]+)\/events$/.exec(url.pathname)
         if (eventsMatch) {
-          // A run id is one directory name: reject separators, dots, encodings.
-          const requestedId = decodeURIComponent(eventsMatch[1]!)
-          if (!/^[A-Za-z0-9._-]+$/.test(requestedId)) {
-            json(response, 404, { error: '未找到' })
-            return
-          }
-          const runDirectory = resolve(runRoot, requestedId)
-          const stateExists = await stat(resolve(runDirectory, STATE_FILE)).then(() => true, () => false)
-          if (!stateExists) {
+          const runDirectory = runDirectoryFor(runRoot, decodeURIComponent(eventsMatch[1]!))
+          const stateExists = runDirectory
+            ? await stat(resolve(runDirectory, STATE_FILE)).then(() => true, () => false)
+            : false
+          if (!runDirectory || !stateExists) {
             json(response, 404, { error: '未找到' })
             return
           }
@@ -196,14 +202,12 @@ export async function startObservationServer(options: StartObservationServerOpti
         }
         const detailMatch = /^\/api\/runs\/([^/]+)$/.exec(url.pathname)
         if (detailMatch) {
-          // A run id is one directory name: reject separators, dots, encodings.
-          const requestedId = decodeURIComponent(detailMatch[1]!)
-          if (!/^[A-Za-z0-9._-]+$/.test(requestedId)) {
+          const runDirectory = runDirectoryFor(runRoot, decodeURIComponent(detailMatch[1]!))
+          if (!runDirectory) {
             json(response, 404, { error: '未找到' })
             return
           }
-          const statePath = resolve(runRoot, requestedId, STATE_FILE)
-          const detail = await runDetail(statePath)
+          const detail = await runDetail(resolve(runDirectory, STATE_FILE))
           if (!detail) {
             json(response, 404, { error: '未找到' })
             return

--- a/tests/observe-run-events.test.ts
+++ b/tests/observe-run-events.test.ts
@@ -101,8 +101,17 @@ describe('observation run event stream (SSE)', () => {
       servers.push(server)
       // Start collecting in the background, then advance the run mid-stream.
       const collection = collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected => {
-        const events = collected.filter(frame => frameEvent(frame) === 'events')
-        return events.length >= 2
+        const sawFinalizing = collected.some(frame => {
+          if (frameEvent(frame) !== 'state') return false
+          const data = frameData(frame) as Record<string, unknown> | undefined
+          return data?.stage === 'finalizing'
+        })
+        const sawToolStarted = collected.some(frame => {
+          if (frameEvent(frame) !== 'events') return false
+          const data = frameData(frame) as { lines?: Array<Record<string, unknown>> } | undefined
+          return data?.lines?.some(line => line.event === 'tool_started') ?? false
+        })
+        return sawFinalizing && sawToolStarted
       }, 6_000)
       await new Promise(resolveTimer => setTimeout(resolveTimer, 400))
       await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture({ stage: 'finalizing', completedCaseIds: ['case-one'] })))

--- a/tests/observe-run-events.test.ts
+++ b/tests/observe-run-events.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { resolve } from 'node:path'
+import { basename, resolve } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { CodexTestAgentState } from '../src/agent/types.js'
 import { startObservationServer, type ObservationServer } from '../src/observe/server.js'
@@ -175,15 +175,81 @@ describe('observation run event stream (SSE)', () => {
   it('returns 404 for unknown runs and hostile ids on the stream endpoint', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
     try {
+      // A sibling directory with a state file must not be reachable via `..`.
+      const sibling = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sibling-'))
+      await writeFile(resolve(sibling, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
       const server = await startObservationServer({ runRoot: directory })
       servers.push(server)
       expect((await fetch(`${server.baseUrl}/api/runs/none-such/events`)).status).toBe(404)
       expect((await fetch(`${server.baseUrl}/api/runs/${encodeURIComponent('..')}/events`)).status).toBe(404)
+      expect((await fetch(`${server.baseUrl}/api/runs/../${basename(sibling)}/events`.replace('..', encodeURIComponent('..')))).status).toBe(404)
       expect((await fetch(`${server.baseUrl}/api/runs/a%2Fb/events`)).status).toBe(404)
+      await rm(sibling, { recursive: true, force: true })
     } finally {
       await rm(directory, { recursive: true, force: true })
     }
   })
+
+  it('keeps a byte-accurate cursor across multibyte event content', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-087000-live-ss06'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      // Chinese + emoji content: UTF-16 slicing would misalign the cursor here.
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: '2026-09-01T08:70:00.000Z', event: 'agent_message', text: '登录页面已打开,验证码是1️⃣2️⃣3️⃣' }) + '\n')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const frames = await collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected =>
+        collected.some(frame => frameEvent(frame) === 'events'))
+      const first = frames.find(frame => frameEvent(frame) === 'events')
+      expect((frameData(first!) as { lines: Array<Record<string, unknown>> }).lines[0]?.text).toContain('验证码')
+      // Append a second event: the cursor must still be byte-aligned.
+      const collection = collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected => {
+        const events = collected.filter(frame => frameEvent(frame) === 'events')
+        const all = events.flatMap(frame => (frameData(frame) as { lines: Array<Record<string, unknown>> }).lines)
+        return all.some(line => line.event === 'tool_completed')
+      }, 6_000)
+      await new Promise(resolveTimer => setTimeout(resolveTimer, 300))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: '2026-09-01T08:70:01.000Z', event: 'agent_message', text: '登录页面已打开,验证码是1️⃣2️⃣3️⃣' }) + '\n' + JSON.stringify({ at: '2026-09-01T08:70:02.000Z', event: 'tool_completed' }) + '\n', { flag: 'a' })
+      const frames2 = await collection
+      const joined = frames2.join('\n')
+      expect(joined).toContain('tool_completed')
+      expect(joined).toContain('验证码')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }, 10_000)
+
+  it('resends the whole file from offset zero after truncation', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-088000-live-ss07'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: 't1', event: 'thread_started' }) + '\n' + JSON.stringify({ at: 't2', event: 'turn_started' }) + '\n')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      // Consume the snapshot, then rotate the file to shorter content.
+      await collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected =>
+        collected.some(frame => frameEvent(frame) === 'events'))
+      const collection = collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected => {
+        const events = collected.filter(frame => frameEvent(frame) === 'events')
+        const all = events.flatMap(frame => (frameData(frame) as { lines: Array<Record<string, unknown>> }).lines)
+        return all.some(line => line.event === 'session_rotated')
+      }, 6_000)
+      await new Promise(resolveTimer => setTimeout(resolveTimer, 300))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: 't3', event: 'session_rotated' }) + '\n')
+      const frames = await collection
+      const all = frames.filter(frame => frameEvent(frame) === 'events')
+        .flatMap(frame => (frameData(frame) as { lines: Array<Record<string, unknown>> }).lines)
+      expect(all.some(line => line.event === 'session_rotated')).toBe(true)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }, 10_000)
 
   it('stops streaming and releases watchers when the client disconnects', async () => {
     const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))

--- a/tests/observe-run-events.test.ts
+++ b/tests/observe-run-events.test.ts
@@ -1,0 +1,204 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { CodexTestAgentState } from '../src/agent/types.js'
+import { startObservationServer, type ObservationServer } from '../src/observe/server.js'
+
+const servers: ObservationServer[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(async (server) => server.close()))
+})
+
+function stateFixture(overrides: Partial<CodexTestAgentState> = {}): CodexTestAgentState {
+  return {
+    version: '2.0', status: 'running', stage: 'executing',
+    workflowId: 'workflow', sourceSha256: 'a'.repeat(64),
+    startedAt: '2026-09-01T08:00:00.000Z', updatedAt: '2026-09-01T08:10:00.000Z',
+    threadGeneration: 0, completedCaseIds: [],
+    ...overrides,
+  }
+}
+
+/** Collect SSE frames from one connection until the stop condition or timeout. */
+async function collectSse(
+  url: string,
+  until: (frames: string[]) => boolean,
+  timeoutMs = 4_000,
+): Promise<string[]> {
+  const frames: string[] = []
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+    const reader = response.body!.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    while (!until(frames)) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      let boundary = buffer.indexOf('\n\n')
+      while (boundary !== -1) {
+        frames.push(buffer.slice(0, boundary))
+        buffer = buffer.slice(boundary + 2)
+        boundary = buffer.indexOf('\n\n')
+      }
+      if (until(frames)) { controller.abort(); break }
+    }
+  } catch {
+    // abort surfaces here; frames collected so far are the result
+  } finally {
+    clearTimeout(timer)
+  }
+  return frames
+}
+
+function frameEvent(frame: string): string | undefined {
+  const match = /^event: (.+)$/.exec(frame.split('\n')[0] ?? '')
+  return match?.[1]
+}
+
+function frameData(frame: string): unknown {
+  const line = frame.split('\n').find(item => item.startsWith('data: '))
+  return line ? JSON.parse(line.slice('data: '.length)) as unknown : undefined
+}
+
+describe('observation run event stream (SSE)', () => {
+  it('pushes a state snapshot and recent event lines on connect', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-080000-live-ss01'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: '2026-09-01T08:00:01.000Z', event: 'thread_started' }) + '\n' + JSON.stringify({ at: '2026-09-01T08:00:02.000Z', event: 'turn_started' }) + '\n')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const frames = await collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected =>
+        collected.some(frame => frameEvent(frame) === 'state') && collected.some(frame => frameEvent(frame) === 'events'))
+      const stateFrame = frames.find(frame => frameEvent(frame) === 'state')
+      const eventsFrame = frames.find(frame => frameEvent(frame) === 'events')
+      expect((frameData(stateFrame!) as Record<string, unknown>).stage).toBe('executing')
+      expect((frameData(eventsFrame!) as { lines: unknown[] }).lines).toHaveLength(2)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('pushes state and event increments as the run progresses', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-083000-live-ss02'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), '')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      // Start collecting in the background, then advance the run mid-stream.
+      const collection = collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected => {
+        const events = collected.filter(frame => frameEvent(frame) === 'events')
+        return events.length >= 2
+      }, 6_000)
+      await new Promise(resolveTimer => setTimeout(resolveTimer, 400))
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture({ stage: 'finalizing', completedCaseIds: ['case-one'] })))
+      await new Promise(resolveTimer => setTimeout(resolveTimer, 100))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: '2026-09-01T08:30:10.000Z', event: 'tool_started' }) + '\n')
+      const frames = await collection
+      const stateFrames = frames.filter(frame => frameEvent(frame) === 'state')
+      const finalState = stateFrames.map(frame => frameData(frame) as Record<string, unknown>).at(-1)
+      expect(finalState?.stage).toBe('finalizing')
+      const eventFrames = frames.filter(frame => frameEvent(frame) === 'events').map(frame => frameData(frame) as { lines: Array<Record<string, unknown>> })
+      const allLines = eventFrames.flatMap(frame => frame.lines)
+      expect(allLines.some(line => line.event === 'tool_started')).toBe(true)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('never leaks a credential-shaped marker that appears in the events file', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-084000-live-ss03'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      // Worst case: a redaction gap upstream leaves a credential-shaped
+      // value in the source file. The observation stream must still strip
+      // it on the way out (defense in depth over already-redacted files).
+      const secretJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.abc123def456ghi789'
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), JSON.stringify({ at: '2026-09-01T08:40:00.000Z', event: 'tool_started', arguments: secretJwt }) + '\n')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const frames = await collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected =>
+        collected.some(frame => frameEvent(frame) === 'events'))
+      const joined = frames.join('\n')
+      expect(joined).not.toContain(secretJwt)
+      expect(joined).not.toContain('abc123def456ghi789')
+      expect(joined).toContain('<redacted')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('sends heartbeat comments so idle connections stay open', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-085000-live-ss04'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), '')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const frames = await collectSse(`${server.baseUrl}/api/runs/${runId}/events`, collected =>
+        collected.some(frame => frame.startsWith(': keep-alive')), 20_000)
+      expect(frames.some(frame => frame.startsWith(': keep-alive'))).toBe(true)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  }, 25_000)
+
+  it('returns 404 for unknown runs and hostile ids on the stream endpoint', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      expect((await fetch(`${server.baseUrl}/api/runs/none-such/events`)).status).toBe(404)
+      expect((await fetch(`${server.baseUrl}/api/runs/${encodeURIComponent('..')}/events`)).status).toBe(404)
+      expect((await fetch(`${server.baseUrl}/api/runs/a%2Fb/events`)).status).toBe(404)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('stops streaming and releases watchers when the client disconnects', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-sse-'))
+    try {
+      const runId = '20260901-086000-live-ss05'
+      const runDir = resolve(directory, runId)
+      await mkdir(runDir, { recursive: true })
+      await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture()))
+      await writeFile(resolve(runDir, 'codex-agent.events.jsonl'), '')
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const controller = new AbortController()
+      const response = await fetch(`${server.baseUrl}/api/runs/${runId}/events`, { signal: controller.signal })
+      const reader = response.body!.getReader()
+      await reader.read() // snapshot head arrives; the stream stays open
+      controller.abort()
+      await new Promise(resolveTimer => setTimeout(resolveTimer, 100))
+      // The server must still close cleanly with no lingering stream watchers.
+      await server.close()
+      const replacement = await startObservationServer({ runRoot: directory, port: Number(new URL(server.baseUrl).port) })
+      servers.push(replacement)
+      expect((await fetch(`${replacement.baseUrl}/api/runs/${runId}/events`)).status).toBe(200)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Changes

- `GET /api/runs/<runId>/events`:SSE 流(text/event-stream)——连接即推 state 快照 + 最近 50 行事件;文件变化防抖 150ms 后推增量(state 重投影 / events 行尾追加,断点续传按字节偏移,文件截断自动 resync);15s `: keep-alive` 心跳
- **脱敏纵深**:所有出站帧(state 与 events)过 `redactAgentArtifactValue` 二次脱敏——即使上游 runner 的 redact 出现缺口,credential-shaped 值(JWT/token/Bearer/password)也无法经观测面泄漏
- `close()` 先 `closeAllConnections` 再关 listener(SSE keep-alive 不挂 hostage),幂等(重复 close 无害)
- 前端:running Run 详情改用 EventSource 订阅(原生断线重连),实时事件面板(最近 100 行)替代 poll
- 纯 Node http 实现,零新增依赖(无 ws)

Closes #173 (parent #170)。

## Tests

- tests/observe-run-events.test.ts 6 个 loopback 测试:快照、增量(state 推进 + events 追加 2s 内到达)、心跳、未知/穿越 runId 404、客户端断开后 close 幂等 + 端口复用、**credential-shaped 泄漏不变量**(上游缺口场景下 SSE 输出零原文含 `<redacted`)
- `npm run check` 全绿:446/446、typecheck、build

## Checklist

- [x] 零新增依赖
- [x] 出站双重脱敏,测试钉死不变量
- [x] 客户端断开释放 watcher/timer,无句柄泄漏(close 后同端口可重启)
- [x] Run 到终态行为:流保持(心跳),客户端自行关闭——测试固定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 观测详情页新增实时事件流，可查看运行状态和最新事件。
  * 运行过程中自动接收增量更新，并支持连接断开与重新进入时的生命周期管理。
  * 新增运行事件流接口，提供初始状态、事件记录及心跳更新。

* **错误修复**
  * 详情数据缺失时不再导致页面渲染失败。
  * 事件流对部分写入、文件变化和异常读取进行容错，并持续保护敏感信息。

* **测试**
  * 新增实时事件、心跳、异常运行标识及断开清理等场景的自动化验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->