### PR TITLE
feat(observe): evidence viewer with explicit read-only allowlist

### DIFF
--- a/src/observe/dashboard-html.ts
+++ b/src/observe/dashboard-html.ts
@@ -31,6 +31,11 @@ export function observationDashboardHtml(): string {
   .note { padding: 8px 12px; background: #fef3c7; border-radius: 6px; font-size: 13px; }
   ul.feed { list-style: none; padding-left: 0; max-height: 260px; overflow-y: auto; font-size: 13px; font-family: ui-monospace, monospace; }
   ul.feed li { padding: 2px 0; border-bottom: 1px dashed #e6e8ec; }
+  ul.evidence { list-style: none; padding-left: 0; margin: 0; font-size: 12px; }
+  ul.evidence li { padding: 1px 0; }
+  ul.evidence a { color: #1d4ed8; text-decoration: none; }
+  ul.evidence a:hover { text-decoration: underline; }
+  @media (prefers-color-scheme: dark) { ul.evidence a { color: #93c5fd; } }
   @media (prefers-color-scheme: dark) {
     body { background: #101418; color: #e5e7eb; }
     table { background: #161b22; }
@@ -175,7 +180,7 @@ export function observationDashboardHtml(): string {
     if (detail.cases && detail.cases.length > 0) {
       const table = document.createElement('table')
       const head = document.createElement('thead')
-      head.innerHTML = '<tr><th>用例</th><th>标题</th><th>结果</th><th>失败来源</th><th>失败类型</th><th>摘要</th><th>证据数</th></tr>'
+      head.innerHTML = '<tr><th>用例</th><th>标题</th><th>结果</th><th>失败来源</th><th>失败类型</th><th>摘要</th><th>证据</th></tr>'
       table.appendChild(head)
       const body = document.createElement('tbody')
       for (const item of detail.cases) {
@@ -186,7 +191,31 @@ export function observationDashboardHtml(): string {
         tr.appendChild(cell(item.failureSource))
         tr.appendChild(cell(item.failureKind))
         tr.appendChild(cell(item.summary))
-        tr.appendChild(cell(item.evidenceCount))
+        const evidenceCell = document.createElement('td')
+        if (item.evidence && item.evidence.length > 0) {
+          const list = document.createElement('ul'); list.className = 'evidence'
+          for (const entry of item.evidence) {
+            const li = document.createElement('li')
+            if (entry.path) {
+              // Results record evidence paths relative to agent-workspace
+              // (evidence/<file>); the route serves from inside that directory.
+              let relativePath = entry.path
+              if (relativePath.startsWith('evidence/')) relativePath = relativePath.slice('evidence/'.length)
+              const link = document.createElement('a')
+              link.href = '/api/runs/' + encodeURIComponent(runId) + '/evidence/' + relativePath.split('/').map(encodeURIComponent).join('/')
+              link.target = '_blank'; link.rel = 'noopener'
+              link.textContent = (entry.kind ? entry.kind + '：' : '') + entry.path
+              li.appendChild(link)
+            } else {
+              li.textContent = (entry.kind ? entry.kind + '：' : '') + entry.description
+            }
+            list.appendChild(li)
+          }
+          evidenceCell.appendChild(list)
+        } else {
+          evidenceCell.textContent = '—'
+        }
+        tr.appendChild(evidenceCell)
         body.appendChild(tr)
       }
       table.appendChild(body)

--- a/src/observe/evidence.ts
+++ b/src/observe/evidence.ts
@@ -1,0 +1,72 @@
+import { readFile, stat } from 'node:fs/promises'
+import { extname, relative, resolve } from 'node:path'
+import type { ServerResponse } from 'node:http'
+
+/** Content types the observation plane is allowed to serve. */
+const IMAGE_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+}
+const TEXT_TYPES: Record<string, string> = {
+  '.txt': 'text/plain; charset=utf-8',
+  '.log': 'text/plain; charset=utf-8',
+  '.md': 'text/plain; charset=utf-8',
+  '.json': 'text/plain; charset=utf-8',
+}
+const MAX_EVIDENCE_BYTES = 20 * 1024 * 1024
+
+export interface EvidenceServingResult {
+  bytes: Buffer
+  contentType: string
+}
+
+/**
+ * Read one evidence file for the observation plane. The requested path must
+ * resolve strictly inside the run's `agent-workspace/evidence` directory and
+ * carry an extension the plane is allowed to serve. Anything else — a
+ * traversal, an absolute path, `.agent-private`, the raw workbook copy, an
+ * unknown extension, an oversized file — is refused.
+ */
+export async function readEvidenceFile(
+  runDirectory: string,
+  requestedPath: string,
+): Promise<EvidenceServingResult | undefined> {
+  const evidenceRoot = resolve(runDirectory, 'agent-workspace', 'evidence')
+  // Result contracts record paths relative to agent-workspace, so accept a
+  // leading `evidence/` prefix and normalize it away.
+  const normalized = requestedPath.replace(/^evidence\//, '')
+  const requested = resolve(evidenceRoot, normalized)
+  const inside = relative(evidenceRoot, requested)
+  if (inside === '' || inside.startsWith('..') || inside.includes('..') || requested.includes('.agent-private')) return undefined
+  const extension = extname(requested).toLowerCase()
+  const contentType = IMAGE_TYPES[extension] ?? TEXT_TYPES[extension]
+  if (!contentType) return undefined
+  let stats
+  try {
+    stats = await stat(requested)
+  } catch {
+    return undefined
+  }
+  if (!stats.isFile() || stats.size > MAX_EVIDENCE_BYTES) return undefined
+  const bytes = await readFile(requested)
+  return { bytes, contentType }
+}
+
+/** Stream one evidence file to the response with no-store caching. */
+export async function serveEvidenceFile(
+  response: ServerResponse,
+  runDirectory: string,
+  requestedPath: string,
+): Promise<void> {
+  const result = await readEvidenceFile(runDirectory, requestedPath)
+  if (!result) {
+    response.writeHead(404, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' })
+    response.end(JSON.stringify({ error: '未找到' }))
+    return
+  }
+  response.writeHead(200, { 'content-type': result.contentType, 'cache-control': 'no-store' })
+  response.end(result.bytes)
+}

--- a/src/observe/qa-plan.md
+++ b/src/observe/qa-plan.md
@@ -15,3 +15,5 @@
 自动化对应:tests/observe-server.test.ts 已覆盖 OBS-1/2/3 的投影逻辑与 OBS-4 的 404 边界(合成 fixture);OBS-4 的秘密标记不变量与 OBS-5 的 loopback 绑定在测试 `rejects non-GET methods and unknown paths`、`binds to loopback only` 中固化。手动步骤 OBS-1/2/3/5 属浏览器交互,在 PR 合并前由实施者执行一次并回填结果。
 
 **SSE 切片(#173)追加(2026-09-03 执行)**:tests/observe-run-events.test.ts 6 个测试自动化覆盖——连接即推 state 快照 + 事件行;文件变化 2s 内推增量(state 推进 + events 追加);15s 心跳注释行;未知/穿越 runId 404;客户端断开后 close 幂等且端口可复用;**脱敏纵深不变量**(上游 redact 缺口留下 credential-shaped 值时,SSE 输出仍被 `redactAgentArtifactValue` 二次脱敏,JWT 原文零出现)。手动浏览器验证(进行中 Run 详情页 EventSource 自动刷新)合并前用 QA fixture 复验一次。
+
+**证据查看切片(#174)追加(2026-09-03 执行)**:tests/observe-evidence.test.ts 5 个测试自动化覆盖——evidence 目录内 png/txt 按 content-type 返回(浏览器可直接渲染);未知扩展(.bin)与原始工作簿副本拒绝;穿越/绝对路径/编码逃逸(`..`、`%2e%2e%2f`、`../../etc/passwd`、`.agent-private` 直读)全部 404;result 契约路径形态(`evidence/<file>` 与剥前缀)可打开;全部 API 响应零 `OBS-SECRET-MARKER` 泄漏。allowlist 为显式扩展名清单(png/jpg/jpeg/gif/webp/txt/log/md/json),路径必须 resolve 在 `agent-workspace/evidence` 内,单文件上限 20MB。

--- a/src/observe/run-detail.ts
+++ b/src/observe/run-detail.ts
@@ -8,6 +8,12 @@ import type {
 import { friendlyRunSummaryFromState } from '../usability/result-summary.js'
 import type { FriendlyRunSummary } from '../usability/result-summary.js'
 
+export interface ObservationEvidenceRef {
+  kind: string
+  path: string | undefined
+  description: string
+}
+
 export interface ObservationCaseRow {
   caseId: string
   title: string
@@ -16,6 +22,7 @@ export interface ObservationCaseRow {
   failureKind: string | undefined
   summary: string
   evidenceCount: number
+  evidence: ObservationEvidenceRef[]
 }
 
 export interface ObservationEnvironmentBlocker {
@@ -73,6 +80,11 @@ function caseRows(result: CodexTestAgentResult | undefined): ObservationCaseRow[
     failureKind: item.failureKind,
     summary: item.summary,
     evidenceCount: item.evidence.length,
+    evidence: item.evidence.map((entry) => ({
+      kind: entry.kind,
+      path: entry.path,
+      description: entry.description,
+    })),
   }))
 }
 

--- a/src/observe/server.ts
+++ b/src/observe/server.ts
@@ -7,6 +7,7 @@ import { defaultRunRoot } from '../usability/run-directory.js'
 import { observationDashboardHtml } from './dashboard-html.js'
 import { runDetail } from './run-detail.js'
 import { serveRunEventStream } from './run-events.js'
+import { serveEvidenceFile } from './evidence.js'
 
 const STATE_FILE = 'codex-agent.state.json'
 
@@ -140,7 +141,7 @@ function basename(path: string): string {
 
 
 /** Validate one requested run id: exactly one safe directory segment that resolves inside the run root. */
-function runDirectoryFor(runRoot: string, requestedId: string): string | undefined {
+export function runDirectoryFor(runRoot: string, requestedId: string): string | undefined {
   if (requestedId === '.' || requestedId === '..' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(requestedId)) return undefined
   const resolved = resolve(runRoot, requestedId)
   const under = relative(runRoot, resolved)
@@ -185,6 +186,18 @@ export async function startObservationServer(options: StartObservationServerOpti
         if (url.pathname === '/api/runs') {
           const runs = await listRuns(runRoot)
           json(response, 200, { runs })
+          return
+        }
+        const evidenceMatch = /^\/api\/runs\/([^/]+)\/evidence\/(.+)$/.exec(url.pathname)
+        if (evidenceMatch) {
+          const runDirectory = runDirectoryFor(runRoot, decodeURIComponent(evidenceMatch[1]!))
+          if (!runDirectory) {
+            json(response, 404, { error: '未找到' })
+            return
+          }
+          // One percent-encoded path segment list under the run's evidence directory.
+          const requestedPath = evidenceMatch[2]!.split('/').map(decodeURIComponent).join('/')
+          await serveEvidenceFile(response, runDirectory, requestedPath)
           return
         }
         const eventsMatch = /^\/api\/runs\/([^/]+)\/events$/.exec(url.pathname)

--- a/tests/observe-evidence.test.ts
+++ b/tests/observe-evidence.test.ts
@@ -1,0 +1,140 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { CodexTestAgentState } from '../src/agent/types.js'
+import { startObservationServer, type ObservationServer } from '../src/observe/server.js'
+
+const servers: ObservationServer[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(async (server) => server.close()))
+})
+
+function stateFixture(overrides: Partial<CodexTestAgentState> = {}): CodexTestAgentState {
+  return {
+    version: '2.0', status: 'running', stage: 'executing',
+    workflowId: 'workflow', sourceSha256: 'a'.repeat(64),
+    startedAt: '2026-09-01T08:00:00.000Z', updatedAt: '2026-09-01T08:10:00.000Z',
+    threadGeneration: 0, completedCaseIds: [],
+    ...overrides,
+  }
+}
+
+/** One run with an evidence tree, private secrets, and a raw workbook copy. */
+async function evidenceFixtureRun(root: string): Promise<string> {
+  const runId = '20260901-080000-evidence-ev01'
+  const runDir = resolve(root, runId)
+  await mkdir(resolve(runDir, 'agent-workspace', 'evidence', 'checkout'), { recursive: true })
+  await mkdir(resolve(runDir, '.agent-private'), { recursive: true })
+  await mkdir(resolve(runDir, 'agent-workspace', 'input'), { recursive: true })
+  await writeFile(resolve(runDir, 'codex-agent.state.json'), JSON.stringify(stateFixture({ status: 'completed', stage: 'completed', outcome: 'passed' })))
+  // A valid 1x1 PNG.
+  await writeFile(resolve(runDir, 'agent-workspace', 'evidence', 'checkout', 'cart.png'), Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', 'base64'))
+  await writeFile(resolve(runDir, 'agent-workspace', 'evidence', 'console.txt'), 'stdout: 完成\n')
+  await writeFile(resolve(runDir, '.agent-private', 'run-values.json'), 'OBS-SECRET-MARKER')
+  await writeFile(resolve(runDir, 'agent-workspace', 'input', 'cases.xlsx'), 'fake workbook bytes')
+  await writeFile(resolve(runDir, 'agent-workspace', 'evidence', 'mystery.bin'), 'binary-ish')
+  return runId
+}
+
+describe('observation evidence serving (allowlist)', () => {
+  it('serves evidence images and text with the right content types', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-evidence-'))
+    try {
+      const runId = await evidenceFixtureRun(directory)
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const png = await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/checkout/cart.png`)
+      expect(png.status).toBe(200)
+      expect(png.headers.get('content-type')).toBe('image/png')
+      expect((await png.arrayBuffer()).byteLength).toBeGreaterThan(50)
+      const text = await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/console.txt`)
+      expect(text.status).toBe(200)
+      expect(text.headers.get('content-type')).toContain('text/plain')
+      expect(await text.text()).toContain('完成')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses unknown extensions and the raw workbook copy', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-evidence-'))
+    try {
+      const runId = await evidenceFixtureRun(directory)
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      expect((await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/mystery.bin`)).status).toBe(404)
+      // The workbook copy lives outside the evidence directory entirely.
+      expect((await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/../input/cases.xlsx`)).status).toBe(404)
+      expect((await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/${encodeURIComponent('..')}/input/cases.xlsx`)).status).toBe(404)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses traversal, agent-private, absolute paths, and encoded escapes', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-evidence-'))
+    try {
+      const runId = await evidenceFixtureRun(directory)
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const attempts = [
+        `${server.baseUrl}/api/runs/${runId}/evidence/${encodeURIComponent('..')}/${encodeURIComponent('..')}/.agent-private/run-values.json`,
+        `${server.baseUrl}/api/runs/${runId}/evidence/${encodeURIComponent('..')}/${encodeURIComponent('..')}/${encodeURIComponent('..')}/etc/passwd`,
+        `${server.baseUrl}/api/runs/${runId}/evidence/%2e%2e%2f.agent-private%2frun-values.json`,
+        `${server.baseUrl}/api/runs/${runId}/evidence/checkout/${encodeURIComponent('..')}/${encodeURIComponent('..')}/.agent-private/run-values.json`,
+        `${server.baseUrl}/api/runs/${runId}/evidence/../../etc/passwd`,
+      ]
+      for (const url of attempts) {
+        expect((await fetch(url)).status).toBe(404)
+      }
+      // And a direct request for the state file through the evidence route.
+      expect((await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/${encodeURIComponent('..')}/codex-agent.state.json`)).status).toBe(404)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('serves evidence referenced by the result contract path shape (evidence/<file>)', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-evidence-'))
+    try {
+      const runId = await evidenceFixtureRun(directory)
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      // Results record `evidence/<file>` relative to agent-workspace; the
+      // route must accept that exact shape so dashboard links resolve.
+      const response = await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/${encodeURIComponent('checkout/cart.png')}`)
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/png')
+      // And the raw prefixed contract value also resolves to the same file:
+      const prefixed = await fetch(`${server.baseUrl}/api/runs/${runId}/evidence/${encodeURIComponent('evidence')}/${encodeURIComponent('checkout/cart.png')}`)
+      expect(prefixed.status).toBe(200)
+      expect(prefixed.headers.get('content-type')).toBe('image/png')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the secret marker out of every evidence response', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'auto-test-observe-evidence-'))
+    try {
+      const runId = await evidenceFixtureRun(directory)
+      const server = await startObservationServer({ runRoot: directory })
+      servers.push(server)
+      const routes = [
+        `${server.baseUrl}/api/runs/${runId}/evidence/console.txt`,
+        `${server.baseUrl}/api/runs/${runId}/evidence/checkout/cart.png`,
+        `${server.baseUrl}/api/runs`,
+        `${server.baseUrl}/api/runs/${runId}`,
+      ]
+      for (const url of routes) {
+        const body = await (await fetch(url)).text()
+        expect(body).not.toContain('OBS-SECRET-MARKER')
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Changes

- `GET /api/runs/<runId>/evidence/<path>`:证据文件服务——png/jpg/jpeg/gif/webp 按图片 content-type 返回(浏览器直接渲染),txt/log/md/json 按文本返回
- **显式只读 allowlist**:扩展名白名单(其它一律 404)、路径必须 resolve 在 `agent-workspace/evidence/` 内、单文件 20MB 上限;`.agent-private`、原始工作簿副本、input/ 目录结构性不可达
- result 契约的 `evidence/<file>` 路径形态原样可打开(仪表盘链接直达文件)
- 详情页用例行的证据列从计数升级为可点击列表(带路径新 tab 打开,无路径的显示描述)

Closes #174 (parent #170)。

## Tests

- tests/observe-evidence.test.ts 5 个 loopback 测试:content-type 正确性;未知扩展与工作簿副本拒绝;穿越/绝对路径/编码逃逸(`..`/`%2e%2e%2f`/`../../etc/passwd`/`.agent-private` 直读)全 404;契约路径形态(前缀与剥前缀)200;全部响应零秘密标记泄漏
- `npm run check` 全绿:453/453、typecheck、build

## Checklist

- [x] allowlist 是显式清单,不是黑名单推断
- [x] 与 #173(SSE)无路径重叠,无依赖
- [x] 零新增依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)